### PR TITLE
feat: on-the-fly contours (ContourTileDataSource) + shader contours + CustomRasterTileLayer

### DIFF
--- a/all/modules/datasources/ContourTileDataSource.i
+++ b/all/modules/datasources/ContourTileDataSource.i
@@ -1,0 +1,37 @@
+#ifndef _CONTOURTILEDATASOURCE_I
+#define _CONTOURTILEDATASOURCE_I
+
+%module(directors="1") ContourTileDataSource
+
+!proxy_imports(carto::ContourTileDataSource, core.MapTile, core.MapBounds, datasources.TileDataSource, datasources.components.TileData, rastertiles.ElevationDecoder)
+
+%{
+#include "datasources/ContourTileDataSource.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <std_string.i>
+%include <cartoswig.i>
+
+%import "datasources/TileDataSource.i"
+%import "datasources/components/TileData.i"
+%import "rastertiles/ElevationDecoder.i"
+
+!polymorphic_shared_ptr(carto::ContourTileDataSource, datasources.ContourTileDataSource)
+
+%attributestring(carto::ContourTileDataSource, std::string, LayerName, getLayerName, setLayerName)
+%attribute(carto::ContourTileDataSource, float, BaseInterval, getBaseInterval, setBaseInterval)
+%attribute(carto::ContourTileDataSource, int, Resolution, getResolution, setResolution)
+%attribute(carto::ContourTileDataSource, int, MinVisibleZoom, getMinVisibleZoom, setMinVisibleZoom)
+%attribute(carto::ContourTileDataSource, bool, SeamlessEdgesEnabled, isSeamlessEdgesEnabled, setSeamlessEdgesEnabled)
+%attribute(carto::ContourTileDataSource, float, SimplifyTolerance, getSimplifyTolerance, setSimplifyTolerance)
+
+%std_exceptions(carto::ContourTileDataSource::ContourTileDataSource)
+
+%feature("director") carto::ContourTileDataSource;
+
+%include "datasources/ContourTileDataSource.h"
+
+#endif

--- a/all/modules/layers/CustomRasterTileLayer.i
+++ b/all/modules/layers/CustomRasterTileLayer.i
@@ -1,0 +1,28 @@
+#ifndef _CUSTOMRASTERTILELAYER_I
+#define _CUSTOMRASTERTILELAYER_I
+
+%module CustomRasterTileLayer
+
+!proxy_imports(carto::CustomRasterTileLayer, datasources.TileDataSource, layers.RasterTileLayer)
+
+%{
+#include "layers/CustomRasterTileLayer.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <std_string.i>
+%include <cartoswig.i>
+
+%import "datasources/TileDataSource.i"
+%import "layers/RasterTileLayer.i"
+
+!polymorphic_shared_ptr(carto::CustomRasterTileLayer, layers.CustomRasterTileLayer)
+
+%attributestring(carto::CustomRasterTileLayer, std::string, ShaderSource, getShaderSource, setShaderSource)
+%std_exceptions(carto::CustomRasterTileLayer::CustomRasterTileLayer)
+
+%include "layers/CustomRasterTileLayer.h"
+
+#endif

--- a/all/modules/layers/HillshadeRasterTileLayer.i
+++ b/all/modules/layers/HillshadeRasterTileLayer.i
@@ -3,7 +3,7 @@
 
 %module HillshadeRasterTileLayer
 
-!proxy_imports(carto::HillshadeRasterTileLayer, core.MapPos, core.MapVec, core.MapPosVector, core.DoubleVector, datasources.TileDataSource, rastertiles.ElevationDecoder, graphics.Color, layers.RasterTileLayer)
+!proxy_imports(carto::HillshadeRasterTileLayer, core.MapPos, core.MapVec, core.MapPosVector, core.DoubleVector, datasources.TileDataSource, rastertiles.ElevationDecoder, graphics.Color, layers.CustomRasterTileLayer)
 
 %{
 #include "layers/HillshadeRasterTileLayer.h"
@@ -17,7 +17,7 @@
 %import "datasources/TileDataSource.i"
 %import "rastertiles/ElevationDecoder.i"
 %import "graphics/Color.i"
-%import "layers/RasterTileLayer.i"
+%import "layers/CustomRasterTileLayer.i"
 %import "core/DoubleVector.i"
 
 !enum(carto::HillshadeMethod::HillshadeMethod)
@@ -33,6 +33,11 @@
 %attributeval(carto::HillshadeRasterTileLayer, carto::Color, HighlightColor, getHighlightColor, setHighlightColor)
 %attributeval(carto::HillshadeRasterTileLayer, carto::Color, AccentColor, getAccentColor, setAccentColor)
 %attributeval(carto::HillshadeRasterTileLayer, std::string, NormalMapLightingShader, getNormalMapLightingShader, setNormalMapLightingShader)
+%attribute(carto::HillshadeRasterTileLayer, bool, ElevationEncodingEnabled, isElevationEncodingEnabled, setElevationEncodingEnabled)
+%attribute(carto::HillshadeRasterTileLayer, bool, ContourEnabled, isContourEnabled, setContourEnabled)
+%attribute(carto::HillshadeRasterTileLayer, float, ContourInterval, getContourInterval, setContourInterval)
+%attributeval(carto::HillshadeRasterTileLayer, carto::Color, ContourColor, getContourColor, setContourColor)
+%attribute(carto::HillshadeRasterTileLayer, float, ContourWidth, getContourWidth, setContourWidth)
 %std_exceptions(carto::HillshadeRasterTileLayer::HillshadeRasterTileLayer)
 
 %include "layers/HillshadeRasterTileLayer.h"

--- a/all/native/datasources/ContourTileDataSource.cpp
+++ b/all/native/datasources/ContourTileDataSource.cpp
@@ -1,0 +1,576 @@
+#include "ContourTileDataSource.h"
+#include "core/BinaryData.h"
+#include "core/MapTile.h"
+#include "core/MapPos.h"
+#include "core/MapBounds.h"
+#include "core/Variant.h"
+#include "components/Exceptions.h"
+#include "graphics/Bitmap.h"
+#include "projections/Projection.h"
+#include "rastertiles/ElevationDecoder.h"
+#include "rastertiles/TerrariumElevationDataDecoder.h"
+#include "rastertiles/MapBoxElevationDataDecoder.h"
+#include "utils/TileUtils.h"
+#include "utils/Log.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <unordered_map>
+#include <vector>
+
+#include <mbvtbuilder/MBVTTileBuilder.h>
+
+#include <mapnikvt/mbvtpackage/MBVTPackage.pb.h>
+
+namespace {
+
+    using GridPoint = std::pair<double, double>; // (gx, gy) in grid node coordinates
+    using Polyline = std::vector<GridPoint>;
+
+    // Linear crossing position of 'level' between corner values va (at ta) and vb (at tb).
+    inline double lerpT(float va, float vb, double level) {
+        double d = static_cast<double>(vb) - static_cast<double>(va);
+        if (d == 0.0) {
+            return 0.5;
+        }
+        double t = (level - va) / d;
+        if (t < 0.0) t = 0.0;
+        if (t > 1.0) t = 1.0;
+        return t;
+    }
+
+    // Marching squares over a WxH height grid (row-major, row 0 = south) for a single level.
+    // Segments are linked into polylines using shared cell-edge ids (no floating point matching).
+    std::vector<Polyline> marchingSquares(const std::vector<float>& heights, int W, int H, double level) {
+        // Edge id: horizontal edge (between (x,y) and (x+1,y)) -> (y*W + x)*2 + 0
+        //          vertical   edge (between (x,y) and (x,y+1)) -> (y*W + x)*2 + 1
+        auto hEdge = [W](int x, int y) -> std::int64_t { return (static_cast<std::int64_t>(y) * W + x) * 2 + 0; };
+        auto vEdge = [W](int x, int y) -> std::int64_t { return (static_cast<std::int64_t>(y) * W + x) * 2 + 1; };
+
+        std::unordered_map<std::int64_t, GridPoint> points; // edge id -> crossing point
+        // adjacency: edge id -> the (up to two) edge ids it is connected to by a segment
+        std::unordered_map<std::int64_t, std::vector<std::int64_t>> adj;
+
+        auto addSegment = [&](std::int64_t ea, GridPoint pa, std::int64_t eb, GridPoint pb) {
+            points[ea] = pa;
+            points[eb] = pb;
+            adj[ea].push_back(eb);
+            adj[eb].push_back(ea);
+        };
+
+        for (int y = 0; y + 1 < H; y++) {
+            for (int x = 0; x + 1 < W; x++) {
+                float v00 = heights[static_cast<std::size_t>(y) * W + x];         // SW
+                float v10 = heights[static_cast<std::size_t>(y) * W + (x + 1)];   // SE
+                float v01 = heights[static_cast<std::size_t>(y + 1) * W + x];     // NW
+                float v11 = heights[static_cast<std::size_t>(y + 1) * W + (x + 1)]; // NE
+
+                int idx = 0;
+                if (v00 >= level) idx |= 1; // SW
+                if (v10 >= level) idx |= 2; // SE
+                if (v11 >= level) idx |= 4; // NE
+                if (v01 >= level) idx |= 8; // NW
+                if (idx == 0 || idx == 15) {
+                    continue;
+                }
+
+                // Crossing points on the 4 cell edges (only some are used per case).
+                std::int64_t eB = hEdge(x, y);       GridPoint pB(x + lerpT(v00, v10, level), y);           // bottom (S)
+                std::int64_t eT = hEdge(x, y + 1);   GridPoint pT(x + lerpT(v01, v11, level), y + 1);       // top (N)
+                std::int64_t eL = vEdge(x, y);       GridPoint pL(x, y + lerpT(v00, v01, level));           // left (W)
+                std::int64_t eR = vEdge(x + 1, y);   GridPoint pR(x + 1, y + lerpT(v10, v11, level));       // right (E)
+
+                switch (idx) {
+                    case 1:  case 14: addSegment(eL, pL, eB, pB); break;
+                    case 2:  case 13: addSegment(eB, pB, eR, pR); break;
+                    case 3:  case 12: addSegment(eL, pL, eR, pR); break;
+                    case 4:  case 11: addSegment(eR, pR, eT, pT); break;
+                    case 6:  case 9:  addSegment(eB, pB, eT, pT); break;
+                    case 7:  case 8:  addSegment(eL, pL, eT, pT); break;
+                    case 5: // saddle: two segments (consistent resolution)
+                        addSegment(eL, pL, eT, pT);
+                        addSegment(eB, pB, eR, pR);
+                        break;
+                    case 10: // saddle
+                        addSegment(eL, pL, eB, pB);
+                        addSegment(eR, pR, eT, pT);
+                        break;
+                    default: break;
+                }
+            }
+        }
+
+        // Link segments into polylines. Walk each unvisited connection, extending from endpoints
+        // with degree 1 first (open chains), then remaining loops.
+        std::vector<Polyline> polylines;
+        std::unordered_map<std::int64_t, std::vector<char>> used; // parallels adj: consumed flags
+        for (const auto& e : adj) {
+            used[e.first] = std::vector<char>(e.second.size(), 0);
+        }
+
+        auto takeEdge = [&](std::int64_t from, std::int64_t to) -> bool {
+            auto it = adj.find(from);
+            if (it == adj.end()) return false;
+            auto& usedVec = used[from];
+            for (std::size_t i = 0; i < it->second.size(); i++) {
+                if (!usedVec[i] && it->second[i] == to) {
+                    usedVec[i] = 1;
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        auto degree = [&](std::int64_t e) -> int {
+            auto it = adj.find(e);
+            return it == adj.end() ? 0 : static_cast<int>(it->second.size());
+        };
+
+        // Helper: from a starting edge, greedily follow unused connections to build a chain.
+        auto buildChain = [&](std::int64_t start) {
+            Polyline line;
+            std::int64_t cur = start;
+            line.push_back(points[cur]);
+            while (true) {
+                auto it = adj.find(cur);
+                if (it == adj.end()) break;
+                std::int64_t next = -1;
+                auto& usedVec = used[cur];
+                for (std::size_t i = 0; i < it->second.size(); i++) {
+                    if (!usedVec[i]) {
+                        next = it->second[i];
+                        usedVec[i] = 1;
+                        // consume the reverse edge too
+                        takeEdge(next, cur);
+                        break;
+                    }
+                }
+                if (next < 0) break;
+                line.push_back(points[next]);
+                cur = next;
+            }
+            return line;
+        };
+
+        // Open chains first (endpoints on the tile border have degree 1).
+        for (const auto& e : adj) {
+            if (degree(e.first) == 1) {
+                bool anyLeft = false;
+                for (char c : used[e.first]) { if (!c) { anyLeft = true; break; } }
+                if (!anyLeft) continue;
+                Polyline line = buildChain(e.first);
+                if (line.size() >= 2) polylines.push_back(std::move(line));
+            }
+        }
+        // Remaining closed loops.
+        for (const auto& e : adj) {
+            bool anyLeft = false;
+            for (char c : used[e.first]) { if (!c) { anyLeft = true; break; } }
+            if (!anyLeft) continue;
+            Polyline line = buildChain(e.first);
+            if (line.size() >= 2) polylines.push_back(std::move(line));
+        }
+
+        return polylines;
+    }
+
+}
+
+namespace carto {
+
+    ContourTileDataSource::ContourTileDataSource(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& elevationDecoder) :
+        TileDataSource(),
+        _dataSource(dataSource),
+        _elevationDecoder(elevationDecoder),
+        _baseInterval(10.0f),
+        _simplifyTolerance(1.0f),
+        _resolution(128),
+        _minVisibleZoom(12),
+        _seamlessEdges(false),
+        _layerName("contour"),
+        _mutex(),
+        _dataSourceListener()
+    {
+        if (!dataSource) {
+            throw NullArgumentException("Null dataSource");
+        }
+        _dataSourceListener = std::make_shared<DataSourceListener>(*this);
+        _dataSource->registerOnChangeListener(_dataSourceListener);
+    }
+
+    ContourTileDataSource::ContourTileDataSource(const std::shared_ptr<TileDataSource>& dataSource) :
+        ContourTileDataSource(dataSource, std::shared_ptr<ElevationDecoder>())
+    {
+    }
+
+    ContourTileDataSource::~ContourTileDataSource() {
+        _dataSource->unregisterOnChangeListener(_dataSourceListener);
+        _dataSourceListener.reset();
+    }
+
+    std::string ContourTileDataSource::getLayerName() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _layerName;
+    }
+
+    void ContourTileDataSource::setLayerName(const std::string& name) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _layerName = name;
+        }
+        notifyTilesChanged(false);
+    }
+
+    float ContourTileDataSource::getBaseInterval() const {
+        return _baseInterval;
+    }
+
+    void ContourTileDataSource::setBaseInterval(float interval) {
+        if (interval <= 0.0f) {
+            throw InvalidArgumentException("Base interval must be positive");
+        }
+        _baseInterval = interval;
+        notifyTilesChanged(false);
+    }
+
+    int ContourTileDataSource::getResolution() const {
+        return _resolution;
+    }
+
+    void ContourTileDataSource::setResolution(int resolution) {
+        _resolution = std::max(8, resolution);
+        notifyTilesChanged(false);
+    }
+
+    int ContourTileDataSource::getMinVisibleZoom() const {
+        return _minVisibleZoom;
+    }
+
+    void ContourTileDataSource::setMinVisibleZoom(int zoom) {
+        _minVisibleZoom = zoom;
+        notifyTilesChanged(false);
+    }
+
+    bool ContourTileDataSource::isSeamlessEdgesEnabled() const {
+        return _seamlessEdges;
+    }
+
+    void ContourTileDataSource::setSeamlessEdgesEnabled(bool enabled) {
+        _seamlessEdges = enabled;
+        notifyTilesChanged(false);
+    }
+
+    float ContourTileDataSource::getSimplifyTolerance() const {
+        return _simplifyTolerance;
+    }
+
+    void ContourTileDataSource::setSimplifyTolerance(float tolerance) {
+        _simplifyTolerance = tolerance;
+        notifyTilesChanged(false);
+    }
+
+    int ContourTileDataSource::getMinZoom() const {
+        // Report the DEM's real min zoom rather than clamping up to MinVisibleZoom: if we clamped up, then
+        // when the camera is below that zoom the layer would fill the whole viewport with min-zoom tiles (an
+        // exponential tile-count blowup as you zoom out). Instead the layer requests few tiles at the camera
+        // zoom, and loadTile returns an empty tile cheaply below MinVisibleZoom (no DEM fetch, no tracing).
+        return _dataSource->getMinZoom();
+    }
+
+    int ContourTileDataSource::getMaxZoom() const {
+        return _dataSource->getMaxZoom();
+    }
+
+    MapBounds ContourTileDataSource::getDataExtent() const {
+        return _dataSource->getDataExtent();
+    }
+
+    std::string ContourTileDataSource::getEncoding() const {
+        return _dataSource->getEncoding();
+    }
+
+    std::shared_ptr<ElevationDecoder> ContourTileDataSource::resolveDecoder(const std::shared_ptr<TileData>& tileData) const {
+        if (_elevationDecoder) {
+            return _elevationDecoder;
+        }
+        std::string encoding = _dataSource->getEncoding();
+        if (tileData) {
+            std::shared_ptr<Variant> encVariant = tileData->getMetadata("encoding");
+            if (encVariant && encVariant->getType() == VariantType::VARIANT_TYPE_STRING) {
+                encoding = encVariant->getString();
+            }
+        }
+        if (encoding == "mapbox") {
+            static std::shared_ptr<ElevationDecoder> mapboxDecoder = std::make_shared<MapBoxElevationDataDecoder>();
+            return mapboxDecoder;
+        }
+        static std::shared_ptr<ElevationDecoder> terrariumDecoder = std::make_shared<TerrariumElevationDataDecoder>();
+        return terrariumDecoder;
+    }
+
+    double ContourTileDataSource::getIntervalForZoom(int zoom) const {
+        double base = _baseInterval;
+        if (zoom <= 9)  return base * 50.0; // very coarse (e.g. 500m) - only relevant if MinVisibleZoom lowered
+        if (zoom <= 11) return base * 20.0; // coarse (e.g. 200m)
+        if (zoom <= 12) return base * 10.0; // e.g. 100m
+        if (zoom == 13) return base * 5.0;  // e.g. 50m
+        return base;                        // full detail (e.g. 10m)
+    }
+
+    long long ContourTileDataSource::computeDiv(long long ele) {
+        // Matches the gdal_contour based pipeline: largest "nice" divisor of the elevation.
+        long long a = std::llabs(ele);
+        if (a % 1000 == 0) return 1000;
+        if (a % 500 == 0) return 500;
+        if (a % 250 == 0) return 250;
+        if (a % 200 == 0) return 200;
+        if (a % 100 == 0) return 100;
+        if (a % 50 == 0) return 50;
+        if (a % 20 == 0) return 20;
+        return 10;
+    }
+
+    std::shared_ptr<TileData> ContourTileDataSource::loadTile(const MapTile& mapTile) {
+        int zoom = mapTile.getZoom();
+
+        std::string layerName;
+        float simplifyTolerance;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            layerName = _layerName;
+            simplifyTolerance = _simplifyTolerance;
+        }
+
+        // Below the useful contour zoom, emit an empty (but valid) tile without fetching or decoding the
+        // DEM. This keeps zoomed-out frames cheap even though the layer may request many such tiles.
+        if (zoom < _minVisibleZoom.load()) {
+            try {
+                mbvtbuilder::MBVTTileBuilder emptyBuilder(zoom, zoom);
+                emptyBuilder.createLayer(layerName);
+                protobuf::encoded_message encodedTile;
+                emptyBuilder.buildTile(zoom, mapTile.getX(), mapTile.getY(), encodedTile);
+                auto data = std::make_shared<BinaryData>(reinterpret_cast<const unsigned char*>(encodedTile.data().data()), encodedTile.data().size());
+                auto tileData = std::make_shared<TileData>(data);
+                applyTileMetadata(tileData, mapTile);
+                return tileData;
+            }
+            catch (const std::exception& ex) {
+                return std::shared_ptr<TileData>();
+            }
+        }
+
+        std::shared_ptr<TileData> elevTileData = _dataSource->loadTile(mapTile);
+        if (!elevTileData || !elevTileData->getData()) {
+            return std::shared_ptr<TileData>();
+        }
+        // Propagate parent-replacement/overzoom to keep behaviour consistent with the wrapped source.
+        if (elevTileData->isReplaceWithParent()) {
+            auto emptyData = std::make_shared<BinaryData>(std::vector<unsigned char>());
+            auto tileData = std::make_shared<TileData>(emptyData);
+            tileData->setReplaceWithParent(true);
+            return tileData;
+        }
+
+        std::shared_ptr<ElevationDecoder> decoder = resolveDecoder(elevTileData);
+        std::array<double, 4> coeffs = decoder->getColorComponentCoefficients();
+
+        std::shared_ptr<Bitmap> bitmap = Bitmap::CreateFromCompressed(elevTileData->getData());
+        if (!bitmap) {
+            Log::Errorf("ContourTileDataSource::loadTile: Failed to decode elevation bitmap for %s", mapTile.toString().c_str());
+            return std::shared_ptr<TileData>();
+        }
+
+        int fullW = bitmap->getWidth();
+        int fullH = bitmap->getHeight();
+        if (fullW < 2 || fullH < 2) {
+            return std::shared_ptr<TileData>();
+        }
+
+        int bytesPerPixel = 0;
+        switch (bitmap->getColorFormat()) {
+            case ColorFormat::COLOR_FORMAT_GRAYSCALE: bytesPerPixel = 1; break;
+            case ColorFormat::COLOR_FORMAT_RGB:       bytesPerPixel = 3; break;
+            case ColorFormat::COLOR_FORMAT_RGBA:      bytesPerPixel = 4; break;
+            default:
+                Log::Error("ContourTileDataSource::loadTile: Unsupported bitmap color format");
+                return std::shared_ptr<TileData>();
+        }
+
+        // Subsample the DEM before tracing: full 256x256 tracing produces far more vertices than
+        // 100/50/10 m contours need, and every extra vertex is re-simplified, uploaded and draped
+        // over the 3D terrain mesh each frame. Trace on an at-most 'resolution'-per-side grid.
+        // The nodes are spread evenly INCLUDING both endpoints (pixel 0 and fullW-1), so grid node 0
+        // maps to the tile's west/south edge and node W-1/H-1 to the east/north edge. That makes
+        // adjacent contour tiles share their boundary samples and meet without holes.
+        int resolution = std::max(8, _resolution.load());
+        int W = std::min(fullW, resolution);
+        int H = std::min(fullH, resolution);
+        if (W < 2 || H < 2) {
+            return std::shared_ptr<TileData>();
+        }
+
+        // Optionally fetch neighbour DEM tiles so the tile's east/north edges use the neighbours' own
+        // edge samples, making contour lines meet across tile boundaries. The DEM bitmap is stored
+        // south-to-north / west-to-east and the tile bounds use mapTile.getFlipped(). In that flipped
+        // (projection) tile scheme north = flipped.y + 1, which flips back to datasource y - 1. So the
+        // geographic east/north/north-east neighbours are datasource tiles (x+1, y) / (x, y-1) / (x+1, y-1).
+        bool seamless = _seamlessEdges.load();
+        std::shared_ptr<Bitmap> eastBitmap, northBitmap, neBitmap;
+        if (seamless) {
+            auto fetchNeighbour = [&](int dx, int dy) -> std::shared_ptr<Bitmap> {
+                MapTile nt(mapTile.getX() + dx, mapTile.getY() + dy, zoom, mapTile.getFrameNr());
+                std::shared_ptr<TileData> td = _dataSource->loadTile(nt);
+                if (!td || !td->getData() || td->isReplaceWithParent()) {
+                    return std::shared_ptr<Bitmap>();
+                }
+                std::shared_ptr<Bitmap> bm = Bitmap::CreateFromCompressed(td->getData());
+                if (!bm || bm->getWidth() != fullW || bm->getHeight() != fullH || bm->getColorFormat() != bitmap->getColorFormat()) {
+                    return std::shared_ptr<Bitmap>(); // fall back to edge duplication
+                }
+                return bm;
+            };
+            eastBitmap = fetchNeighbour(1, 0);
+            northBitmap = fetchNeighbour(0, -1);
+            neBitmap = fetchNeighbour(1, -1);
+        }
+
+        const std::vector<std::uint8_t>& pixelData = bitmap->getPixelData();
+        auto decodePixel = [&](const std::vector<std::uint8_t>& pd, int lx, int ly) -> float {
+            const std::uint8_t* ptr = &pd[(static_cast<std::size_t>(ly) * fullW + lx) * bytesPerPixel];
+            double r = 0, g = 0, b = 0, a = 255;
+            switch (bytesPerPixel) {
+                case 1: r = g = b = ptr[0]; break;
+                case 3: r = ptr[0]; g = ptr[1]; b = ptr[2]; break;
+                case 4: r = ptr[0]; g = ptr[1]; b = ptr[2]; a = ptr[3]; break;
+            }
+            return static_cast<float>(coeffs[0] * r + coeffs[1] * g + coeffs[2] * b + coeffs[3] * (a / 255.0));
+        };
+        // Sample the DEM at pixel (px, py). With seamless edges px may reach fullW and py may reach fullH,
+        // which pull from the east/north/north-east neighbours' opposite edge (or duplicate our own edge
+        // if a neighbour is missing).
+        auto sampleHeight = [&](int px, int py) -> float {
+            bool east = (px >= fullW);
+            bool north = (py >= fullH);
+            if (east && north) {
+                if (neBitmap) return decodePixel(neBitmap->getPixelData(), 0, 0);
+                return decodePixel(pixelData, fullW - 1, fullH - 1);
+            }
+            if (east) {
+                if (eastBitmap) return decodePixel(eastBitmap->getPixelData(), 0, py);
+                return decodePixel(pixelData, fullW - 1, py);
+            }
+            if (north) {
+                if (northBitmap) return decodePixel(northBitmap->getPixelData(), px, 0);
+                return decodePixel(pixelData, px, fullH - 1);
+            }
+            return decodePixel(pixelData, px, py);
+        };
+
+        // Decode DEM into a resampled height grid (row 0 = south). Nodes span [0, spanW]/[0, spanH]:
+        // without seamless edges spanW = fullW-1 (last sample = last pixel), with seamless edges spanW = fullW
+        // (last sample = east neighbour's first column), so node W-1 lands exactly on the tile's east edge.
+        int spanW = seamless ? fullW : (fullW - 1);
+        int spanH = seamless ? fullH : (fullH - 1);
+        std::vector<float> heights(static_cast<std::size_t>(W) * H);
+        float minH = 1.0e9f, maxH = -1.0e9f;
+        for (int gy = 0; gy < H; gy++) {
+            int py = static_cast<int>(std::llround(static_cast<double>(gy) * spanH / (H - 1)));
+            for (int gx = 0; gx < W; gx++) {
+                int px = static_cast<int>(std::llround(static_cast<double>(gx) * spanW / (W - 1)));
+                float h = sampleHeight(px, py);
+                heights[static_cast<std::size_t>(gy) * W + gx] = h;
+                if (h < minH) minH = h;
+                if (h > maxH) maxH = h;
+            }
+        }
+
+        // Geographic bounds of this tile (EPSG3857). Note the getFlipped(): the DEM bitmap's
+        // south edge (grid row 0) corresponds to the flipped tile's minimum-y bound, matching
+        // ElevationManager. The MBVT builder is called with the raw tile x/y (as GeoJSONVectorTileDataSource
+        // does), so the same footprint is reproduced without a double flip.
+        std::shared_ptr<Projection> projection = getProjection();
+        MapBounds bounds = TileUtils::CalculateMapTileBounds(mapTile.getFlipped(), projection);
+        double minX = bounds.getMin().getX(), minY = bounds.getMin().getY();
+        double sizeX = bounds.getMax().getX() - minX;
+        double sizeY = bounds.getMax().getY() - minY;
+
+        auto gridToWgs84 = [&](const GridPoint& p) -> mbvtbuilder::MBVTTileBuilder::Point {
+            // Node 0 -> tile min edge, node W-1/H-1 -> tile max edge (even resample spans full extent).
+            double fx = p.first / static_cast<double>(W - 1);
+            double fy = p.second / static_cast<double>(H - 1);
+            if (fx > 1.0) fx = 1.0;
+            if (fy > 1.0) fy = 1.0;
+            MapPos pos3857(minX + fx * sizeX, minY + fy * sizeY);
+            MapPos wgs84 = projection->toWgs84(pos3857);
+            return mbvtbuilder::MBVTTileBuilder::Point(wgs84.getX(), wgs84.getY());
+        };
+
+        double interval = getIntervalForZoom(zoom);
+
+        mbvtbuilder::MBVTTileBuilder tileBuilder(zoom, zoom);
+        tileBuilder.setSimplifyTolerance(simplifyTolerance);
+        int layerIndex = tileBuilder.createLayer(layerName);
+
+        // Generate one feature (a MultiLineString) per contour level.
+        long long firstLevel = static_cast<long long>(std::ceil(minH / interval));
+        long long lastLevel = static_cast<long long>(std::floor(maxH / interval));
+        // Safety cap: a very low-zoom tile can span kilometres of relief. Beyond this many levels the
+        // tile is unreadable anyway, so bound the tracing cost. (Raise base interval to see more range.)
+        const long long MAX_LEVELS = 200;
+        if (lastLevel - firstLevel + 1 > MAX_LEVELS) {
+            Log::Warnf("ContourTileDataSource::loadTile: %s spans %lld contour levels at interval %g m; capping to %lld. Increase base interval or restrict min zoom.",
+                       mapTile.toString().c_str(), lastLevel - firstLevel + 1, interval, MAX_LEVELS);
+            lastLevel = firstLevel + MAX_LEVELS - 1;
+        }
+        for (long long l = firstLevel; l <= lastLevel; l++) {
+            double level = l * interval;
+            long long ele = static_cast<long long>(std::llround(level));
+
+            std::vector<Polyline> polylines = marchingSquares(heights, W, H, level);
+            if (polylines.empty()) {
+                continue;
+            }
+
+            mbvtbuilder::MBVTTileBuilder::MultiLineString lines;
+            lines.reserve(polylines.size());
+            for (const Polyline& pl : polylines) {
+                std::vector<mbvtbuilder::MBVTTileBuilder::Point> line;
+                line.reserve(pl.size());
+                for (const GridPoint& gp : pl) {
+                    line.push_back(gridToWgs84(gp));
+                }
+                lines.push_back(std::move(line));
+            }
+
+            picojson::object props;
+            props["ele"] = picojson::value(static_cast<std::int64_t>(ele));
+            props["div"] = picojson::value(static_cast<std::int64_t>(computeDiv(ele)));
+            tileBuilder.addMultiLineString(layerIndex, std::move(lines), picojson::value(static_cast<std::int64_t>(ele)), picojson::value(props), false);
+        }
+
+        try {
+            protobuf::encoded_message encodedTile;
+            tileBuilder.buildTile(zoom, mapTile.getX(), mapTile.getY(), encodedTile);
+            auto data = std::make_shared<BinaryData>(reinterpret_cast<const unsigned char*>(encodedTile.data().data()), encodedTile.data().size());
+            auto tileData = std::make_shared<TileData>(data);
+            applyTileMetadata(tileData, mapTile);
+            return tileData;
+        }
+        catch (const std::exception& ex) {
+            Log::Errorf("ContourTileDataSource::loadTile: Failed to build contour tile %s: %s", mapTile.toString().c_str(), ex.what());
+            return std::shared_ptr<TileData>();
+        }
+    }
+
+    ContourTileDataSource::DataSourceListener::DataSourceListener(ContourTileDataSource& dataSource) :
+        _dataSource(dataSource)
+    {
+    }
+
+    void ContourTileDataSource::DataSourceListener::onTilesChanged(bool removeTiles) {
+        _dataSource.notifyTilesChanged(removeTiles);
+    }
+
+}

--- a/all/native/datasources/ContourTileDataSource.h
+++ b/all/native/datasources/ContourTileDataSource.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_CONTOURTILEDATASOURCE_H_
+#define _CARTO_CONTOURTILEDATASOURCE_H_
+
+#include "datasources/TileDataSource.h"
+#include "components/DirectorPtr.h"
+
+#include <atomic>
+#include <mutex>
+#include <string>
+
+namespace carto {
+    class ElevationDecoder;
+
+    /**
+     * A tile data source that generates vector contour lines on the fly from an
+     * RGB-encoded elevation (DEM) tile data source. The wrapped elevation data source
+     * is shared (e.g. with a HillshadeRasterTileLayer) so terrain tiles are fetched
+     * only once.
+     *
+     * The generated tiles are standard Mapbox Vector Tiles containing a single line
+     * layer (default name "contour"). Each contour feature carries two attributes:
+     *   - 'ele': the contour elevation in meters.
+     *   - 'div': the largest "nice" divisor of the elevation (1000, 500, 250, 200,
+     *            100, 50, 20 or 10), matching the gdal_contour based pipeline. This
+     *            lets CartoCSS filter contour importance by elevation, e.g.
+     *            #contour[div=500][zoom>=12] { ... }.
+     *
+     * Attach the source to a normal VectorTileLayer to render lines and labels
+     * ([ele] as the label text) fully from the decoder style.
+     *
+     * Note: this class is experimental and may change or even be removed in future SDK versions.
+     */
+    class ContourTileDataSource : public TileDataSource {
+    public:
+        /**
+         * Constructs a ContourTileDataSource object.
+         * @param dataSource The RGB-encoded elevation data source to generate contours from.
+         * @param elevationDecoder The decoder used to convert RGB pixels to elevation. If null,
+         *        the decoder is inferred from the data source 'encoding' metadata (defaults to terrarium).
+         */
+        ContourTileDataSource(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& elevationDecoder);
+        /**
+         * Constructs a ContourTileDataSource object, inferring the elevation decoder from the
+         * data source 'encoding' metadata (defaults to terrarium).
+         * @param dataSource The RGB-encoded elevation data source to generate contours from.
+         */
+        explicit ContourTileDataSource(const std::shared_ptr<TileDataSource>& dataSource);
+        virtual ~ContourTileDataSource();
+
+        /**
+         * Returns the name of the generated vector tile layer.
+         * @return The layer name. The default is "contour".
+         */
+        std::string getLayerName() const;
+        /**
+         * Sets the name of the generated vector tile layer. This must match the layer id used in the CartoCSS style.
+         * @param name The layer name.
+         */
+        void setLayerName(const std::string& name);
+
+        /**
+         * Returns the base contour interval in meters.
+         * @return The base contour interval in meters. The default is 10.
+         */
+        float getBaseInterval() const;
+        /**
+         * Sets the base contour interval in meters. At low zoom levels a coarser multiple of this
+         * interval is generated to save processing (z<=12 uses 10x, z==13 uses 5x, z>=14 uses 1x).
+         * @param interval The base contour interval in meters.
+         */
+        void setBaseInterval(float interval);
+
+        /**
+         * Returns the target grid resolution used for contour tracing.
+         * @return The target grid resolution. The default is 128.
+         */
+        int getResolution() const;
+        /**
+         * Sets the target grid resolution used for contour tracing. The DEM is subsampled so that
+         * the traced grid is at most this many samples per side. Lower values produce coarser but
+         * much cheaper geometry (fewer vertices to trace, simplify, upload and drape over terrain).
+         * @param resolution The target grid resolution (clamped to at least 8).
+         */
+        void setResolution(int resolution);
+
+        /**
+         * Returns the minimum zoom at which contour geometry is generated.
+         * @return The minimum contour zoom. The default is 12.
+         */
+        int getMinVisibleZoom() const;
+        /**
+         * Sets the minimum zoom at which contour geometry is generated. Below this zoom loadTile returns
+         * an empty (but valid) tile without fetching or tracing the DEM. Note: in CartoCSS 'zoom' means the
+         * TILE zoom, so the style must also draw the desired zoom range for contours to actually appear.
+         * @param zoom The minimum contour zoom.
+         */
+        void setMinVisibleZoom(int zoom);
+
+        /**
+         * Returns whether seamless tile edges are enabled.
+         * @return True if seamless edges are enabled. The default is false.
+         */
+        bool isSeamlessEdgesEnabled() const;
+        /**
+         * Sets whether to generate seamless tile edges. When enabled, the east/north/north-east neighbour
+         * DEM tiles are fetched so that a tile's east and north edges use the exact same elevation samples
+         * as the adjacent tiles, removing the small gaps where contour lines meet at tile boundaries.
+         * This costs up to three extra DEM tile fetches/decodes per tile (they are usually cached).
+         * @param enabled True to enable seamless edges.
+         */
+        void setSeamlessEdgesEnabled(bool enabled);
+
+        /**
+         * Returns the simplification tolerance in tile pixels.
+         * @return The simplification tolerance in tile pixels. The default is 1.0.
+         */
+        float getSimplifyTolerance() const;
+        /**
+         * Sets the simplification tolerance in tile pixels. Use 0.0 to disable simplification.
+         * @param tolerance The simplification tolerance in tile pixels.
+         */
+        void setSimplifyTolerance(float tolerance);
+
+        virtual int getMinZoom() const;
+        virtual int getMaxZoom() const;
+        virtual MapBounds getDataExtent() const;
+        virtual std::string getEncoding() const;
+
+        virtual std::shared_ptr<TileData> loadTile(const MapTile& tile);
+
+    protected:
+        class DataSourceListener : public TileDataSource::OnChangeListener {
+        public:
+            explicit DataSourceListener(ContourTileDataSource& dataSource);
+            virtual void onTilesChanged(bool removeTiles);
+        private:
+            ContourTileDataSource& _dataSource;
+        };
+
+        std::shared_ptr<ElevationDecoder> resolveDecoder(const std::shared_ptr<TileData>& tileData) const;
+        double getIntervalForZoom(int zoom) const;
+        static long long computeDiv(long long ele);
+
+        const DirectorPtr<TileDataSource> _dataSource;
+        const std::shared_ptr<ElevationDecoder> _elevationDecoder;
+
+        std::atomic<float> _baseInterval;
+        std::atomic<float> _simplifyTolerance;
+        std::atomic<int> _resolution;
+        std::atomic<int> _minVisibleZoom;
+        std::atomic<bool> _seamlessEdges;
+        std::string _layerName;
+        mutable std::mutex _mutex;
+
+    private:
+        std::shared_ptr<DataSourceListener> _dataSourceListener;
+    };
+
+}
+
+#endif

--- a/all/native/layers/CustomRasterTileLayer.cpp
+++ b/all/native/layers/CustomRasterTileLayer.cpp
@@ -1,0 +1,96 @@
+#include "CustomRasterTileLayer.h"
+#include "renderers/MapRenderer.h"
+#include "renderers/TileRenderer.h"
+#include "graphics/Bitmap.h"
+#include "graphics/Color.h"
+
+#include <vt/TileId.h>
+#include <vt/Tile.h>
+#include <vt/TileBitmap.h>
+#include <vt/TileLayer.h>
+#include <vt/TileLayerBuilder.h>
+#include <vt/TileTransformer.h>
+
+namespace carto {
+
+    CustomRasterTileLayer::CustomRasterTileLayer(const std::shared_ptr<TileDataSource>& dataSource) :
+        RasterTileLayer(dataSource),
+        _shaderSource(),
+        _customShaderMutex()
+    {
+        setTileBlendingSpeed(0.0f);
+    }
+
+    CustomRasterTileLayer::~CustomRasterTileLayer() {
+    }
+
+    std::string CustomRasterTileLayer::getShaderSource() const {
+        std::lock_guard<std::recursive_mutex> lock(_customShaderMutex);
+        return _shaderSource;
+    }
+
+    void CustomRasterTileLayer::setShaderSource(const std::string& shaderSource) {
+        {
+            std::lock_guard<std::recursive_mutex> lock(_customShaderMutex);
+            _shaderSource = shaderSource;
+        }
+        redraw();
+    }
+
+    std::string CustomRasterTileLayer::getEffectiveShaderSource() const {
+        std::lock_guard<std::recursive_mutex> lock(_customShaderMutex);
+        return _shaderSource.empty() ? PASSTHROUGH_SHADER : _shaderSource;
+    }
+
+    bool CustomRasterTileLayer::onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState) {
+        updateTileLoadListener();
+
+        if (auto mapRenderer = getMapRenderer()) {
+            float opacity = getOpacity();
+
+            if (opacity < 1.0f) {
+                mapRenderer->clearAndBindScreenFBO(Color(0, 0, 0, 0), false, false);
+            }
+
+            _tileRenderer->setNormalMapLightingShader(getEffectiveShaderSource());
+            _tileRenderer->setRasterFilterMode(getRasterFilterMode());
+            _tileRenderer->setLayerBlendingSpeed(getTileBlendingSpeed());
+            // Generic raster filter: no DEM elevation encoding or built-in contours.
+            _tileRenderer->setNormalMapElevationEncoded(false);
+            _tileRenderer->setNormalMapContourInterval(0.0f);
+
+            bool refresh = _tileRenderer->onDrawFrame(deltaSeconds, viewState);
+
+            if (opacity < 1.0f) {
+                mapRenderer->blendAndUnbindScreenFBO(opacity);
+            }
+
+            return refresh;
+        }
+        return false;
+    }
+
+    std::shared_ptr<vt::Tile> CustomRasterTileLayer::createVectorTile(const MapTile& subTile, const MapTile& tile, const std::shared_ptr<TileData>& tileData, const std::shared_ptr<Bitmap>& bitmap, const std::shared_ptr<vt::TileTransformer>& tileTransformer) const {
+        // Upload the raw RGBA tile as a NORMALMAP-type bitmap so it runs through the custom fragment
+        // shader path (the injected shader samples it via getRawColor()). No normal map is computed.
+        vt::TileId vtTileId(tile.getZoom(), tile.getX(), tile.getY());
+        std::shared_ptr<Bitmap> rgbaBitmap = bitmap->getRGBABitmap();
+        int width = rgbaBitmap->getWidth();
+        int height = rgbaBitmap->getHeight();
+        const std::vector<unsigned char>& pixelData = rgbaBitmap->getPixelData();
+        std::vector<std::uint8_t> data(pixelData.begin(), pixelData.end());
+        auto tileBitmap = std::make_shared<vt::TileBitmap>(vt::TileBitmap::Type::NORMALMAP, vt::TileBitmap::Format::RGBA, width, height, std::move(data));
+
+        float tileSize = 256.0f; // 'normalized' tile size in pixels; not important here
+        vt::TileLayerBuilder tileLayerBuilder(std::string(), 0, vtTileId, tileTransformer, tileSize, 1.0f);
+        tileLayerBuilder.addBitmap(tileBitmap);
+        std::shared_ptr<vt::TileLayer> tileLayer = tileLayerBuilder.buildTileLayer();
+        return std::make_shared<vt::Tile>(vtTileId, tileSize, std::vector<std::shared_ptr<vt::TileLayer> > { tileLayer });
+    }
+
+    const std::string CustomRasterTileLayer::PASSTHROUGH_SHADER =
+        "vec4 applyLighting(lowp vec4 color, mediump vec3 normal, mediump vec3 surfaceNormal, mediump float intensity) {\n"
+        "    return getRawColor();\n"
+        "}\n";
+
+}

--- a/all/native/layers/CustomRasterTileLayer.h
+++ b/all/native/layers/CustomRasterTileLayer.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_CUSTOMRASTERTILELAYER_H_
+#define _CARTO_CUSTOMRASTERTILELAYER_H_
+
+#include "layers/RasterTileLayer.h"
+
+#include <mutex>
+#include <string>
+
+namespace carto {
+
+    /**
+     * A raster tile layer that renders each tile through a custom GLSL fragment shader ("filter").
+     * The data source can be any raster TileDataSource - most commonly an RGB-encoded elevation
+     * (terrarium/mapbox) source, but any raster works. This is the general form of
+     * HillshadeRasterTileLayer, which specializes it for DEM data (normal map + hillshade + contours).
+     *
+     * The shader must define:
+     *   vec4 applyLighting(lowp vec4 color, mediump vec3 normal, mediump vec3 surfaceNormal, mediump float intensity)
+     * and it can use these helpers (injected before it):
+     *   getRawColor()  - the untouched RGBA texel of the source tile at this fragment
+     *   getMapZoom()   - the current fractional map zoom (for per-zoom logic)
+     * plus the shared uniforms/varyings vUV (tile uv), uUVScale (texture size) and uBitmap.
+     * It must return a PREMULTIPLIED color (rgb already multiplied by alpha); return alpha 0 where the
+     * output should be transparent so layers below show through.
+     *
+     * Note: this class is experimental and may change or even be removed in future SDK versions.
+     */
+    class CustomRasterTileLayer : public RasterTileLayer {
+    public:
+        /**
+         * Constructs a CustomRasterTileLayer object from a raster data source.
+         * @param dataSource The raster data source from which this layer loads data.
+         */
+        explicit CustomRasterTileLayer(const std::shared_ptr<TileDataSource>& dataSource);
+        virtual ~CustomRasterTileLayer();
+
+        /**
+         * Returns the custom fragment shader source.
+         * @return The shader source. Empty means the default passthrough (outputs the raw tile).
+         */
+        std::string getShaderSource() const;
+        /**
+         * Sets the custom fragment shader source (the "filter"). See the class description for the
+         * required entry point and available helpers. Empty resets to the passthrough shader.
+         * @param shaderSource The GLSL shader source.
+         */
+        void setShaderSource(const std::string& shaderSource);
+
+    protected:
+        virtual bool onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState);
+
+        virtual std::shared_ptr<vt::Tile> createVectorTile(const MapTile& subTile, const MapTile& tile, const std::shared_ptr<TileData>& tileData, const std::shared_ptr<Bitmap>& bitmap, const std::shared_ptr<vt::TileTransformer>& tileTransformer) const;
+
+        // The shader source actually handed to the renderer. Falls back to PASSTHROUGH_SHADER.
+        virtual std::string getEffectiveShaderSource() const;
+
+        static const std::string PASSTHROUGH_SHADER;
+
+        std::string _shaderSource;
+        mutable std::recursive_mutex _customShaderMutex;
+    };
+
+}
+
+#endif

--- a/all/native/layers/HillshadeRasterTileLayer.cpp
+++ b/all/native/layers/HillshadeRasterTileLayer.cpp
@@ -29,7 +29,7 @@
 namespace carto
 {
 
-    HillshadeRasterTileLayer::HillshadeRasterTileLayer(const std::shared_ptr<TileDataSource> &dataSource, const std::shared_ptr<ElevationDecoder> &elevationDecoder) : RasterTileLayer(dataSource),
+    HillshadeRasterTileLayer::HillshadeRasterTileLayer(const std::shared_ptr<TileDataSource> &dataSource, const std::shared_ptr<ElevationDecoder> &elevationDecoder) : CustomRasterTileLayer(dataSource),
         _elevationDecoder(elevationDecoder),
         _contrast(0.5f),
         _heightScale(0.09f),
@@ -40,11 +40,16 @@ namespace carto
         _highlightColor(Color(255, 255, 255, 255)),
         _illuminationDirection(MapVec(-0.42261826, 0.90630779, -0.70710678)),  // azimuth=335°, altitude=45° (MapLibre defaults)
         _illuminationMapRotationEnabled(true),
-        _hillshadeMethod(HillshadeMethod::HillshadeMethod::STANDARD)
+        _hillshadeMethod(HillshadeMethod::HillshadeMethod::STANDARD),
+        _contourEnabled(false),
+        _elevationEncodingEnabled(false),
+        _contourInterval(100.0f),
+        _contourColor(Color(0xC5, 0x60, 0x08, 0xff)),
+        _contourWidth(0.75f)
     {
         setTileBlendingSpeed(0.0f);
     }
-    HillshadeRasterTileLayer::HillshadeRasterTileLayer(const std::shared_ptr<TileDataSource> &dataSource) : RasterTileLayer(dataSource),
+    HillshadeRasterTileLayer::HillshadeRasterTileLayer(const std::shared_ptr<TileDataSource> &dataSource) : CustomRasterTileLayer(dataSource),
         _elevationDecoder(nullptr),
         _contrast(0.5f),
         _heightScale(1.0f),
@@ -55,7 +60,12 @@ namespace carto
         _highlightColor(Color(255, 255, 255, 255)),
         _illuminationDirection(MapVec(-0.42261826, 0.90630779, -0.70710678)),  // azimuth=335°, altitude=45° (MapLibre defaults)
         _illuminationMapRotationEnabled(true),
-        _hillshadeMethod(HillshadeMethod::HillshadeMethod::STANDARD)
+        _hillshadeMethod(HillshadeMethod::HillshadeMethod::STANDARD),
+        _contourEnabled(false),
+        _elevationEncodingEnabled(false),
+        _contourInterval(100.0f),
+        _contourColor(Color(0xC5, 0x60, 0x08, 0xff)),
+        _contourWidth(0.75f)
     {
         setTileBlendingSpeed(0.0f);
     }
@@ -160,6 +170,53 @@ namespace carto
         redraw();
     }
 
+    bool HillshadeRasterTileLayer::isElevationEncodingEnabled() const {
+        return _elevationEncodingEnabled.load();
+    }
+
+    void HillshadeRasterTileLayer::setElevationEncodingEnabled(bool enabled) {
+        _elevationEncodingEnabled.store(enabled);
+        updateTiles(false); // format change (elevation packed into the normal map)
+    }
+
+    bool HillshadeRasterTileLayer::isContourEnabled() const {
+        return _contourEnabled.load();
+    }
+
+    void HillshadeRasterTileLayer::setContourEnabled(bool enabled) {
+        _contourEnabled.store(enabled);
+        // Toggling contours changes the normal map encoding (elevation packed into B/A), so the
+        // tiles must be rebuilt (as with setContrast, which is also baked into the normal map).
+        updateTiles(false);
+    }
+
+    float HillshadeRasterTileLayer::getContourInterval() const {
+        return _contourInterval.load();
+    }
+
+    void HillshadeRasterTileLayer::setContourInterval(float interval) {
+        _contourInterval.store(interval);
+        redraw();
+    }
+
+    Color HillshadeRasterTileLayer::getContourColor() const {
+        return _contourColor.load();
+    }
+
+    void HillshadeRasterTileLayer::setContourColor(const Color& color) {
+        _contourColor.store(color);
+        redraw();
+    }
+
+    float HillshadeRasterTileLayer::getContourWidth() const {
+        return _contourWidth.load();
+    }
+
+    void HillshadeRasterTileLayer::setContourWidth(float width) {
+        _contourWidth.store(width);
+        redraw();
+    }
+
     bool HillshadeRasterTileLayer::onDrawFrame(float deltaSeconds, BillboardSorter &billboardSorter, const ViewState &viewState)
     {
         updateTileLoadListener();
@@ -179,6 +236,10 @@ namespace carto
             _tileRenderer->setNormalMapShadowColor(getShadowColor());
             _tileRenderer->setNormalMapAccentColor(getAccentColor());
             _tileRenderer->setNormalMapHighlightColor(getHighlightColor());
+            _tileRenderer->setNormalMapElevationEncoded(isElevationEncoded());
+            _tileRenderer->setNormalMapContourInterval(isContourEnabled() ? getContourInterval() : 0.0f);
+            _tileRenderer->setNormalMapContourColor(getContourColor());
+            _tileRenderer->setNormalMapContourWidth(getContourWidth());
             _tileRenderer->setNormalIlluminationDirection(getIlluminationDirection());
             _tileRenderer->setNormalIlluminationMapRotationEnabled(getIlluminationMapRotationEnabled());
 
@@ -218,6 +279,7 @@ namespace carto
     std::shared_ptr<vt::Tile> HillshadeRasterTileLayer::createVectorTile(const MapTile& subTile, const MapTile& tile, const std::shared_ptr<TileData>& tileData, const std::shared_ptr<Bitmap>& bitmap, const std::shared_ptr<vt::TileTransformer>& tileTransformer) const {
         std::uint8_t alpha = 0;
         std::array<float, 4> scales;
+        std::array<float, 4> elevationCoeffs = { { 0.0f, 0.0f, 0.0f, 0.0f } };
         {
             // Try to get decoder type from tile metadata first, fallback to layer's decoder
             std::shared_ptr<ElevationDecoder> decoder = _elevationDecoder;
@@ -240,6 +302,8 @@ namespace carto
                 decoder = mapboxDecoder;
             }
             scales = decoder->getVectorTileScales();
+            std::array<double, 4> rawCoeffs = decoder->getColorComponentCoefficients();
+            elevationCoeffs = { { static_cast<float>(rawCoeffs[0]), static_cast<float>(rawCoeffs[1]), static_cast<float>(rawCoeffs[2]), static_cast<float>(rawCoeffs[3]) } };
             alpha = static_cast<std::uint8_t>(getContrast() * 255.0f);
             float heightScale = decoder->getMinimumHeightScale();
             float scale = heightScale * static_cast<float>(bitmap->getHeight() * std::pow(2.0, tile.getZoom()) / 40075016.6855785);
@@ -258,7 +322,7 @@ namespace carto
         auto rgbaBitmapDataPtr = reinterpret_cast<const std::uint32_t*>(rgbaBitmap->getPixelData().data());
         std::vector<std::uint32_t> rgbaBitmapData(rgbaBitmapDataPtr, rgbaBitmapDataPtr + rgbaBitmap->getWidth() * rgbaBitmap->getHeight());
         auto vtBitmap = std::make_shared<vt::Bitmap>(rgbaBitmap->getWidth(), rgbaBitmap->getHeight(), std::move(rgbaBitmapData));
-        vt::NormalMapBuilder normalMapBuilder(scales, alpha);
+        vt::NormalMapBuilder normalMapBuilder(scales, alpha, isElevationEncoded(), elevationCoeffs);
         std::shared_ptr<const vt::Bitmap> normalMap = normalMapBuilder.buildNormalMapFromHeightMap(vtTileId, vtTileId, vtBitmap);
         auto normalMapDataPtr = reinterpret_cast<const std::uint8_t*>(normalMap->data.data());
         std::vector<std::uint8_t> normalMapData(normalMapDataPtr, normalMapDataPtr + normalMap->data.size() * sizeof(std::uint32_t));

--- a/all/native/layers/HillshadeRasterTileLayer.h
+++ b/all/native/layers/HillshadeRasterTileLayer.h
@@ -9,7 +9,7 @@
 
 #include "graphics/Color.h"
 #include "components/DirectorPtr.h"
-#include "layers/RasterTileLayer.h"
+#include "layers/CustomRasterTileLayer.h"
 #include "rastertiles/ElevationDecoder.h"
 
 #include <atomic>
@@ -50,7 +50,7 @@ namespace carto {
      * The shading is based on the direction of the main light source, which can be configured using Options class.
      * Note: this class is experimental and may change or even be removed in future SDK versions.
      */
-    class HillshadeRasterTileLayer : public RasterTileLayer {
+    class HillshadeRasterTileLayer : public CustomRasterTileLayer {
     public:
         /**
          * Constructs a HillshadeRasterTileLayer object from a data source.
@@ -166,6 +166,63 @@ namespace carto {
          */
         void setHillshadeMethod(HillshadeMethod::HillshadeMethod method);
 
+        /**
+         * Returns whether the normal map encodes absolute elevation (so a custom normal-map lighting
+         * shader can call getElevation()).
+         * @return True if elevation encoding is enabled. Default is false.
+         */
+        bool isElevationEncodingEnabled() const;
+        /**
+         * Sets whether the normal map encodes absolute elevation in addition to the surface normal.
+         * Required for a custom normal-map lighting shader that reads getElevation()/getMapZoom() (e.g.
+         * to draw its own per-zoom contour lines). Enabling contour lines turns this on implicitly.
+         * @param enabled True to encode elevation into the normal map.
+         */
+        void setElevationEncodingEnabled(bool enabled);
+
+        /**
+         * Returns whether GPU contour lines are drawn over the hillshade.
+         * @return True if contour lines are enabled. Default is false.
+         */
+        bool isContourEnabled() const;
+        /**
+         * Sets whether to draw anti-aliased contour lines over the hillshade, computed in the shader
+         * from the elevation data. Enabling this makes the normal map encode absolute elevation (which
+         * is also available to a custom normal-map lighting shader). Note: this class is experimental.
+         * @param enabled True to draw contour lines.
+         */
+        void setContourEnabled(bool enabled);
+        /**
+         * Returns the spacing between contour lines in meters.
+         * @return The contour interval in meters. Default is 100.
+         */
+        float getContourInterval() const;
+        /**
+         * Sets the spacing between contour lines in meters.
+         * @param interval The contour interval in meters.
+         */
+        void setContourInterval(float interval);
+        /**
+         * Returns the contour line color.
+         * @return The contour line color.
+         */
+        Color getContourColor() const;
+        /**
+         * Sets the contour line color.
+         * @param color The contour line color.
+         */
+        void setContourColor(const Color& color);
+        /**
+         * Returns the contour line half-width in screen pixels.
+         * @return The contour line width. Default is 0.75.
+         */
+        float getContourWidth() const;
+        /**
+         * Sets the contour line half-width in screen pixels.
+         * @param width The contour line width in pixels.
+         */
+        void setContourWidth(float width);
+
         double getElevation(const MapPos& pos) const;
         std::vector<double> getElevations(const std::vector<MapPos> poses) const;
 
@@ -192,6 +249,15 @@ namespace carto {
         std::atomic<MapVec> _illuminationDirection;
         std::atomic<bool> _illuminationMapRotationEnabled;
         std::atomic<HillshadeMethod::HillshadeMethod> _hillshadeMethod;
+        std::atomic<bool> _contourEnabled;
+        std::atomic<bool> _elevationEncodingEnabled;
+        std::atomic<float> _contourInterval;
+        std::atomic<Color> _contourColor;
+        std::atomic<float> _contourWidth;
+
+        // Elevation is packed into the normal map when contours are on or when explicitly requested
+        // for a custom shader.
+        bool isElevationEncoded() const { return _contourEnabled.load() || _elevationEncodingEnabled.load(); }
     };
     
 }

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -20,6 +20,7 @@
 #include <vt/LabelCuller.h>
 #include <vt/TileTransformer.h>
 #include <vt/GLExtensions.h>
+#include <vt/NormalMapBuilder.h>
 
 #include <cmath>
 #include <unordered_map>
@@ -152,6 +153,22 @@ namespace carto {
             _normalMapLightingShader = newValue;
             _vtRenderer.reset();
         }
+    }
+    void TileRenderer::setNormalMapElevationEncoded(bool enabled) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _normalMapElevationEncoded = enabled;
+    }
+    void TileRenderer::setNormalMapContourInterval(float interval) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _normalMapContourInterval = interval;
+    }
+    void TileRenderer::setNormalMapContourColor(const Color& color) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _normalMapContourColor = color;
+    }
+    void TileRenderer::setNormalMapContourWidth(float width) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _normalMapContourWidth = width;
     }
     void TileRenderer::setNormalIlluminationDirection(MapVec direction) {
         std::lock_guard<std::mutex> lock(_mutex);
@@ -700,6 +717,16 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
                     glUniform3fv(glGetUniformLocation(shaderProgram, "u_lightDir"), 1, _normalLightDir.data() );
                     glUniform1i(glGetUniformLocation(shaderProgram, "u_method"), (_hillshadeMethod));
                     glUniform1f(glGetUniformLocation(shaderProgram, "u_exaggeration"), _hillshadeExaggeration);
+                    // Elevation-encoded normal map + contour lines (opt-in). These uniforms have no
+                    // effect unless the normal map was built with elevation encoding (see HillshadeRasterTileLayer).
+                    glUniform1f(glGetUniformLocation(shaderProgram, "u_elevationEncoded"), _normalMapElevationEncoded ? 1.0f : 0.0f);
+                    glUniform2f(glGetUniformLocation(shaderProgram, "u_elevationDecode"), vt::NormalMapBuilder::ELEVATION_SCALE, vt::NormalMapBuilder::ELEVATION_OFFSET);
+                    glUniform1f(glGetUniformLocation(shaderProgram, "u_contrast"), _hillshadeExaggeration);
+                    glUniform4f(glGetUniformLocation(shaderProgram, "u_contourColor"), _normalMapContourColor.getR() / 255.0f, _normalMapContourColor.getG() / 255.0f, _normalMapContourColor.getB() / 255.0f, _normalMapContourColor.getA() / 255.0f);
+                    glUniform1f(glGetUniformLocation(shaderProgram, "u_contourInterval"), _normalMapContourInterval);
+                    glUniform1f(glGetUniformLocation(shaderProgram, "u_contourWidth"), _normalMapContourWidth);
+                    // Current fractional map zoom, for per-zoom custom normal-map shaders (getMapZoom()).
+                    glUniform1f(glGetUniformLocation(shaderProgram, "u_zoom"), viewState.zoom);
             });
             tileRenderer->setLightingShaderNormalMap(lightingShaderNormalMap);
         }

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -63,6 +63,10 @@ namespace carto {
         void setNormalMapHighlightColor(const Color& color);
         void setNormalMapAccentColor(const Color& color);
         void setNormalMapLightingShader(const std::string& shader);
+        void setNormalMapElevationEncoded(bool enabled);
+        void setNormalMapContourInterval(float interval);
+        void setNormalMapContourColor(const Color& color);
+        void setNormalMapContourWidth(float width);
         void setNormalIlluminationMapRotationEnabled(bool enabled);
         void setNormalIlluminationDirection(MapVec direction);
         void setHillshadeMethod(int method);
@@ -113,6 +117,10 @@ namespace carto {
         Color _normalMapAccentColor;
         Color _normalMapHighlightColor;
         std::string _normalMapLightingShader;
+        bool _normalMapElevationEncoded = false;
+        float _normalMapContourInterval = 0.0f; // meters; <= 0 disables contour lines
+        Color _normalMapContourColor;
+        float _normalMapContourWidth = 0.75f; // contour half-width in screen pixels
         std::optional<std::regex> _rendererLayerFilter;
         std::optional<std::regex> _clickHandlerLayerFilter;
 


### PR DESCRIPTION
Adds on-the-fly contour lines from RGB-elevation tiles (replacing pre-baked mbtiles), a GPU shader contour path in the hillshade layer, and a general custom-shader raster layer. Depends on the matching libs-carto `develop` changes (submodule pointer bumped in this branch).

## 1. `ContourTileDataSource` — on-the-fly contour geometry
Decorates any RGB-encoded elevation `TileDataSource` (shares fetch/decode — no second download) and generates vector contour tiles via marching squares (stitched into polylines). Emits a `contour` layer with `ele` (metres) and `div` (largest nice divisor: 1000/500/250/200/100/50/20/10, matching the `gdal_contour` pipeline), so it drops into a normal `VectorTileLayer` + CartoCSS with no style changes. Options: base interval, generation resolution (DEM subsample), min visible zoom, simplify tolerance, optional seamless edges (fetch E/N/NE neighbours so lines meet across tile boundaries).

## 2. Shader contour lines (hillshade)
`HillshadeRasterTileLayer.setContourEnabled/Interval/Color/Width` draws anti-aliased contour lines in the fragment shader from the elevation, which is opt-in encoded into the normal map (normal.xy in R,G; 16-bit elevation in B,A; contrast → uniform; default off is byte-identical). Unaffected by tile zoom (per-fragment, fixed metre interval). `setElevationEncodingEnabled` + `setNormalMapLightingShader` lets an app write its own per-zoom / `div` contour shader via `getElevation()` / `getMapZoom()`.

## 3. `CustomRasterTileLayer` — general custom-shader raster layer
New base class of `HillshadeRasterTileLayer`. Runs a custom GLSL "filter" shader over any raster source (`setShaderSource`); the shader reads `getRawColor()` / `getMapZoom()` and returns a premultiplied color. Hillshade is now the DEM specialization (behavior unchanged — its virtual overrides shadow the base).

## Also
- Fixes cracks in vector lines draped over 3D terrain at low zoom in regular-grid mode (libs-carto: draped geometry follows the surface triangles instead of bilinear).

## Notes
- New public API surfaces via SWIG (regen required for the app bindings).
- `SecondFragment` demo edits are intentionally not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)