### PR TITLE
feat(layers): CompositeVectorTileLayer — mix external sources into a vector-tile style

### DIFF
--- a/all/modules/layers/CompositeVectorTileLayer.i
+++ b/all/modules/layers/CompositeVectorTileLayer.i
@@ -1,0 +1,34 @@
+#ifndef _COMPOSITEVECTORTILELAYER_I
+#define _COMPOSITEVECTORTILELAYER_I
+
+%module CompositeVectorTileLayer
+
+!proxy_imports(carto::CompositeVectorTileLayer, datasources.TileDataSource, layers.VectorTileLayer, vectortiles.VectorTileDecoder, rastertiles.ElevationDecoder)
+
+%{
+#include "layers/CompositeVectorTileLayer.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_string.i>
+%include <std_vector.i>
+%include <std_shared_ptr.i>
+%include <cartoswig.i>
+
+%import "layers/VectorTileLayer.i"
+%import "datasources/TileDataSource.i"
+%import "vectortiles/VectorTileDecoder.i"
+%import "rastertiles/ElevationDecoder.i"
+
+!enum(carto::CompositeSourceType::CompositeSourceType)
+!polymorphic_shared_ptr(carto::CompositeVectorTileLayer, layers.CompositeVectorTileLayer)
+
+%attribute(carto::CompositeVectorTileLayer, bool, SinglePassRenderingEnabled, isSinglePassRenderingEnabled, setSinglePassRenderingEnabled)
+%std_exceptions(carto::CompositeVectorTileLayer::CompositeVectorTileLayer)
+%std_exceptions(carto::CompositeVectorTileLayer::addExternalDataSource)
+%std_exceptions(carto::CompositeVectorTileLayer::addVectorDataSource)
+
+%include "layers/CompositeVectorTileLayer.h"
+
+#endif

--- a/all/modules/layers/CompositeVectorTileLayer.i
+++ b/all/modules/layers/CompositeVectorTileLayer.i
@@ -3,7 +3,7 @@
 
 %module CompositeVectorTileLayer
 
-!proxy_imports(carto::CompositeVectorTileLayer, datasources.TileDataSource, layers.VectorTileLayer, vectortiles.VectorTileDecoder, rastertiles.ElevationDecoder)
+!proxy_imports(carto::CompositeVectorTileLayer, datasources.TileDataSource, layers.VectorTileLayer, vectortiles.VectorTileDecoder, rastertiles.ElevationDecoder, core.StringVector)
 
 %{
 #include "layers/CompositeVectorTileLayer.h"
@@ -20,6 +20,7 @@
 %import "datasources/TileDataSource.i"
 %import "vectortiles/VectorTileDecoder.i"
 %import "rastertiles/ElevationDecoder.i"
+%import "core/StringVector.i"
 
 !enum(carto::CompositeSourceType::CompositeSourceType)
 !polymorphic_shared_ptr(carto::CompositeVectorTileLayer, layers.CompositeVectorTileLayer)

--- a/all/modules/layers/HillshadeRasterTileLayer.i
+++ b/all/modules/layers/HillshadeRasterTileLayer.i
@@ -25,6 +25,7 @@
 
 %attribute(carto::HillshadeRasterTileLayer, float, Contrast, getContrast, setContrast)
 %attribute(carto::HillshadeRasterTileLayer, float, HeightScale, getHeightScale, setHeightScale)
+%attribute(carto::HillshadeRasterTileLayer, float, Exaggeration, getExaggeration, setExaggeration)
 %attribute(carto::HillshadeRasterTileLayer, carto::MapVec, IlluminationDirection, getIlluminationDirection, setIlluminationDirection)
 %attribute(carto::HillshadeRasterTileLayer, bool, IlluminationMapRotationEnabled, getIlluminationMapRotationEnabled, setIlluminationMapRotationEnabled)
 %attribute(carto::HillshadeRasterTileLayer, bool, ExagerateHeightScaleEnabled, getExagerateHeightScaleEnabled, setExagerateHeightScaleEnabled)

--- a/all/modules/vectortiles/MBVectorTileDecoder.i
+++ b/all/modules/vectortiles/MBVectorTileDecoder.i
@@ -48,6 +48,7 @@
 %ignore carto::MBVectorTileDecoder::loadCartoCSSMap;
 %ignore carto::MBVectorTileDecoder::getStyleLayerNames;
 %ignore carto::MBVectorTileDecoder::resolveLayerConfig;
+%ignore carto::MBVectorTileDecoder::getStyleLayerZoomRange;
 
 %include "vectortiles/MBVectorTileDecoder.h"
 

--- a/all/modules/vectortiles/MBVectorTileDecoder.i
+++ b/all/modules/vectortiles/MBVectorTileDecoder.i
@@ -46,6 +46,8 @@
 %ignore carto::MBVectorTileDecoder::getSymbolizerContextSettings;
 %ignore carto::MBVectorTileDecoder::loadMapnikMap;
 %ignore carto::MBVectorTileDecoder::loadCartoCSSMap;
+%ignore carto::MBVectorTileDecoder::getStyleLayerNames;
+%ignore carto::MBVectorTileDecoder::resolveLayerConfig;
 
 %include "vectortiles/MBVectorTileDecoder.h"
 

--- a/all/native/datasources/DynamicMergedMBVTTileDataSource.cpp
+++ b/all/native/datasources/DynamicMergedMBVTTileDataSource.cpp
@@ -1,0 +1,116 @@
+#include "DynamicMergedMBVTTileDataSource.h"
+#include "datasources/MergedMBVTTileDataSource.h"
+#include "core/MapTile.h"
+#include "components/Exceptions.h"
+
+#include <algorithm>
+
+namespace carto {
+
+    DynamicMergedMBVTTileDataSource::DynamicMergedMBVTTileDataSource(const std::shared_ptr<TileDataSource>& baseDataSource) :
+        TileDataSource(),
+        _baseDataSource(baseDataSource),
+        _extraDataSources(),
+        _mergedChain(baseDataSource),
+        _mutex()
+    {
+        if (!baseDataSource) {
+            throw NullArgumentException("Null baseDataSource");
+        }
+        _dataSourceListener = std::make_shared<DataSourceListener>(*this);
+        _baseDataSource->registerOnChangeListener(_dataSourceListener);
+    }
+
+    DynamicMergedMBVTTileDataSource::~DynamicMergedMBVTTileDataSource() {
+        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        for (const auto& entry : _extraDataSources) {
+            entry.second->unregisterOnChangeListener(_dataSourceListener);
+        }
+        _baseDataSource->unregisterOnChangeListener(_dataSourceListener);
+        _dataSourceListener.reset();
+    }
+
+    void DynamicMergedMBVTTileDataSource::addDataSource(const std::string& key, const std::shared_ptr<TileDataSource>& dataSource) {
+        if (!dataSource) {
+            throw NullArgumentException("Null dataSource");
+        }
+        {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            auto it = std::find_if(_extraDataSources.begin(), _extraDataSources.end(), [&](const auto& entry) { return entry.first == key; });
+            if (it != _extraDataSources.end()) {
+                if (it->second == dataSource) {
+                    return;
+                }
+                it->second->unregisterOnChangeListener(_dataSourceListener);
+                it->second = dataSource;
+            } else {
+                _extraDataSources.emplace_back(key, dataSource);
+            }
+            dataSource->registerOnChangeListener(_dataSourceListener);
+            rebuildChain();
+        }
+        notifyTilesChanged(true);
+    }
+
+    bool DynamicMergedMBVTTileDataSource::removeDataSource(const std::string& key) {
+        {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            auto it = std::find_if(_extraDataSources.begin(), _extraDataSources.end(), [&](const auto& entry) { return entry.first == key; });
+            if (it == _extraDataSources.end()) {
+                return false;
+            }
+            it->second->unregisterOnChangeListener(_dataSourceListener);
+            _extraDataSources.erase(it);
+            rebuildChain();
+        }
+        notifyTilesChanged(true);
+        return true;
+    }
+
+    bool DynamicMergedMBVTTileDataSource::containsDataSource(const std::string& key) const {
+        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        return std::any_of(_extraDataSources.begin(), _extraDataSources.end(), [&](const auto& entry) { return entry.first == key; });
+    }
+
+    void DynamicMergedMBVTTileDataSource::rebuildChain() {
+        std::shared_ptr<TileDataSource> chain = _baseDataSource.get();
+        for (const auto& entry : _extraDataSources) {
+            chain = std::make_shared<MergedMBVTTileDataSource>(chain, entry.second);
+        }
+        _mergedChain = chain;
+    }
+
+    int DynamicMergedMBVTTileDataSource::getMinZoom() const {
+        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        return _mergedChain->getMinZoom();
+    }
+
+    int DynamicMergedMBVTTileDataSource::getMaxZoom() const {
+        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        return _mergedChain->getMaxZoom();
+    }
+
+    MapBounds DynamicMergedMBVTTileDataSource::getDataExtent() const {
+        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        return _mergedChain->getDataExtent();
+    }
+
+    std::shared_ptr<TileData> DynamicMergedMBVTTileDataSource::loadTile(const MapTile& tile) {
+        std::shared_ptr<TileDataSource> chain;
+        {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            chain = _mergedChain;
+        }
+        return chain->loadTile(tile);
+    }
+
+    DynamicMergedMBVTTileDataSource::DataSourceListener::DataSourceListener(DynamicMergedMBVTTileDataSource& dataSource) :
+        _dataSource(dataSource)
+    {
+    }
+
+    void DynamicMergedMBVTTileDataSource::DataSourceListener::onTilesChanged(bool removeTiles) {
+        _dataSource.notifyTilesChanged(removeTiles);
+    }
+
+}

--- a/all/native/datasources/DynamicMergedMBVTTileDataSource.h
+++ b/all/native/datasources/DynamicMergedMBVTTileDataSource.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_DYNAMICMERGEDMBVTTILEDATASOURCE_H_
+#define _CARTO_DYNAMICMERGEDMBVTTILEDATASOURCE_H_
+
+#include "datasources/TileDataSource.h"
+#include "components/DirectorPtr.h"
+
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace carto {
+
+    /**
+     * A tile data source that merges a fixed base MBVT/protobuf source with a dynamically
+     * mutable set of additional MBVT sources, keyed by name. Adding or removing a source
+     * rebuilds an internal MergedMBVTTileDataSource chain and notifies listeners so tiles
+     * are reloaded. Used internally by CompositeVectorTileLayer to support runtime add/remove
+     * of merged vector sources (including ContourTileDataSource) while the owning layer's
+     * data source pointer stays constant.
+     *
+     * As with MergedMBVTTileDataSource, the merged sources are assumed to have distinct
+     * layer ids.
+     */
+    class DynamicMergedMBVTTileDataSource : public TileDataSource {
+    public:
+        explicit DynamicMergedMBVTTileDataSource(const std::shared_ptr<TileDataSource>& baseDataSource);
+        virtual ~DynamicMergedMBVTTileDataSource();
+
+        /**
+         * Adds (or replaces, if the key already exists) a named MBVT source to merge on top
+         * of the base source.
+         */
+        void addDataSource(const std::string& key, const std::shared_ptr<TileDataSource>& dataSource);
+        /**
+         * Removes the named source. Returns true if a source was removed.
+         */
+        bool removeDataSource(const std::string& key);
+        /**
+         * Returns true if a source with the given key is registered.
+         */
+        bool containsDataSource(const std::string& key) const;
+
+        virtual int getMinZoom() const;
+        virtual int getMaxZoom() const;
+        virtual MapBounds getDataExtent() const;
+
+        virtual std::shared_ptr<TileData> loadTile(const MapTile& tile);
+
+    protected:
+        class DataSourceListener : public TileDataSource::OnChangeListener {
+        public:
+            explicit DataSourceListener(DynamicMergedMBVTTileDataSource& dataSource);
+            virtual void onTilesChanged(bool removeTiles);
+        private:
+            DynamicMergedMBVTTileDataSource& _dataSource;
+        };
+
+        // Rebuilds _mergedChain from _baseDataSource + _extraDataSources. Must hold _mutex.
+        void rebuildChain();
+
+        const DirectorPtr<TileDataSource> _baseDataSource;
+        std::vector<std::pair<std::string, std::shared_ptr<TileDataSource> > > _extraDataSources;
+        std::shared_ptr<TileDataSource> _mergedChain;
+
+        mutable std::recursive_mutex _mutex;
+
+    private:
+        std::shared_ptr<DataSourceListener> _dataSourceListener;
+    };
+
+}
+
+#endif

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -1,5 +1,6 @@
 #include "CompositeVectorTileLayer.h"
 #include "datasources/DynamicMergedMBVTTileDataSource.h"
+#include "datasources/ContourTileDataSource.h"
 #include "layers/RasterTileLayer.h"
 #include "layers/HillshadeRasterTileLayer.h"
 #include "vectortiles/MBVectorTileDecoder.h"
@@ -133,6 +134,7 @@ namespace carto {
             _mergedDataSource->addDataSource(name, dataSource); // notifies -> master tiles reload
             rebuildRenderSteps();
         }
+        applyVectorSourceConfigs();
         refresh();
     }
 
@@ -150,6 +152,7 @@ namespace carto {
                     }
                 }
                 _externalSources.erase(it);
+                _lastVectorConfig.erase(name);
                 rebuildRenderSteps();
                 removed = true;
             }
@@ -226,6 +229,10 @@ namespace carto {
 
     void CompositeVectorTileLayer::loadData(const std::shared_ptr<CullState>& cullState) {
         VectorTileLayer::loadData(cullState);
+
+        // Re-apply merged-vector (contour) generation parameters in case the style / nuti
+        // parameters changed (a change triggers a decoder update -> tile reload -> loadData).
+        applyVectorSourceConfigs();
 
         std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
         for (const ExternalSource& s : _externalSources) {
@@ -368,6 +375,49 @@ namespace carto {
             if (const mvt::Value* v = getValue("contour-color")) { hillshade->setContourColor(parseColorValue(*v, Color(0xC5, 0x60, 0x08, 0xff))); }
             if (const mvt::Value* v = getValue("contour-width")) { hillshade->setContourWidth(valueToFloat(*v, 1.0f)); }
             // TODO: illumination-direction (azimuth degrees) -> setIlluminationDirection(MapVec).
+        }
+    }
+
+    void CompositeVectorTileLayer::applyVectorSourceConfigs() {
+        auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
+        if (!decoder) {
+            return;
+        }
+
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        for (const ExternalSource& s : _externalSources) {
+            if (s.type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR) {
+                continue;
+            }
+            auto contour = std::dynamic_pointer_cast<ContourTileDataSource>(s.dataSource);
+            if (!contour) {
+                continue;
+            }
+            // Contour generation parameters are not per-frame (changing them regenerates
+            // tiles), so evaluate at a neutral zoom; nuti parameters still apply.
+            mvt::ResolvedLayerConfig config = decoder->resolveLayerConfig(s.name, 0.0f);
+            std::map<std::string, float>& applied = _lastVectorConfig[s.name];
+
+            auto changed = [&](const std::string& key, float& outValue) {
+                auto it = config.values.find(key);
+                if (it == config.values.end()) {
+                    return false;
+                }
+                float value = valueToFloat(it->second, 0.0f);
+                auto ait = applied.find(key);
+                if (ait != applied.end() && ait->second == value) {
+                    return false;
+                }
+                applied[key] = value;
+                outValue = value;
+                return true;
+            };
+
+            float value = 0.0f;
+            if (changed("base-interval", value))      { contour->setBaseInterval(value); }
+            if (changed("resolution", value))         { contour->setResolution(static_cast<int>(value)); }
+            if (changed("min-visible-zoom", value))   { contour->setMinVisibleZoom(static_cast<int>(value)); }
+            if (changed("simplify-tolerance", value)) { contour->setSimplifyTolerance(value); }
         }
     }
 

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -7,10 +7,10 @@
 #include "rastertiles/ElevationDecoder.h"
 #include "rastertiles/TerrariumElevationDataDecoder.h"
 #include "rastertiles/MapBoxElevationDataDecoder.h"
-#include "renderers/TileRenderer.h"
 #include "renderers/MapRenderer.h"
 #include "graphics/ViewState.h"
 #include "graphics/Color.h"
+#include "core/MapRange.h"
 #include "components/Exceptions.h"
 #include "utils/Log.h"
 
@@ -75,7 +75,8 @@ namespace carto {
         VectorTileLayer(std::make_shared<DynamicMergedMBVTTileDataSource>(dataSource), decoder),
         _mergedDataSource(),
         _externalSources(),
-        _renderSteps(),
+        _drawItems(),
+        _lastVectorConfig(),
         _singlePassRenderingEnabled(false),
         _componentsSet(false),
         _childOptions(),
@@ -84,7 +85,7 @@ namespace carto {
         _sourceMutex()
     {
         _mergedDataSource = std::static_pointer_cast<DynamicMergedMBVTTileDataSource>(getDataSource());
-        rebuildRenderSteps();
+        rebuildDrawItems();
     }
 
     CompositeVectorTileLayer::~CompositeVectorTileLayer() {
@@ -103,12 +104,12 @@ namespace carto {
         if (type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_RASTER) {
             childLayer = std::make_shared<RasterTileLayer>(dataSource);
         } else { // HILLSHADE
-            std::shared_ptr<ElevationDecoder> decoder = elevationDecoder;
-            if (!decoder) {
-                decoder = resolveElevationDecoder(dataSource);
+            std::shared_ptr<ElevationDecoder> elevDecoder = elevationDecoder;
+            if (!elevDecoder) {
+                elevDecoder = resolveElevationDecoder(dataSource);
             }
-            childLayer = decoder ? std::make_shared<HillshadeRasterTileLayer>(dataSource, decoder)
-                                 : std::make_shared<HillshadeRasterTileLayer>(dataSource);
+            childLayer = elevDecoder ? std::make_shared<HillshadeRasterTileLayer>(dataSource, elevDecoder)
+                                     : std::make_shared<HillshadeRasterTileLayer>(dataSource);
         }
 
         {
@@ -118,7 +119,7 @@ namespace carto {
             if (_componentsSet) {
                 wireChild(childLayer);
             }
-            rebuildRenderSteps();
+            rebuildDrawItems();
         }
         refresh();
     }
@@ -131,8 +132,8 @@ namespace carto {
             std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
             removeExternalDataSource(name);
             _externalSources.push_back({ name, CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR, dataSource, std::shared_ptr<Layer>() });
-            _mergedDataSource->addDataSource(name, dataSource); // notifies -> master tiles reload
-            rebuildRenderSteps();
+            _mergedDataSource->addDataSource(name, dataSource); // notifies -> master + group tiles reload
+            rebuildDrawItems();
         }
         applyVectorSourceConfigs();
         refresh();
@@ -153,7 +154,7 @@ namespace carto {
                 }
                 _externalSources.erase(it);
                 _lastVectorConfig.erase(name);
-                rebuildRenderSteps();
+                rebuildDrawItems();
                 removed = true;
             }
         }
@@ -193,6 +194,18 @@ namespace carto {
         return std::make_shared<TerrariumElevationDataDecoder>();
     }
 
+    std::string CompositeVectorTileLayer::buildFilterString(const std::vector<std::string>& group) {
+        if (group.empty()) {
+            return "$^"; // impossible anchor sequence -> matches no layer name (empty group renders nothing)
+        }
+        std::string pattern = "^(";
+        for (std::size_t i = 0; i < group.size(); i++) {
+            pattern += (i ? "|" : "") + group[i];
+        }
+        pattern += ")";
+        return pattern;
+    }
+
     void CompositeVectorTileLayer::wireChild(const std::shared_ptr<Layer>& child) {
         if (!child) {
             return;
@@ -206,6 +219,93 @@ namespace carto {
             return;
         }
         child->unregisterDataSourceListener();
+    }
+
+    std::shared_ptr<Layer> CompositeVectorTileLayer::makeGroupLayer(const std::string& filter) {
+        // Internal group layer: same merged source + decoder as this layer, with a fixed
+        // rendererLayerFilter. Shares the master data source so a source change reloads all groups.
+        auto groupLayer = std::make_shared<VectorTileLayer>(getDataSource(), getTileDecoder());
+        groupLayer->setRendererLayerFilter(filter);
+        groupLayer->setLabelRenderOrder(getLabelRenderOrder());
+        groupLayer->setBuildingRenderOrder(getBuildingRenderOrder());
+        std::shared_ptr<Layer> child = groupLayer;
+        if (_componentsSet) {
+            wireChild(child);
+        }
+        return child;
+    }
+
+    void CompositeVectorTileLayer::applyExternalChildZoomRange(const ExternalSource& source) {
+        auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
+        if (!decoder || !source.childLayer) {
+            return;
+        }
+        std::vector<int> range = decoder->getStyleLayerZoomRange(source.name);
+        if (range.size() == 2) {
+            source.childLayer->setVisibleZoomRange(MapRange(static_cast<float>(range[0]), static_cast<float>(range[1])));
+        }
+    }
+
+    void CompositeVectorTileLayer::rebuildDrawItems() {
+        // Caller holds _sourceMutex (or is the constructor).
+
+        // Drop previous internal group layers.
+        for (const DrawItem& item : _drawItems) {
+            if (item.groupLayer && _componentsSet) {
+                unwireChild(item.groupLayer);
+            }
+        }
+        _drawItems.clear();
+
+        auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
+        if (!decoder) {
+            VectorTileLayer::setRendererLayerFilter("");
+            return;
+        }
+        std::vector<std::string> order = decoder->getStyleLayerNames();
+
+        // Constrain each external child's visible zoom range to the style's config-rule range.
+        for (const ExternalSource& s : _externalSources) {
+            if (s.childLayer) {
+                applyExternalChildZoomRange(s);
+            }
+        }
+
+        auto isChildSlot = [&](const std::string& layerName) {
+            const ExternalSource* s = findExternalSource(layerName);
+            return s && s->childLayer && s->type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR;
+        };
+
+        std::vector<std::string> group;
+        bool firstSlotSeen = false;
+        for (const std::string& layerName : order) {
+            if (isChildSlot(layerName)) {
+                if (!firstSlotSeen) {
+                    // Group 0 renders on this layer itself.
+                    VectorTileLayer::setRendererLayerFilter(buildFilterString(group));
+                    firstSlotSeen = true;
+                } else {
+                    _drawItems.push_back({ DRAW_ITEM_VT_GROUP, std::string(), makeGroupLayer(buildFilterString(group)) });
+                }
+                _drawItems.push_back({ DRAW_ITEM_EXTERNAL, layerName, std::shared_ptr<Layer>() });
+                group.clear();
+            } else {
+                group.push_back(layerName);
+            }
+        }
+        if (!firstSlotSeen) {
+            // No external child slots: render everything on this layer, no interleaving.
+            VectorTileLayer::setRendererLayerFilter("");
+        } else if (!group.empty()) {
+            _drawItems.push_back({ DRAW_ITEM_VT_GROUP, std::string(), makeGroupLayer(buildFilterString(group)) });
+        }
+
+        // Warn about registered raster/hillshade sources that have no slot in the style order.
+        for (const ExternalSource& s : _externalSources) {
+            if (s.childLayer && s.type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR && std::find(order.begin(), order.end(), s.name) == order.end()) {
+                Log::Warnf("CompositeVectorTileLayer: external source '%s' is not listed in the style 'layers' - it will not be drawn", s.name.c_str());
+            }
+        }
     }
 
     void CompositeVectorTileLayer::setComponents(const std::shared_ptr<CancelableThreadPool>& envelopeThreadPool,
@@ -225,6 +325,11 @@ namespace carto {
                 wireChild(s.childLayer);
             }
         }
+        for (const DrawItem& item : _drawItems) {
+            if (item.groupLayer) {
+                wireChild(item.groupLayer);
+            }
+        }
     }
 
     void CompositeVectorTileLayer::loadData(const std::shared_ptr<CullState>& cullState) {
@@ -240,6 +345,11 @@ namespace carto {
                 s.childLayer->loadData(cullState);
             }
         }
+        for (const DrawItem& item : _drawItems) {
+            if (item.groupLayer) {
+                item.groupLayer->loadData(cullState);
+            }
+        }
     }
 
     void CompositeVectorTileLayer::offsetLayerHorizontally(double offset) {
@@ -251,6 +361,11 @@ namespace carto {
                 s.childLayer->offsetLayerHorizontally(offset);
             }
         }
+        for (const DrawItem& item : _drawItems) {
+            if (item.groupLayer) {
+                item.groupLayer->offsetLayerHorizontally(offset);
+            }
+        }
     }
 
     bool CompositeVectorTileLayer::isUpdateInProgress() const {
@@ -260,6 +375,11 @@ namespace carto {
         std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
         for (const ExternalSource& s : _externalSources) {
             if (s.childLayer && s.childLayer->isUpdateInProgress()) {
+                return true;
+            }
+        }
+        for (const DrawItem& item : _drawItems) {
+            if (item.groupLayer && item.groupLayer->isUpdateInProgress()) {
                 return true;
             }
         }
@@ -275,72 +395,24 @@ namespace carto {
                 s.childLayer->calculateRayIntersectedElements(ray, viewState, results);
             }
         }
+        for (const DrawItem& item : _drawItems) {
+            if (item.groupLayer) {
+                item.groupLayer->calculateRayIntersectedElements(ray, viewState, results);
+            }
+        }
     }
 
     bool CompositeVectorTileLayer::onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState) {
-        return renderSegmented(deltaSeconds, billboardSorter, viewState, false);
+        return renderComposite(deltaSeconds, billboardSorter, viewState, false);
     }
 
     bool CompositeVectorTileLayer::onDrawFrame3D(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState) {
-        return renderSegmented(deltaSeconds, billboardSorter, viewState, true);
+        return renderComposite(deltaSeconds, billboardSorter, viewState, true);
     }
 
     const CompositeVectorTileLayer::ExternalSource* CompositeVectorTileLayer::findExternalSource(const std::string& name) const {
         auto it = std::find_if(_externalSources.begin(), _externalSources.end(), [&](const ExternalSource& s) { return s.name == name; });
         return it != _externalSources.end() ? &(*it) : nullptr;
-    }
-
-    void CompositeVectorTileLayer::rebuildRenderSteps() {
-        // Caller holds _sourceMutex (or is the constructor).
-        _renderSteps.clear();
-
-        auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
-        if (!decoder) {
-            return;
-        }
-        std::vector<std::string> order = decoder->getStyleLayerNames();
-
-        auto isChildSlot = [&](const std::string& layerName) {
-            const ExternalSource* s = findExternalSource(layerName);
-            return s && s->childLayer && s->type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR;
-        };
-
-        auto buildFilter = [](const std::vector<std::string>& group) -> std::optional<std::regex> {
-            if (group.empty()) {
-                return std::nullopt;
-            }
-            std::string pattern = "^(";
-            for (std::size_t i = 0; i < group.size(); i++) {
-                pattern += (i ? "|" : "") + group[i];
-            }
-            pattern += ")";
-            return std::regex(pattern, std::regex::ECMAScript);
-        };
-
-        std::vector<std::string> group;
-        for (const std::string& layerName : order) {
-            if (isChildSlot(layerName)) {
-                RenderStep step;
-                step.vtFilter = buildFilter(group);
-                step.hasVtGroup = !group.empty();
-                step.childSlot = layerName;
-                _renderSteps.push_back(std::move(step));
-                group.clear();
-            } else {
-                group.push_back(layerName);
-            }
-        }
-        RenderStep tail;
-        tail.vtFilter = buildFilter(group);
-        tail.hasVtGroup = !group.empty();
-        _renderSteps.push_back(std::move(tail));
-
-        // Warn about registered raster/hillshade sources that have no slot in the style order.
-        for (const ExternalSource& s : _externalSources) {
-            if (s.childLayer && std::find(order.begin(), order.end(), s.name) == order.end()) {
-                Log::Warnf("CompositeVectorTileLayer: external source '%s' is not listed in the style 'layers' - it will not be drawn", s.name.c_str());
-            }
-        }
     }
 
     void CompositeVectorTileLayer::applyConfig(const ExternalSource& source, const mvt::ResolvedLayerConfig& config, const ViewState& viewState) {
@@ -421,57 +493,38 @@ namespace carto {
         }
     }
 
-    bool CompositeVectorTileLayer::renderSegmented(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain) {
+    bool CompositeVectorTileLayer::renderComposite(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain) {
         auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
 
         std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
 
-        bool hasChildSteps = std::any_of(_renderSteps.begin(), _renderSteps.end(), [](const RenderStep& s) { return !s.childSlot.empty(); });
-        if (!decoder || !hasChildSteps) {
-            // No interleaving needed - behave exactly as a plain VectorTileLayer.
-            return terrain ? VectorTileLayer::onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
-                           : VectorTileLayer::onDrawFrame(deltaSeconds, billboardSorter, viewState);
-        }
+        // Group 0 renders on this layer itself (with the group-0 rendererLayerFilter set in
+        // rebuildDrawItems). When there are no external child slots, this draws everything.
+        bool refresh = terrain ? VectorTileLayer::onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
+                               : VectorTileLayer::onDrawFrame(deltaSeconds, billboardSorter, viewState);
 
-        auto mapRenderer = getMapRenderer();
-        if (!mapRenderer) {
-            return false;
-        }
-
-        float opacity = getOpacity();
-        if (opacity < 1.0f) {
-            mapRenderer->clearAndBindScreenFBO(Color(0, 0, 0, 0), true, true);
-        }
-
-        _tileRenderer->setLabelOrder(static_cast<int>(getLabelRenderOrder()));
-        _tileRenderer->setBuildingOrder(static_cast<int>(getBuildingRenderOrder()));
-        _tileRenderer->setLayerBlendingSpeed(getLayerBlendingSpeed());
-        _tileRenderer->setLabelBlendingSpeed(getLabelBlendingSpeed());
-
-        bool refresh = false;
-        for (const RenderStep& step : _renderSteps) {
-            if (step.hasVtGroup) {
-                _tileRenderer->setRendererLayerFilter(step.vtFilter);
-                refresh = (terrain ? _tileRenderer->onDrawFrame3D(deltaSeconds, viewState)
-                                   : _tileRenderer->onDrawFrame(deltaSeconds, viewState)) || refresh;
-            }
-            if (!step.childSlot.empty()) {
-                const ExternalSource* source = findExternalSource(step.childSlot);
-                if (source && source->childLayer) {
-                    mvt::ResolvedLayerConfig config = decoder->resolveLayerConfig(step.childSlot, viewState.getZoom());
-                    applyConfig(*source, config, viewState);
-                    if (config.visible) {
-                        refresh = (terrain ? source->childLayer->onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
-                                           : source->childLayer->onDrawFrame(deltaSeconds, billboardSorter, viewState)) || refresh;
-                    }
+        for (const DrawItem& item : _drawItems) {
+            if (item.kind == DRAW_ITEM_VT_GROUP) {
+                if (item.groupLayer) {
+                    refresh = (terrain ? item.groupLayer->onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
+                                       : item.groupLayer->onDrawFrame(deltaSeconds, billboardSorter, viewState)) || refresh;
                 }
+                continue;
             }
-        }
-
-        _tileRenderer->setRendererLayerFilter(std::nullopt);
-
-        if (opacity < 1.0f) {
-            mapRenderer->blendAndUnbindScreenFBO(opacity);
+            const ExternalSource* source = findExternalSource(item.slot);
+            if (!source || !source->childLayer) {
+                continue;
+            }
+            bool visible = true;
+            if (decoder) {
+                mvt::ResolvedLayerConfig config = decoder->resolveLayerConfig(item.slot, viewState.getZoom());
+                applyConfig(*source, config, viewState);
+                visible = config.visible;
+            }
+            if (visible) {
+                refresh = (terrain ? source->childLayer->onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
+                                   : source->childLayer->onDrawFrame(deltaSeconds, billboardSorter, viewState)) || refresh;
+            }
         }
         return refresh;
     }

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -100,7 +100,6 @@ namespace carto {
         }
 
         std::shared_ptr<Layer> childLayer;
-        float baseHeightScale = 1.0f;
         if (type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_RASTER) {
             childLayer = std::make_shared<RasterTileLayer>(dataSource);
         } else { // HILLSHADE
@@ -108,18 +107,14 @@ namespace carto {
             if (!elevDecoder) {
                 elevDecoder = resolveElevationDecoder(dataSource);
             }
-            auto hillshade = elevDecoder ? std::make_shared<HillshadeRasterTileLayer>(dataSource, elevDecoder)
-                                         : std::make_shared<HillshadeRasterTileLayer>(dataSource);
-            // The natural hillshade height scale is small (~0.09 with a decoder); 'hillshade-exaggeration'
-            // is a multiplier of this default so exaggeration=1 keeps the normal look.
-            baseHeightScale = hillshade->getHeightScale();
-            childLayer = hillshade;
+            childLayer = elevDecoder ? std::make_shared<HillshadeRasterTileLayer>(dataSource, elevDecoder)
+                                     : std::make_shared<HillshadeRasterTileLayer>(dataSource);
         }
 
         {
             std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
             removeExternalDataSource(name); // replace if it exists
-            _externalSources.push_back({ name, type, dataSource, childLayer, baseHeightScale });
+            _externalSources.push_back({ name, type, dataSource, childLayer });
             if (_componentsSet) {
                 wireChild(childLayer);
             }
@@ -469,11 +464,12 @@ namespace carto {
         } else if (source.type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_HILLSHADE) {
             auto hillshade = std::static_pointer_cast<HillshadeRasterTileLayer>(source.childLayer);
             if (const mvt::Value* v = getValue("opacity")) { hillshade->setOpacity(valueToFloat(*v, 1.0f)); }
+            // exaggeration is a per-frame shader uniform (no re-decode) -> animates smoothly with zoom.
+            if (const mvt::Value* v = getValue("exaggeration")) { hillshade->setExaggeration(valueToFloat(*v, 1.0f)); }
 
             if (decodeZoomChanged) { // decode-bound: only at integer zoom crossings (aligned with tile reload)
-                // exaggeration multiplies the layer's natural height scale (~0.09); height-scale sets it raw.
-                if (const mvt::Value* v = getValue("exaggeration")) { hillshade->setHeightScale(source.baseHeightScale * valueToFloat(*v, 1.0f)); }
-                else if (const mvt::Value* v = getValue("height-scale")) { hillshade->setHeightScale(valueToFloat(*v, 1.0f)); }
+                // height-scale is the raw normal-map height scale (baked at decode; steps with zoom).
+                if (const mvt::Value* v = getValue("height-scale")) { hillshade->setHeightScale(valueToFloat(*v, 1.0f)); }
                 if (const mvt::Value* v = getValue("contrast")) { hillshade->setContrast(valueToFloat(*v, 0.5f)); }
                 if (const mvt::Value* v = getValue("contour-interval")) {
                     float interval = valueToFloat(*v, 0.0f);

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -1,5 +1,4 @@
 #include "CompositeVectorTileLayer.h"
-#include "datasources/DynamicMergedMBVTTileDataSource.h"
 #include "datasources/ContourTileDataSource.h"
 #include "layers/RasterTileLayer.h"
 #include "layers/HillshadeRasterTileLayer.h"
@@ -72,8 +71,7 @@ namespace carto {
     }
 
     CompositeVectorTileLayer::CompositeVectorTileLayer(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<VectorTileDecoder>& decoder) :
-        VectorTileLayer(std::make_shared<DynamicMergedMBVTTileDataSource>(dataSource), decoder),
-        _mergedDataSource(),
+        VectorTileLayer(dataSource, decoder),
         _externalSources(),
         _drawItems(),
         _lastVectorConfig(),
@@ -84,7 +82,6 @@ namespace carto {
         _childTouchHandler(),
         _sourceMutex()
     {
-        _mergedDataSource = std::static_pointer_cast<DynamicMergedMBVTTileDataSource>(getDataSource());
         rebuildDrawItems();
     }
 
@@ -128,11 +125,25 @@ namespace carto {
         if (!dataSource) {
             throw NullArgumentException("Null dataSource");
         }
+
+        // A vector source is drawn as its own child VectorTileLayer over its own source, using the
+        // master decoder and filtered to its own layer name. Kept separate (not merged) so it can
+        // overzoom independently - e.g. a ContourTileDataSource renders z13+ from z12 DEM data via
+        // the child layer's MaxOverzoomLevel, without needing the DEM at the target zoom.
+        auto childVectorLayer = std::make_shared<VectorTileLayer>(dataSource, getTileDecoder());
+        childVectorLayer->setRendererLayerFilter("^(" + name + ")$");
+        childVectorLayer->setMaxOverzoomLevel(dataSource->getMaxOverzoomLevel());
+        childVectorLayer->setLabelRenderOrder(getLabelRenderOrder());
+        childVectorLayer->setBuildingRenderOrder(getBuildingRenderOrder());
+        std::shared_ptr<Layer> childLayer = childVectorLayer;
+
         {
             std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
             removeExternalDataSource(name);
-            _externalSources.push_back({ name, CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR, dataSource, std::shared_ptr<Layer>() });
-            _mergedDataSource->addDataSource(name, dataSource); // notifies -> master + group tiles reload
+            _externalSources.push_back({ name, CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR, dataSource, childLayer });
+            if (_componentsSet) {
+                wireChild(childLayer);
+            }
             rebuildDrawItems();
         }
         applyVectorSourceConfigs();
@@ -145,12 +156,8 @@ namespace carto {
             std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
             auto it = std::find_if(_externalSources.begin(), _externalSources.end(), [&](const ExternalSource& s) { return s.name == name; });
             if (it != _externalSources.end()) {
-                if (it->type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR) {
-                    _mergedDataSource->removeDataSource(name);
-                } else if (it->childLayer) {
-                    if (_componentsSet) {
-                        unwireChild(it->childLayer);
-                    }
+                if (it->childLayer && _componentsSet) {
+                    unwireChild(it->childLayer);
                 }
                 _externalSources.erase(it);
                 _lastVectorConfig.erase(name);
@@ -196,13 +203,18 @@ namespace carto {
 
     std::string CompositeVectorTileLayer::buildFilterString(const std::vector<std::string>& group) {
         if (group.empty()) {
-            return "$^"; // impossible anchor sequence -> matches no layer name (empty group renders nothing)
+            // Match nothing. Note: the filter is tested with std::regex_match (full match) and the
+            // per-tile background layer has an EMPTY name (TileReader), so a filter that full-matches
+            // "" (e.g. "$^") would draw the opaque background and overpaint earlier groups. This
+            // char class requires exactly one char that is neither \s nor \S -> matches no string,
+            // not even "".
+            return "[^\\s\\S]";
         }
         std::string pattern = "^(";
         for (std::size_t i = 0; i < group.size(); i++) {
             pattern += (i ? "|" : "") + group[i];
         }
-        pattern += ")";
+        pattern += ")$";
         return pattern;
     }
 
@@ -273,7 +285,7 @@ namespace carto {
 
         auto isChildSlot = [&](const std::string& layerName) {
             const ExternalSource* s = findExternalSource(layerName);
-            return s && s->childLayer && s->type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR;
+            return s && s->childLayer; // raster / hillshade / vector children all occupy a slot
         };
 
         std::vector<std::string> group;
@@ -281,10 +293,13 @@ namespace carto {
         for (const std::string& layerName : order) {
             if (isChildSlot(layerName)) {
                 if (!firstSlotSeen) {
-                    // Group 0 renders on this layer itself.
+                    // Group 0 renders on this layer itself (never-match if empty, so nothing -
+                    // not even the empty-named background layer - is drawn).
                     VectorTileLayer::setRendererLayerFilter(buildFilterString(group));
                     firstSlotSeen = true;
-                } else {
+                } else if (!group.empty()) {
+                    // A non-empty intermediate group gets its own stable-filtered layer. Empty
+                    // intermediate groups are skipped entirely (no layer to fetch/decode/overpaint).
                     _drawItems.push_back({ DRAW_ITEM_VT_GROUP, std::string(), makeGroupLayer(buildFilterString(group)) });
                 }
                 _drawItems.push_back({ DRAW_ITEM_EXTERNAL, layerName, std::shared_ptr<Layer>() });
@@ -300,9 +315,9 @@ namespace carto {
             _drawItems.push_back({ DRAW_ITEM_VT_GROUP, std::string(), makeGroupLayer(buildFilterString(group)) });
         }
 
-        // Warn about registered raster/hillshade sources that have no slot in the style order.
+        // Warn about registered sources that have no slot in the style order.
         for (const ExternalSource& s : _externalSources) {
-            if (s.childLayer && s.type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR && std::find(order.begin(), order.end(), s.name) == order.end()) {
+            if (s.childLayer && std::find(order.begin(), order.end(), s.name) == order.end()) {
                 Log::Warnf("CompositeVectorTileLayer: external source '%s' is not listed in the style 'layers' - it will not be drawn", s.name.c_str());
             }
         }
@@ -516,7 +531,10 @@ namespace carto {
                 continue;
             }
             bool visible = true;
-            if (decoder) {
+            // Raster/hillshade children are gated by their config symbolizer's zoom/nuti visibility.
+            // Vector children have no config symbolizer (they are styled by normal line/text rules,
+            // which the child's own decode already zoom-filters), so they always draw.
+            if (source->type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR && decoder) {
                 mvt::ResolvedLayerConfig config = decoder->resolveLayerConfig(item.slot, viewState.getZoom());
                 applyConfig(*source, config, viewState);
                 visible = config.visible;

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -1,0 +1,429 @@
+#include "CompositeVectorTileLayer.h"
+#include "datasources/DynamicMergedMBVTTileDataSource.h"
+#include "layers/RasterTileLayer.h"
+#include "layers/HillshadeRasterTileLayer.h"
+#include "vectortiles/MBVectorTileDecoder.h"
+#include "rastertiles/ElevationDecoder.h"
+#include "rastertiles/TerrariumElevationDataDecoder.h"
+#include "rastertiles/MapBoxElevationDataDecoder.h"
+#include "renderers/TileRenderer.h"
+#include "renderers/MapRenderer.h"
+#include "graphics/ViewState.h"
+#include "graphics/Color.h"
+#include "components/Exceptions.h"
+#include "utils/Log.h"
+
+#include <algorithm>
+#include <variant>
+
+#include <mapnikvt/Value.h>
+#include <mapnikvt/LayerConfigResolver.h>
+
+namespace carto {
+
+    namespace {
+        float valueToFloat(const mvt::Value& value, float defaultValue) {
+            if (auto v = std::get_if<double>(&value))     { return static_cast<float>(*v); }
+            if (auto v = std::get_if<long long>(&value))  { return static_cast<float>(*v); }
+            if (auto v = std::get_if<bool>(&value))       { return *v ? 1.0f : 0.0f; }
+            return defaultValue;
+        }
+
+        Color parseColorValue(const mvt::Value& value, const Color& defaultValue) {
+            const std::string* str = std::get_if<std::string>(&value);
+            if (!str || str->empty() || (*str)[0] != '#') {
+                return defaultValue;
+            }
+            std::string hex = str->substr(1);
+            unsigned long packed = 0;
+            try {
+                packed = std::stoul(hex, nullptr, 16);
+            } catch (const std::exception&) {
+                return defaultValue;
+            }
+            if (hex.size() == 6) {
+                return Color(static_cast<unsigned char>((packed >> 16) & 0xff),
+                             static_cast<unsigned char>((packed >> 8) & 0xff),
+                             static_cast<unsigned char>(packed & 0xff), 255);
+            }
+            if (hex.size() == 8) {
+                return Color(static_cast<unsigned char>((packed >> 24) & 0xff),
+                             static_cast<unsigned char>((packed >> 16) & 0xff),
+                             static_cast<unsigned char>((packed >> 8) & 0xff),
+                             static_cast<unsigned char>(packed & 0xff));
+            }
+            return defaultValue;
+        }
+
+        RasterTileFilterMode::RasterTileFilterMode parseFilterMode(const std::string& mode) {
+            if (mode == "nearest") { return RasterTileFilterMode::RASTER_TILE_FILTER_MODE_NEAREST; }
+            if (mode == "bicubic") { return RasterTileFilterMode::RASTER_TILE_FILTER_MODE_BICUBIC; }
+            return RasterTileFilterMode::RASTER_TILE_FILTER_MODE_BILINEAR;
+        }
+
+        HillshadeMethod::HillshadeMethod parseHillshadeMethod(const std::string& method) {
+            if (method == "combined")         { return HillshadeMethod::HillshadeMethod::COMBINED; }
+            if (method == "igor")             { return HillshadeMethod::HillshadeMethod::IGOR; }
+            if (method == "multidirectional") { return HillshadeMethod::HillshadeMethod::MULTIDIRECTIONAL; }
+            if (method == "basic")            { return HillshadeMethod::HillshadeMethod::BASIC; }
+            return HillshadeMethod::HillshadeMethod::STANDARD;
+        }
+    }
+
+    CompositeVectorTileLayer::CompositeVectorTileLayer(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<VectorTileDecoder>& decoder) :
+        VectorTileLayer(std::make_shared<DynamicMergedMBVTTileDataSource>(dataSource), decoder),
+        _mergedDataSource(),
+        _externalSources(),
+        _renderSteps(),
+        _singlePassRenderingEnabled(false),
+        _componentsSet(false),
+        _childOptions(),
+        _childMapRenderer(),
+        _childTouchHandler(),
+        _sourceMutex()
+    {
+        _mergedDataSource = std::static_pointer_cast<DynamicMergedMBVTTileDataSource>(getDataSource());
+        rebuildRenderSteps();
+    }
+
+    CompositeVectorTileLayer::~CompositeVectorTileLayer() {
+    }
+
+    void CompositeVectorTileLayer::addExternalDataSource(const std::string& name, const std::shared_ptr<TileDataSource>& dataSource, CompositeSourceType::CompositeSourceType type, const std::shared_ptr<ElevationDecoder>& elevationDecoder) {
+        if (!dataSource) {
+            throw NullArgumentException("Null dataSource");
+        }
+        if (type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR) {
+            addVectorDataSource(name, dataSource);
+            return;
+        }
+
+        std::shared_ptr<Layer> childLayer;
+        if (type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_RASTER) {
+            childLayer = std::make_shared<RasterTileLayer>(dataSource);
+        } else { // HILLSHADE
+            std::shared_ptr<ElevationDecoder> decoder = elevationDecoder;
+            if (!decoder) {
+                decoder = resolveElevationDecoder(dataSource);
+            }
+            childLayer = decoder ? std::make_shared<HillshadeRasterTileLayer>(dataSource, decoder)
+                                 : std::make_shared<HillshadeRasterTileLayer>(dataSource);
+        }
+
+        {
+            std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+            removeExternalDataSource(name); // replace if it exists
+            _externalSources.push_back({ name, type, dataSource, childLayer });
+            if (_componentsSet) {
+                wireChild(childLayer);
+            }
+            rebuildRenderSteps();
+        }
+        refresh();
+    }
+
+    void CompositeVectorTileLayer::addVectorDataSource(const std::string& name, const std::shared_ptr<TileDataSource>& dataSource) {
+        if (!dataSource) {
+            throw NullArgumentException("Null dataSource");
+        }
+        {
+            std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+            removeExternalDataSource(name);
+            _externalSources.push_back({ name, CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR, dataSource, std::shared_ptr<Layer>() });
+            _mergedDataSource->addDataSource(name, dataSource); // notifies -> master tiles reload
+            rebuildRenderSteps();
+        }
+        refresh();
+    }
+
+    bool CompositeVectorTileLayer::removeExternalDataSource(const std::string& name) {
+        bool removed = false;
+        {
+            std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+            auto it = std::find_if(_externalSources.begin(), _externalSources.end(), [&](const ExternalSource& s) { return s.name == name; });
+            if (it != _externalSources.end()) {
+                if (it->type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR) {
+                    _mergedDataSource->removeDataSource(name);
+                } else if (it->childLayer) {
+                    if (_componentsSet) {
+                        unwireChild(it->childLayer);
+                    }
+                }
+                _externalSources.erase(it);
+                rebuildRenderSteps();
+                removed = true;
+            }
+        }
+        if (removed) {
+            refresh();
+        }
+        return removed;
+    }
+
+    std::vector<std::string> CompositeVectorTileLayer::getExternalDataSourceNames() const {
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        std::vector<std::string> names;
+        for (const ExternalSource& s : _externalSources) {
+            names.push_back(s.name);
+        }
+        return names;
+    }
+
+    bool CompositeVectorTileLayer::isSinglePassRenderingEnabled() const {
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        return _singlePassRenderingEnabled;
+    }
+
+    void CompositeVectorTileLayer::setSinglePassRenderingEnabled(bool enabled) {
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        _singlePassRenderingEnabled = enabled;
+    }
+
+    std::shared_ptr<ElevationDecoder> CompositeVectorTileLayer::resolveElevationDecoder(const std::shared_ptr<TileDataSource>& dataSource) {
+        std::string encoding = dataSource ? dataSource->getEncoding() : std::string();
+        if (encoding.empty()) {
+            return std::shared_ptr<ElevationDecoder>(); // let HillshadeRasterTileLayer infer per tile
+        }
+        if (encoding == "mapbox") {
+            return std::make_shared<MapBoxElevationDataDecoder>();
+        }
+        return std::make_shared<TerrariumElevationDataDecoder>();
+    }
+
+    void CompositeVectorTileLayer::wireChild(const std::shared_ptr<Layer>& child) {
+        if (!child) {
+            return;
+        }
+        child->setComponents(_envelopeThreadPool, _tileThreadPool, _childOptions, _childMapRenderer, _childTouchHandler);
+        child->registerDataSourceListener();
+    }
+
+    void CompositeVectorTileLayer::unwireChild(const std::shared_ptr<Layer>& child) {
+        if (!child) {
+            return;
+        }
+        child->unregisterDataSourceListener();
+    }
+
+    void CompositeVectorTileLayer::setComponents(const std::shared_ptr<CancelableThreadPool>& envelopeThreadPool,
+                                                 const std::shared_ptr<CancelableThreadPool>& tileThreadPool,
+                                                 const std::weak_ptr<Options>& options,
+                                                 const std::weak_ptr<MapRenderer>& mapRenderer,
+                                                 const std::weak_ptr<TouchHandler>& touchHandler) {
+        VectorTileLayer::setComponents(envelopeThreadPool, tileThreadPool, options, mapRenderer, touchHandler);
+
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        _childOptions = options;
+        _childMapRenderer = mapRenderer;
+        _childTouchHandler = touchHandler;
+        _componentsSet = true;
+        for (const ExternalSource& s : _externalSources) {
+            if (s.childLayer) {
+                wireChild(s.childLayer);
+            }
+        }
+    }
+
+    void CompositeVectorTileLayer::loadData(const std::shared_ptr<CullState>& cullState) {
+        VectorTileLayer::loadData(cullState);
+
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        for (const ExternalSource& s : _externalSources) {
+            if (s.childLayer) {
+                s.childLayer->loadData(cullState);
+            }
+        }
+    }
+
+    void CompositeVectorTileLayer::offsetLayerHorizontally(double offset) {
+        VectorTileLayer::offsetLayerHorizontally(offset);
+
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        for (const ExternalSource& s : _externalSources) {
+            if (s.childLayer) {
+                s.childLayer->offsetLayerHorizontally(offset);
+            }
+        }
+    }
+
+    bool CompositeVectorTileLayer::isUpdateInProgress() const {
+        if (VectorTileLayer::isUpdateInProgress()) {
+            return true;
+        }
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        for (const ExternalSource& s : _externalSources) {
+            if (s.childLayer && s.childLayer->isUpdateInProgress()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void CompositeVectorTileLayer::calculateRayIntersectedElements(const cglib::ray3<double>& ray, const ViewState& viewState, std::vector<RayIntersectedElement>& results) const {
+        VectorTileLayer::calculateRayIntersectedElements(ray, viewState, results);
+
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        for (const ExternalSource& s : _externalSources) {
+            if (s.childLayer) {
+                s.childLayer->calculateRayIntersectedElements(ray, viewState, results);
+            }
+        }
+    }
+
+    bool CompositeVectorTileLayer::onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState) {
+        return renderSegmented(deltaSeconds, billboardSorter, viewState, false);
+    }
+
+    bool CompositeVectorTileLayer::onDrawFrame3D(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState) {
+        return renderSegmented(deltaSeconds, billboardSorter, viewState, true);
+    }
+
+    const CompositeVectorTileLayer::ExternalSource* CompositeVectorTileLayer::findExternalSource(const std::string& name) const {
+        auto it = std::find_if(_externalSources.begin(), _externalSources.end(), [&](const ExternalSource& s) { return s.name == name; });
+        return it != _externalSources.end() ? &(*it) : nullptr;
+    }
+
+    void CompositeVectorTileLayer::rebuildRenderSteps() {
+        // Caller holds _sourceMutex (or is the constructor).
+        _renderSteps.clear();
+
+        auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
+        if (!decoder) {
+            return;
+        }
+        std::vector<std::string> order = decoder->getStyleLayerNames();
+
+        auto isChildSlot = [&](const std::string& layerName) {
+            const ExternalSource* s = findExternalSource(layerName);
+            return s && s->childLayer && s->type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR;
+        };
+
+        auto buildFilter = [](const std::vector<std::string>& group) -> std::optional<std::regex> {
+            if (group.empty()) {
+                return std::nullopt;
+            }
+            std::string pattern = "^(";
+            for (std::size_t i = 0; i < group.size(); i++) {
+                pattern += (i ? "|" : "") + group[i];
+            }
+            pattern += ")";
+            return std::regex(pattern, std::regex::ECMAScript);
+        };
+
+        std::vector<std::string> group;
+        for (const std::string& layerName : order) {
+            if (isChildSlot(layerName)) {
+                RenderStep step;
+                step.vtFilter = buildFilter(group);
+                step.hasVtGroup = !group.empty();
+                step.childSlot = layerName;
+                _renderSteps.push_back(std::move(step));
+                group.clear();
+            } else {
+                group.push_back(layerName);
+            }
+        }
+        RenderStep tail;
+        tail.vtFilter = buildFilter(group);
+        tail.hasVtGroup = !group.empty();
+        _renderSteps.push_back(std::move(tail));
+
+        // Warn about registered raster/hillshade sources that have no slot in the style order.
+        for (const ExternalSource& s : _externalSources) {
+            if (s.childLayer && std::find(order.begin(), order.end(), s.name) == order.end()) {
+                Log::Warnf("CompositeVectorTileLayer: external source '%s' is not listed in the style 'layers' - it will not be drawn", s.name.c_str());
+            }
+        }
+    }
+
+    void CompositeVectorTileLayer::applyConfig(const ExternalSource& source, const mvt::ResolvedLayerConfig& config, const ViewState& viewState) {
+        auto getValue = [&](const std::string& key) -> const mvt::Value* {
+            auto it = config.values.find(key);
+            return it != config.values.end() ? &it->second : nullptr;
+        };
+
+        if (source.type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_RASTER) {
+            auto raster = std::static_pointer_cast<RasterTileLayer>(source.childLayer);
+            if (const mvt::Value* v = getValue("opacity")) { raster->setOpacity(valueToFloat(*v, 1.0f)); }
+            if (const mvt::Value* v = getValue("filter-mode")) {
+                if (auto str = std::get_if<std::string>(v)) { raster->setTileFilterMode(parseFilterMode(*str)); }
+            }
+        } else if (source.type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_HILLSHADE) {
+            auto hillshade = std::static_pointer_cast<HillshadeRasterTileLayer>(source.childLayer);
+            if (const mvt::Value* v = getValue("opacity"))      { hillshade->setOpacity(valueToFloat(*v, 1.0f)); }
+            if (const mvt::Value* v = getValue("exaggeration"))  { hillshade->setHeightScale(valueToFloat(*v, 1.0f)); }
+            else if (const mvt::Value* v = getValue("height-scale")) { hillshade->setHeightScale(valueToFloat(*v, 1.0f)); }
+            if (const mvt::Value* v = getValue("contrast"))     { hillshade->setContrast(valueToFloat(*v, 0.5f)); }
+            if (const mvt::Value* v = getValue("shadow-color"))    { hillshade->setShadowColor(parseColorValue(*v, Color(0, 0, 0, 255))); }
+            if (const mvt::Value* v = getValue("highlight-color")) { hillshade->setHighlightColor(parseColorValue(*v, Color(255, 255, 255, 255))); }
+            if (const mvt::Value* v = getValue("accent-color"))    { hillshade->setAccentColor(parseColorValue(*v, Color(0, 0, 0, 255))); }
+            if (const mvt::Value* v = getValue("method")) {
+                if (auto str = std::get_if<std::string>(v)) { hillshade->setHillshadeMethod(parseHillshadeMethod(*str)); }
+            }
+            if (const mvt::Value* v = getValue("contour-interval")) {
+                float interval = valueToFloat(*v, 0.0f);
+                hillshade->setContourEnabled(interval > 0.0f);
+                if (interval > 0.0f) { hillshade->setContourInterval(interval); }
+            }
+            if (const mvt::Value* v = getValue("contour-color")) { hillshade->setContourColor(parseColorValue(*v, Color(0xC5, 0x60, 0x08, 0xff))); }
+            if (const mvt::Value* v = getValue("contour-width")) { hillshade->setContourWidth(valueToFloat(*v, 1.0f)); }
+            // TODO: illumination-direction (azimuth degrees) -> setIlluminationDirection(MapVec).
+        }
+    }
+
+    bool CompositeVectorTileLayer::renderSegmented(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain) {
+        auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
+
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+
+        bool hasChildSteps = std::any_of(_renderSteps.begin(), _renderSteps.end(), [](const RenderStep& s) { return !s.childSlot.empty(); });
+        if (!decoder || !hasChildSteps) {
+            // No interleaving needed - behave exactly as a plain VectorTileLayer.
+            return terrain ? VectorTileLayer::onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
+                           : VectorTileLayer::onDrawFrame(deltaSeconds, billboardSorter, viewState);
+        }
+
+        auto mapRenderer = getMapRenderer();
+        if (!mapRenderer) {
+            return false;
+        }
+
+        float opacity = getOpacity();
+        if (opacity < 1.0f) {
+            mapRenderer->clearAndBindScreenFBO(Color(0, 0, 0, 0), true, true);
+        }
+
+        _tileRenderer->setLabelOrder(static_cast<int>(getLabelRenderOrder()));
+        _tileRenderer->setBuildingOrder(static_cast<int>(getBuildingRenderOrder()));
+        _tileRenderer->setLayerBlendingSpeed(getLayerBlendingSpeed());
+        _tileRenderer->setLabelBlendingSpeed(getLabelBlendingSpeed());
+
+        bool refresh = false;
+        for (const RenderStep& step : _renderSteps) {
+            if (step.hasVtGroup) {
+                _tileRenderer->setRendererLayerFilter(step.vtFilter);
+                refresh = (terrain ? _tileRenderer->onDrawFrame3D(deltaSeconds, viewState)
+                                   : _tileRenderer->onDrawFrame(deltaSeconds, viewState)) || refresh;
+            }
+            if (!step.childSlot.empty()) {
+                const ExternalSource* source = findExternalSource(step.childSlot);
+                if (source && source->childLayer) {
+                    mvt::ResolvedLayerConfig config = decoder->resolveLayerConfig(step.childSlot, viewState.getZoom());
+                    applyConfig(*source, config, viewState);
+                    if (config.visible) {
+                        refresh = (terrain ? source->childLayer->onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
+                                           : source->childLayer->onDrawFrame(deltaSeconds, billboardSorter, viewState)) || refresh;
+                    }
+                }
+            }
+        }
+
+        _tileRenderer->setRendererLayerFilter(std::nullopt);
+
+        if (opacity < 1.0f) {
+            mapRenderer->blendAndUnbindScreenFBO(opacity);
+        }
+        return refresh;
+    }
+
+}

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -203,18 +203,22 @@ namespace carto {
         return std::make_shared<TerrariumElevationDataDecoder>();
     }
 
-    std::string CompositeVectorTileLayer::buildFilterString(const std::vector<std::string>& group) {
+    std::string CompositeVectorTileLayer::buildFilterString(const std::vector<std::string>& group, bool includeBackground) {
+        // The filter is tested with std::regex_match (full match) and the per-tile background layer
+        // has an EMPTY name (TileReader). So "^$" matches ONLY the background, and a trailing empty
+        // alternative "(...|)" additionally matches it. Non-bottom groups must NOT match "" or they
+        // would paint the opaque background over earlier groups.
         if (group.empty()) {
-            // Match nothing. Note: the filter is tested with std::regex_match (full match) and the
-            // per-tile background layer has an EMPTY name (TileReader), so a filter that full-matches
-            // "" (e.g. "$^") would draw the opaque background and overpaint earlier groups. This
-            // char class requires exactly one char that is neither \s nor \S -> matches no string,
-            // not even "".
-            return "[^\\s\\S]";
+            // Bottom group with no style layers still draws the background; other empty groups match
+            // nothing ("[^\\s\\S]" requires one impossible char, so it matches no string, not even "").
+            return includeBackground ? "^$" : "[^\\s\\S]";
         }
         std::string pattern = "^(";
         for (std::size_t i = 0; i < group.size(); i++) {
             pattern += (i ? "|" : "") + group[i];
+        }
+        if (includeBackground) {
+            pattern += "|"; // empty alternative -> also matches the empty-named background layer
         }
         pattern += ")$";
         return pattern;
@@ -295,9 +299,9 @@ namespace carto {
         for (const std::string& layerName : order) {
             if (isChildSlot(layerName)) {
                 if (!firstSlotSeen) {
-                    // Group 0 renders on this layer itself (never-match if empty, so nothing -
-                    // not even the empty-named background layer - is drawn).
-                    VectorTileLayer::setRendererLayerFilter(buildFilterString(group));
+                    // Group 0 renders on this layer itself. It also draws the style background
+                    // (includeBackground), so the Map background-color appears once at the bottom.
+                    VectorTileLayer::setRendererLayerFilter(buildFilterString(group, /*includeBackground=*/true));
                     firstSlotSeen = true;
                 } else if (!group.empty()) {
                     // A non-empty intermediate group gets its own stable-filtered layer. Empty

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -447,26 +447,18 @@ namespace carto {
             auto it = config.values.find(key);
             return it != config.values.end() ? &it->second : nullptr;
         };
-        // Some hillshade setters re-decode the tile (setHeightScale/setContrast/setContourEnabled call
-        // updateTiles). Applying those every frame with a zoom-interpolated value would re-decode
-        // continuously, so they are applied only when the value actually changes. Cheap setters
-        // (opacity, colors, method, illumination, contour width/color, filter mode = redraw only) are
-        // applied every frame so they stay smooth.
+        // Some hillshade setters bake into the normal map and re-decode the tile
+        // (setHeightScale/setContrast/setContourEnabled call updateTiles). Applying those every frame
+        // with a zoom-interpolated value would re-decode continuously and the tiles would never
+        // settle, so the value appears static. Instead they are applied only when the INTEGER zoom
+        // changes - which is exactly when the hillshade tiles reload for the new zoom level anyway, so
+        // the re-decode is aligned and free. Result: per-zoom-level animation of exaggeration/contrast.
+        // Cheap redraw-only setters (opacity, colors, method, illumination, contour width/color, filter
+        // mode) are applied every frame so they stay smooth.
         std::map<std::string, float>& applied = _lastChildConfig[source.name];
-        auto changedFloat = [&](const std::string& key, float& out) {
-            const mvt::Value* v = getValue(key);
-            if (!v) {
-                return false;
-            }
-            float value = valueToFloat(*v, 0.0f);
-            auto it = applied.find(key);
-            if (it != applied.end() && it->second == value) {
-                return false;
-            }
-            applied[key] = value;
-            out = value;
-            return true;
-        };
+        int intZoom = static_cast<int>(std::floor(viewState.getZoom()));
+        bool decodeZoomChanged = (applied.find("__izoom") == applied.end()) || (static_cast<int>(applied["__izoom"]) != intZoom);
+        applied["__izoom"] = static_cast<float>(intZoom);
 
         if (source.type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_RASTER) {
             auto raster = std::static_pointer_cast<RasterTileLayer>(source.childLayer);
@@ -478,17 +470,16 @@ namespace carto {
             auto hillshade = std::static_pointer_cast<HillshadeRasterTileLayer>(source.childLayer);
             if (const mvt::Value* v = getValue("opacity")) { hillshade->setOpacity(valueToFloat(*v, 1.0f)); }
 
-            float f = 0.0f;
-            // exaggeration multiplies the layer's natural height scale (~0.09); height-scale sets it raw.
-            if (getValue("exaggeration")) {
-                if (changedFloat("exaggeration", f)) { hillshade->setHeightScale(source.baseHeightScale * f); }
-            } else if (getValue("height-scale")) {
-                if (changedFloat("height-scale", f)) { hillshade->setHeightScale(f); }
-            }
-            if (changedFloat("contrast", f)) { hillshade->setContrast(f); }
-            if (changedFloat("contour-interval", f)) {
-                hillshade->setContourEnabled(f > 0.0f);
-                if (f > 0.0f) { hillshade->setContourInterval(f); }
+            if (decodeZoomChanged) { // decode-bound: only at integer zoom crossings (aligned with tile reload)
+                // exaggeration multiplies the layer's natural height scale (~0.09); height-scale sets it raw.
+                if (const mvt::Value* v = getValue("exaggeration")) { hillshade->setHeightScale(source.baseHeightScale * valueToFloat(*v, 1.0f)); }
+                else if (const mvt::Value* v = getValue("height-scale")) { hillshade->setHeightScale(valueToFloat(*v, 1.0f)); }
+                if (const mvt::Value* v = getValue("contrast")) { hillshade->setContrast(valueToFloat(*v, 0.5f)); }
+                if (const mvt::Value* v = getValue("contour-interval")) {
+                    float interval = valueToFloat(*v, 0.0f);
+                    hillshade->setContourEnabled(interval > 0.0f);
+                    if (interval > 0.0f) { hillshade->setContourInterval(interval); }
+                }
             }
 
             if (const mvt::Value* v = getValue("shadow-color"))    { hillshade->setShadowColor(parseColorValue(*v, Color(0, 0, 0, 255))); }

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -100,6 +100,7 @@ namespace carto {
         }
 
         std::shared_ptr<Layer> childLayer;
+        float baseHeightScale = 1.0f;
         if (type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_RASTER) {
             childLayer = std::make_shared<RasterTileLayer>(dataSource);
         } else { // HILLSHADE
@@ -107,14 +108,18 @@ namespace carto {
             if (!elevDecoder) {
                 elevDecoder = resolveElevationDecoder(dataSource);
             }
-            childLayer = elevDecoder ? std::make_shared<HillshadeRasterTileLayer>(dataSource, elevDecoder)
-                                     : std::make_shared<HillshadeRasterTileLayer>(dataSource);
+            auto hillshade = elevDecoder ? std::make_shared<HillshadeRasterTileLayer>(dataSource, elevDecoder)
+                                         : std::make_shared<HillshadeRasterTileLayer>(dataSource);
+            // The natural hillshade height scale is small (~0.09 with a decoder); 'hillshade-exaggeration'
+            // is a multiplier of this default so exaggeration=1 keeps the normal look.
+            baseHeightScale = hillshade->getHeightScale();
+            childLayer = hillshade;
         }
 
         {
             std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
             removeExternalDataSource(name); // replace if it exists
-            _externalSources.push_back({ name, type, dataSource, childLayer });
+            _externalSources.push_back({ name, type, dataSource, childLayer, baseHeightScale });
             if (_componentsSet) {
                 wireChild(childLayer);
             }
@@ -163,6 +168,7 @@ namespace carto {
                 }
                 _externalSources.erase(it);
                 _lastVectorConfig.erase(name);
+                _lastChildConfig.erase(name);
                 rebuildDrawItems();
                 removed = true;
             }
@@ -441,6 +447,26 @@ namespace carto {
             auto it = config.values.find(key);
             return it != config.values.end() ? &it->second : nullptr;
         };
+        // Some hillshade setters re-decode the tile (setHeightScale/setContrast/setContourEnabled call
+        // updateTiles). Applying those every frame with a zoom-interpolated value would re-decode
+        // continuously, so they are applied only when the value actually changes. Cheap setters
+        // (opacity, colors, method, illumination, contour width/color, filter mode = redraw only) are
+        // applied every frame so they stay smooth.
+        std::map<std::string, float>& applied = _lastChildConfig[source.name];
+        auto changedFloat = [&](const std::string& key, float& out) {
+            const mvt::Value* v = getValue(key);
+            if (!v) {
+                return false;
+            }
+            float value = valueToFloat(*v, 0.0f);
+            auto it = applied.find(key);
+            if (it != applied.end() && it->second == value) {
+                return false;
+            }
+            applied[key] = value;
+            out = value;
+            return true;
+        };
 
         if (source.type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_RASTER) {
             auto raster = std::static_pointer_cast<RasterTileLayer>(source.childLayer);
@@ -450,20 +476,26 @@ namespace carto {
             }
         } else if (source.type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_HILLSHADE) {
             auto hillshade = std::static_pointer_cast<HillshadeRasterTileLayer>(source.childLayer);
-            if (const mvt::Value* v = getValue("opacity"))      { hillshade->setOpacity(valueToFloat(*v, 1.0f)); }
-            if (const mvt::Value* v = getValue("exaggeration"))  { hillshade->setHeightScale(valueToFloat(*v, 1.0f)); }
-            else if (const mvt::Value* v = getValue("height-scale")) { hillshade->setHeightScale(valueToFloat(*v, 1.0f)); }
-            if (const mvt::Value* v = getValue("contrast"))     { hillshade->setContrast(valueToFloat(*v, 0.5f)); }
+            if (const mvt::Value* v = getValue("opacity")) { hillshade->setOpacity(valueToFloat(*v, 1.0f)); }
+
+            float f = 0.0f;
+            // exaggeration multiplies the layer's natural height scale (~0.09); height-scale sets it raw.
+            if (getValue("exaggeration")) {
+                if (changedFloat("exaggeration", f)) { hillshade->setHeightScale(source.baseHeightScale * f); }
+            } else if (getValue("height-scale")) {
+                if (changedFloat("height-scale", f)) { hillshade->setHeightScale(f); }
+            }
+            if (changedFloat("contrast", f)) { hillshade->setContrast(f); }
+            if (changedFloat("contour-interval", f)) {
+                hillshade->setContourEnabled(f > 0.0f);
+                if (f > 0.0f) { hillshade->setContourInterval(f); }
+            }
+
             if (const mvt::Value* v = getValue("shadow-color"))    { hillshade->setShadowColor(parseColorValue(*v, Color(0, 0, 0, 255))); }
             if (const mvt::Value* v = getValue("highlight-color")) { hillshade->setHighlightColor(parseColorValue(*v, Color(255, 255, 255, 255))); }
             if (const mvt::Value* v = getValue("accent-color"))    { hillshade->setAccentColor(parseColorValue(*v, Color(0, 0, 0, 255))); }
             if (const mvt::Value* v = getValue("method")) {
                 if (auto str = std::get_if<std::string>(v)) { hillshade->setHillshadeMethod(parseHillshadeMethod(*str)); }
-            }
-            if (const mvt::Value* v = getValue("contour-interval")) {
-                float interval = valueToFloat(*v, 0.0f);
-                hillshade->setContourEnabled(interval > 0.0f);
-                if (interval > 0.0f) { hillshade->setContourInterval(interval); }
             }
             if (const mvt::Value* v = getValue("contour-color")) { hillshade->setContourColor(parseColorValue(*v, Color(0xC5, 0x60, 0x08, 0xff))); }
             if (const mvt::Value* v = getValue("contour-width")) { hillshade->setContourWidth(valueToFloat(*v, 1.0f)); }

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -10,10 +10,12 @@
 #include "graphics/ViewState.h"
 #include "graphics/Color.h"
 #include "core/MapRange.h"
+#include "core/MapVec.h"
 #include "components/Exceptions.h"
 #include "utils/Log.h"
 
 #include <algorithm>
+#include <cmath>
 #include <variant>
 
 #include <mapnikvt/Value.h>
@@ -461,7 +463,12 @@ namespace carto {
             }
             if (const mvt::Value* v = getValue("contour-color")) { hillshade->setContourColor(parseColorValue(*v, Color(0xC5, 0x60, 0x08, 0xff))); }
             if (const mvt::Value* v = getValue("contour-width")) { hillshade->setContourWidth(valueToFloat(*v, 1.0f)); }
-            // TODO: illumination-direction (azimuth degrees) -> setIlluminationDirection(MapVec).
+            if (const mvt::Value* v = getValue("illumination-direction")) {
+                // Azimuth in degrees (0 = north, clockwise) at a fixed 45 deg altitude, matching the
+                // HillshadeRasterTileLayer default direction convention (sin az, cos az, -sin alt).
+                double azimuth = valueToFloat(*v, 335.0f) * M_PI / 180.0;
+                hillshade->setIlluminationDirection(MapVec(std::sin(azimuth), std::cos(azimuth), -0.70710678));
+            }
         }
     }
 

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -549,14 +549,6 @@ namespace carto {
                 mvt::ResolvedLayerConfig config = decoder->resolveLayerConfig(item.slot, viewState.getZoom());
                 applyConfig(*source, config, viewState);
                 visible = config.visible;
-                { // TEMP DEBUG: verify per-zoom config evaluation (remove after diagnosis)
-                    auto oit = config.values.find("opacity");
-                    auto eit = config.values.find("exaggeration");
-                    float op = oit != config.values.end() ? valueToFloat(oit->second, -1.0f) : -1.0f;
-                    float ex = eit != config.values.end() ? valueToFloat(eit->second, -1.0f) : -1.0f;
-                    Log::Infof("CompositeVectorTileLayer[DEBUG] slot=%s viewZoom=%.3f visible=%d opacity=%.3f exaggeration=%.3f",
-                               item.slot.c_str(), viewState.getZoom(), (int)visible, op, ex);
-                }
             }
             if (visible) {
                 refresh = (terrain ? source->childLayer->onDrawFrame3D(deltaSeconds, billboardSorter, viewState)

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -549,6 +549,14 @@ namespace carto {
                 mvt::ResolvedLayerConfig config = decoder->resolveLayerConfig(item.slot, viewState.getZoom());
                 applyConfig(*source, config, viewState);
                 visible = config.visible;
+                { // TEMP DEBUG: verify per-zoom config evaluation (remove after diagnosis)
+                    auto oit = config.values.find("opacity");
+                    auto eit = config.values.find("exaggeration");
+                    float op = oit != config.values.end() ? valueToFloat(oit->second, -1.0f) : -1.0f;
+                    float ex = eit != config.values.end() ? valueToFloat(eit->second, -1.0f) : -1.0f;
+                    Log::Infof("CompositeVectorTileLayer[DEBUG] slot=%s viewZoom=%.3f visible=%d opacity=%.3f exaggeration=%.3f",
+                               item.slot.c_str(), viewState.getZoom(), (int)visible, op, ex);
+                }
             }
             if (visible) {
                 refresh = (terrain ? source->childLayer->onDrawFrame3D(deltaSeconds, billboardSorter, viewState)

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -150,7 +150,9 @@ namespace carto {
         };
 
         static std::shared_ptr<ElevationDecoder> resolveElevationDecoder(const std::shared_ptr<TileDataSource>& dataSource);
-        static std::string buildFilterString(const std::vector<std::string>& group);
+        // includeBackground: also match the empty-named per-tile background layer (only the bottom
+        // group 0 should, so the style Map background-color is drawn once at the bottom).
+        static std::string buildFilterString(const std::vector<std::string>& group, bool includeBackground = false);
 
         void wireChild(const std::shared_ptr<Layer>& child);
         void unwireChild(const std::shared_ptr<Layer>& child);

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -148,11 +148,16 @@ namespace carto {
         void rebuildRenderSteps();
         const ExternalSource* findExternalSource(const std::string& name) const;
         void applyConfig(const ExternalSource& source, const mvt::ResolvedLayerConfig& config, const ViewState& viewState);
+        // Applies '#name' config symbolizer values to merged vector sources whose generation
+        // parameters live on the data source (currently ContourTileDataSource). Called off the
+        // render thread (from loadData); only re-applies changed values to avoid reload loops.
+        void applyVectorSourceConfigs();
         bool renderSegmented(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain);
 
         std::shared_ptr<DynamicMergedMBVTTileDataSource> _mergedDataSource;
         std::vector<ExternalSource> _externalSources;
         std::vector<RenderStep> _renderSteps;
+        std::map<std::string, std::map<std::string, float> > _lastVectorConfig; // per-source applied contour params
         bool _singlePassRenderingEnabled;
 
         // Cached component handles for wiring child layers added after setComponents().

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -134,6 +134,7 @@ namespace carto {
             CompositeSourceType::CompositeSourceType type;
             std::shared_ptr<TileDataSource> dataSource;
             std::shared_ptr<Layer> childLayer; // raster/hillshade child; null for merged vector
+            float baseHeightScale = 1.0f;      // hillshade's default heightScale; exaggeration multiplies it
         };
 
         // One ordered draw step after the layer's own group-0 render: either an external
@@ -170,6 +171,7 @@ namespace carto {
         std::vector<ExternalSource> _externalSources;
         std::vector<DrawItem> _drawItems;
         std::map<std::string, std::map<std::string, float> > _lastVectorConfig; // per-source applied contour params
+        std::map<std::string, std::map<std::string, float> > _lastChildConfig;  // per-source last-applied decode-affecting values (avoid per-frame re-decode)
         bool _singlePassRenderingEnabled;
 
         // Cached component handles for wiring child layers added after setComponents().

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -135,28 +135,38 @@ namespace carto {
             std::shared_ptr<Layer> childLayer; // raster/hillshade child; null for merged vector
         };
 
-        struct RenderStep {
-            std::optional<std::regex> vtFilter; // filter for the vt style-layer group before the child
-            bool hasVtGroup = false;
-            std::string childSlot;              // raster/hillshade source name to draw after the group ("" = none)
+        // One ordered draw step after the layer's own group-0 render: either an external
+        // raster/hillshade child, or an internal VectorTileLayer rendering a later style-layer
+        // group with a fixed rendererLayerFilter (the filter is applied at tile-build time, so
+        // each group needs its own stable-filtered layer - a single renderer cannot be
+        // re-filtered per frame).
+        enum DrawItemKind { DRAW_ITEM_EXTERNAL, DRAW_ITEM_VT_GROUP };
+        struct DrawItem {
+            DrawItemKind kind;
+            std::string slot;                  // external source name (DRAW_ITEM_EXTERNAL)
+            std::shared_ptr<Layer> groupLayer; // internal group layer (DRAW_ITEM_VT_GROUP); held as
+                                               // Layer so protected virtuals are reachable via friend
         };
 
         static std::shared_ptr<ElevationDecoder> resolveElevationDecoder(const std::shared_ptr<TileDataSource>& dataSource);
+        static std::string buildFilterString(const std::vector<std::string>& group);
 
         void wireChild(const std::shared_ptr<Layer>& child);
         void unwireChild(const std::shared_ptr<Layer>& child);
-        void rebuildRenderSteps();
+        std::shared_ptr<Layer> makeGroupLayer(const std::string& filter);
+        void rebuildDrawItems();
+        void applyExternalChildZoomRange(const ExternalSource& source);
         const ExternalSource* findExternalSource(const std::string& name) const;
         void applyConfig(const ExternalSource& source, const mvt::ResolvedLayerConfig& config, const ViewState& viewState);
         // Applies '#name' config symbolizer values to merged vector sources whose generation
         // parameters live on the data source (currently ContourTileDataSource). Called off the
         // render thread (from loadData); only re-applies changed values to avoid reload loops.
         void applyVectorSourceConfigs();
-        bool renderSegmented(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain);
+        bool renderComposite(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain);
 
         std::shared_ptr<DynamicMergedMBVTTileDataSource> _mergedDataSource;
         std::vector<ExternalSource> _externalSources;
-        std::vector<RenderStep> _renderSteps;
+        std::vector<DrawItem> _drawItems;
         std::map<std::string, std::map<std::string, float> > _lastVectorConfig; // per-source applied contour params
         bool _singlePassRenderingEnabled;
 

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -20,7 +20,6 @@ namespace carto {
     class TileDataSource;
     class VectorTileDecoder;
     class ElevationDecoder;
-    class DynamicMergedMBVTTileDataSource;
     namespace mvt { struct ResolvedLayerConfig; }
 
     namespace CompositeSourceType {
@@ -37,8 +36,10 @@ namespace carto {
              */
             COMPOSITE_SOURCE_TYPE_HILLSHADE,
             /**
-             * Another MBVT/protobuf source (including ContourTileDataSource), merged into the
-             * master source and styled by the master CartoCSS. Has no separate child layer.
+             * Another MBVT/protobuf source (including ContourTileDataSource), drawn at its style
+             * slot as its own child VectorTileLayer using the master decoder, filtered to its own
+             * layer name. Kept separate (not merged) so it overzooms independently via its own
+             * MaxOverzoomLevel and does not need the DEM at the target zoom.
              */
             COMPOSITE_SOURCE_TYPE_VECTOR
         };
@@ -164,7 +165,6 @@ namespace carto {
         void applyVectorSourceConfigs();
         bool renderComposite(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain);
 
-        std::shared_ptr<DynamicMergedMBVTTileDataSource> _mergedDataSource;
         std::vector<ExternalSource> _externalSources;
         std::vector<DrawItem> _drawItems;
         std::map<std::string, std::map<std::string, float> > _lastVectorConfig; // per-source applied contour params

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -134,7 +134,6 @@ namespace carto {
             CompositeSourceType::CompositeSourceType type;
             std::shared_ptr<TileDataSource> dataSource;
             std::shared_ptr<Layer> childLayer; // raster/hillshade child; null for merged vector
-            float baseHeightScale = 1.0f;      // hillshade's default heightScale; exaggeration multiplies it
         };
 
         // One ordered draw step after the layer's own group-0 render: either an external

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_COMPOSITEVECTORTILELAYER_H_
+#define _CARTO_COMPOSITEVECTORTILELAYER_H_
+
+#include "layers/VectorTileLayer.h"
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <regex>
+#include <string>
+#include <vector>
+
+namespace carto {
+    class TileDataSource;
+    class VectorTileDecoder;
+    class ElevationDecoder;
+    class DynamicMergedMBVTTileDataSource;
+    namespace mvt { struct ResolvedLayerConfig; }
+
+    namespace CompositeSourceType {
+        /**
+         * The kind of an external data source added to a CompositeVectorTileLayer.
+         */
+        enum CompositeSourceType {
+            /**
+             * A raster tile source, drawn as a RasterTileLayer at its style slot.
+             */
+            COMPOSITE_SOURCE_TYPE_RASTER,
+            /**
+             * An RGB-encoded elevation source, drawn as a HillshadeRasterTileLayer at its style slot.
+             */
+            COMPOSITE_SOURCE_TYPE_HILLSHADE,
+            /**
+             * Another MBVT/protobuf source (including ContourTileDataSource), merged into the
+             * master source and styled by the master CartoCSS. Has no separate child layer.
+             */
+            COMPOSITE_SOURCE_TYPE_VECTOR
+        };
+    }
+
+    /**
+     * A VectorTileLayer that can weave named external data sources (raster, hillshade,
+     * merged vector / contour) into the master CartoCSS style's layer order.
+     *
+     * Each external source is placed at the position of a matching layer name in the style
+     * project's "layers" array, and configured by a matching '#name { ... }' block in the
+     * CartoCSS (e.g. raster-opacity, hillshade-exaggeration), including zoom- and nuti-
+     * parameter-dependent expressions. Raster and hillshade sources are rendered as their
+     * own draped child layers interleaved between the master style layers; merged vector
+     * sources are folded into the master source and styled normally.
+     *
+     * Sources can be added and removed at runtime.
+     */
+    class CompositeVectorTileLayer : public VectorTileLayer {
+    public:
+        /**
+         * Constructs a CompositeVectorTileLayer from a master vector data source and decoder.
+         * @param dataSource The master vector tile data source.
+         * @param decoder The tile decoder (must be an MBVectorTileDecoder for external source
+         *                configuration and placement to work).
+         */
+        CompositeVectorTileLayer(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<VectorTileDecoder>& decoder);
+        virtual ~CompositeVectorTileLayer();
+
+        /**
+         * Adds a named external data source. For raster and hillshade types the source is
+         * drawn as its own child layer at the style slot named 'name'. For the vector type
+         * the source is merged into the master source (see addVectorDataSource).
+         * @param name The source name; must match a layer name in the style "layers" array.
+         * @param dataSource The external data source.
+         * @param type The source type.
+         * @param elevationDecoder Optional elevation decoder for hillshade sources. If null,
+         *        it is resolved from the data source 'encoding' metadata ("terrarium"/"mapbox").
+         */
+        void addExternalDataSource(const std::string& name, const std::shared_ptr<TileDataSource>& dataSource, CompositeSourceType::CompositeSourceType type, const std::shared_ptr<ElevationDecoder>& elevationDecoder = std::shared_ptr<ElevationDecoder>());
+        /**
+         * Adds a named MBVT/protobuf source (including ContourTileDataSource) merged into the
+         * master source and styled by the master CartoCSS. Equivalent to addExternalDataSource
+         * with COMPOSITE_SOURCE_TYPE_VECTOR.
+         * @param name The source name; its layers must be declared in the master style.
+         * @param dataSource The vector data source to merge.
+         */
+        void addVectorDataSource(const std::string& name, const std::shared_ptr<TileDataSource>& dataSource);
+        /**
+         * Removes the named external data source (of any type). Returns true if removed.
+         * @param name The source name.
+         * @return True if a source was removed.
+         */
+        bool removeExternalDataSource(const std::string& name);
+        /**
+         * Returns the names of all registered external data sources.
+         * @return The registered external source names.
+         */
+        std::vector<std::string> getExternalDataSourceNames() const;
+
+        /**
+         * Returns whether single-pass segmented rendering is enabled (Milestone 6, optional).
+         * @return True if single-pass rendering is enabled. The default is false.
+         */
+        bool isSinglePassRenderingEnabled() const;
+        /**
+         * Sets whether to use the optional single-pass segmented renderer instead of the
+         * default one-vt-pass-per-segment path. Intended for A/B comparison; currently a
+         * no-op placeholder until the single-pass renderer lands.
+         * @param enabled True to enable single-pass rendering.
+         */
+        void setSinglePassRenderingEnabled(bool enabled);
+
+    protected:
+        virtual void setComponents(const std::shared_ptr<CancelableThreadPool>& envelopeThreadPool,
+                                   const std::shared_ptr<CancelableThreadPool>& tileThreadPool,
+                                   const std::weak_ptr<Options>& options,
+                                   const std::weak_ptr<MapRenderer>& mapRenderer,
+                                   const std::weak_ptr<TouchHandler>& touchHandler);
+
+        virtual void loadData(const std::shared_ptr<CullState>& cullState);
+        virtual void offsetLayerHorizontally(double offset);
+        virtual bool isUpdateInProgress() const;
+        virtual void calculateRayIntersectedElements(const cglib::ray3<double>& ray, const ViewState& viewState, std::vector<RayIntersectedElement>& results) const;
+
+        virtual bool onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState);
+        virtual bool onDrawFrame3D(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState);
+
+    private:
+        struct ExternalSource {
+            std::string name;
+            CompositeSourceType::CompositeSourceType type;
+            std::shared_ptr<TileDataSource> dataSource;
+            std::shared_ptr<Layer> childLayer; // raster/hillshade child; null for merged vector
+        };
+
+        struct RenderStep {
+            std::optional<std::regex> vtFilter; // filter for the vt style-layer group before the child
+            bool hasVtGroup = false;
+            std::string childSlot;              // raster/hillshade source name to draw after the group ("" = none)
+        };
+
+        static std::shared_ptr<ElevationDecoder> resolveElevationDecoder(const std::shared_ptr<TileDataSource>& dataSource);
+
+        void wireChild(const std::shared_ptr<Layer>& child);
+        void unwireChild(const std::shared_ptr<Layer>& child);
+        void rebuildRenderSteps();
+        const ExternalSource* findExternalSource(const std::string& name) const;
+        void applyConfig(const ExternalSource& source, const mvt::ResolvedLayerConfig& config, const ViewState& viewState);
+        bool renderSegmented(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain);
+
+        std::shared_ptr<DynamicMergedMBVTTileDataSource> _mergedDataSource;
+        std::vector<ExternalSource> _externalSources;
+        std::vector<RenderStep> _renderSteps;
+        bool _singlePassRenderingEnabled;
+
+        // Cached component handles for wiring child layers added after setComponents().
+        bool _componentsSet;
+        std::weak_ptr<Options> _childOptions;
+        std::weak_ptr<MapRenderer> _childMapRenderer;
+        std::weak_ptr<TouchHandler> _childTouchHandler;
+
+        mutable std::recursive_mutex _sourceMutex;
+    };
+
+}
+
+#endif

--- a/all/native/layers/HillshadeRasterTileLayer.cpp
+++ b/all/native/layers/HillshadeRasterTileLayer.cpp
@@ -33,6 +33,7 @@ namespace carto
         _elevationDecoder(elevationDecoder),
         _contrast(0.5f),
         _heightScale(0.09f),
+        _exaggeration(1.0f),
         _exagerateHeightScaleEnabled(true),
         _normalMapLightingShader(),
         _accentColor(Color(0, 0, 0, 255)),
@@ -53,6 +54,7 @@ namespace carto
         _elevationDecoder(nullptr),
         _contrast(0.5f),
         _heightScale(1.0f),
+        _exaggeration(1.0f),
         _exagerateHeightScaleEnabled(true),
         _normalMapLightingShader(),
         _accentColor(Color(0, 0, 0, 255)),
@@ -91,6 +93,15 @@ namespace carto
     void HillshadeRasterTileLayer::setHeightScale(float heightScale) {
         _heightScale.store(heightScale);
         updateTiles(false);
+    }
+
+    float HillshadeRasterTileLayer::getExaggeration() const {
+        return _exaggeration.load();
+    }
+
+    void HillshadeRasterTileLayer::setExaggeration(float exaggeration) {
+        _exaggeration.store(exaggeration);
+        redraw(); // per-frame shader uniform only; no tile re-decode
     }
 
     Color HillshadeRasterTileLayer::getShadowColor() const {
@@ -263,7 +274,7 @@ namespace carto
                     break;
             }
             _tileRenderer->setHillshadeMethod(hillshadeMethod);
-            _tileRenderer->setHillshadeExaggeration(getContrast());
+            _tileRenderer->setHillshadeExaggeration(getContrast() * getExaggeration());
             bool refresh = _tileRenderer->onDrawFrame(deltaSeconds, viewState);
 
             if (opacity < 1.0f)

--- a/all/native/layers/HillshadeRasterTileLayer.h
+++ b/all/native/layers/HillshadeRasterTileLayer.h
@@ -83,6 +83,20 @@ namespace carto {
         void setHeightScale(float heightScale);
 
         /**
+         * Returns the per-frame relief exaggeration factor. Unlike height scale this is a shader
+         * uniform applied at render time (no tile re-decode), so it can be animated smoothly.
+         * @return The exaggeration factor. Default is 1.0.
+         */
+        float getExaggeration() const;
+        /**
+         * Sets the per-frame relief exaggeration factor. Scales the hillshade slope/intensity in the
+         * shader without re-decoding tiles, so it can change smoothly (e.g. with zoom). 1.0 leaves the
+         * appearance unchanged.
+         * @param exaggeration The exaggeration factor.
+         */
+        void setExaggeration(float exaggeration);
+
+        /**
          * Returns the shading color of areas that face away from the light source.
          * @return The shadow color of the layer.
          */
@@ -242,6 +256,8 @@ namespace carto {
         std::atomic<float> _contrast;
         std::atomic<bool> _exagerateHeightScaleEnabled;
         std::atomic<float> _heightScale;
+
+        std::atomic<float> _exaggeration;
         std::string _normalMapLightingShader;
         std::atomic<Color> _shadowColor;
         std::atomic<Color> _accentColor;

--- a/all/native/layers/Layer.h
+++ b/all/native/layers/Layer.h
@@ -162,6 +162,7 @@ namespace carto {
         friend class MapRenderer;
         friend class BackgroundRenderer;
         friend class TouchHandler;
+        friend class CompositeVectorTileLayer; // forwards lifecycle/draw to owned child layers
     
         Layer();
         

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -201,6 +201,16 @@ namespace carto {
         return mvt::resolveLayerConfig(*_map, layerName, viewZoom, nutiValues);
     }
 
+    std::vector<int> MBVectorTileDecoder::getStyleLayerZoomRange(const std::string& layerName) const {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (!_map) {
+            return { 0, 24 };
+        }
+        std::pair<int, int> range = mvt::resolveLayerZoomRange(*_map, layerName);
+        return { range.first, range.second };
+    }
+
     void MBVectorTileDecoder::updateSymbolizer() {
         auto parameterValueMap = std::make_shared<std::map<std::string, mvt::Value>>(*_symbolizerContextSettings->getNutiParameterValueMap());
         for (auto it2 = _parameterValueMap.begin(); it2 != _parameterValueMap.end(); it2++) {

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -174,6 +174,33 @@ namespace carto {
         return std::string();
     }
 
+    std::vector<std::string> MBVectorTileDecoder::getStyleLayerNames() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        std::vector<std::string> names;
+        if (_map) {
+            for (const std::shared_ptr<mvt::Layer>& layer : _map->getLayers()) {
+                names.push_back(layer->getName());
+            }
+        }
+        return names;
+    }
+
+    mvt::ResolvedLayerConfig MBVectorTileDecoder::resolveLayerConfig(const std::string& layerName, float viewZoom) const {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (!_map) {
+            return mvt::ResolvedLayerConfig();
+        }
+        // Effective nuti value map: style defaults overlaid with runtime overrides (same as
+        // updateSymbolizer()).
+        auto nutiValues = std::make_shared<std::map<std::string, mvt::Value>>(*_symbolizerContextSettings->getNutiParameterValueMap());
+        for (auto it = _parameterValueMap.begin(); it != _parameterValueMap.end(); it++) {
+            (*nutiValues)[it->first] = it->second;
+        }
+        return mvt::resolveLayerConfig(*_map, layerName, viewZoom, nutiValues);
+    }
+
     void MBVectorTileDecoder::updateSymbolizer() {
         auto parameterValueMap = std::make_shared<std::map<std::string, mvt::Value>>(*_symbolizerContextSettings->getNutiParameterValueMap());
         for (auto it2 = _parameterValueMap.begin(); it2 != _parameterValueMap.end(); it2++) {

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -132,6 +132,16 @@ namespace carto {
          */
         mvt::ResolvedLayerConfig resolveLayerConfig(const std::string& layerName, float viewZoom) const;
 
+        /**
+         * Returns the { minZoom, maxZoom } range over which the named style layer's config
+         * symbolizer rules are active. Used by CompositeVectorTileLayer to constrain an
+         * external source child layer's visible zoom range. Returns { 0, 24 } if the layer
+         * has no config rules. Note: for internal use, not exposed to the public API.
+         * @param layerName The style layer name.
+         * @return A two-element vector { minZoom, maxZoom }.
+         */
+        std::vector<int> getStyleLayerZoomRange(const std::string& layerName) const;
+
 
         /**
          * Returns the value of feature id override flag. This is intended for cases when feature ids in tile are not globally unique.

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -17,6 +17,7 @@
 #include <variant>
 
 #include <mapnikvt/Value.h>
+#include <mapnikvt/LayerConfigResolver.h>
 
 namespace carto {
     namespace mvt {
@@ -109,6 +110,27 @@ namespace carto {
          * @param params The getStyleParameters to set.
          */
         void setJSONStyleParameters(const std::string& params);
+
+        /**
+         * Returns the ordered list of style layer names as declared by the style (the
+         * project JSON "layers" array). This defines both the draw order and which layers
+         * exist. Used by CompositeVectorTileLayer to place external data sources in the
+         * layer order. Note: for internal use, not exposed to the public API.
+         * @return The ordered style layer names.
+         */
+        std::vector<std::string> getStyleLayerNames() const;
+
+        /**
+         * Evaluates the config symbolizer(s) of the named style layer (raster / hillshade /
+         * contour) at the given fractional view zoom and the current style parameter (nuti)
+         * state, without decoding a tile. Honors rule zoom ranges and filter predicates.
+         * Used by CompositeVectorTileLayer to drive external data source settings per frame.
+         * Note: for internal use, not exposed to the public API.
+         * @param layerName The style layer name.
+         * @param viewZoom The fractional view zoom.
+         * @return The resolved configuration (visible flag + evaluated property values).
+         */
+        mvt::ResolvedLayerConfig resolveLayerConfig(const std::string& layerName, float viewZoom) const;
 
 
         /**

--- a/docs/composite-vector-tile-layer-config.md
+++ b/docs/composite-vector-tile-layer-config.md
@@ -1,0 +1,208 @@
+# CompositeVectorTileLayer — style configuration reference
+
+`CompositeVectorTileLayer` is a `VectorTileLayer` that weaves named external data sources
+(raster, hillshade, extra vector / contour) into a master CartoCSS style's layer order.
+Each external source is placed at the position of a matching layer name in the style, and
+configured by a matching `#name { … }` block — including zoom- and nuti-parameter-dependent
+expressions.
+
+## 1. Registering sources (Java API)
+
+```java
+MBVectorTileDecoder decoder = new MBVectorTileDecoder(styleSet); // master style
+CompositeVectorTileLayer layer = new CompositeVectorTileLayer(baseVectorSource, decoder);
+
+// raster / hillshade: drawn as their own child layer at the '#name' slot
+layer.addExternalDataSource("satellite", rasterSource, CompositeSourceType.COMPOSITE_SOURCE_TYPE_RASTER);
+layer.addExternalDataSource("hillshade", demSource,   CompositeSourceType.COMPOSITE_SOURCE_TYPE_HILLSHADE);
+//   (hillshade decoder arg optional; if omitted it is resolved from demSource.getEncoding())
+
+// vector (incl. contour): its own child VectorTileLayer over its own source, master-styled,
+//   filtered to its layer name, overzooming independently via its MaxOverzoomLevel
+layer.addVectorDataSource("contour", new ContourTileDataSource(demSource));
+
+layer.removeExternalDataSource("satellite");     // dynamic remove
+layer.getExternalDataSourceNames();              // list
+
+mapView.getLayers().add(layer);
+```
+
+## 2. Placement — the layer order
+
+An external source is drawn **only if its name appears in the master style's layer order**,
+and it is drawn at that position:
+
+- **Bundle style** (`CompiledStyleSet`, project JSON): the `"layers"` array defines order and
+  which layers exist. Add the external name there. **Note:** the array is reversed into draw
+  order — the *last* entry is the bottom layer, the *first* entry is on top.
+- **Raw CartoCSS string** (`CartoCSSStyleSet`): order = first `#name` reference in the CSS
+  (top of file = bottom of map). No `"layers"` array; also **no nuti parameters** (see §6).
+
+A registered source whose name is not in the layer order is skipped (with a warning).
+
+## 3. Source types & config properties
+
+### Raster (`COMPOSITE_SOURCE_TYPE_RASTER`)
+Drawn as a `RasterTileLayer`.
+
+| CartoCSS property | Effect | Timing |
+|---|---|---|
+| `raster-opacity` | layer opacity 0..1 | per-frame (smooth) |
+| `raster-filter-mode` | `nearest` \| `bilinear` \| `bicubic` | per-frame |
+| `raster-visible` | `true`/`false` hard toggle | per-frame |
+
+> `raster-comp-op` is parsed but not yet applied (RasterTileLayer has no blend-mode setter);
+> use `raster-opacity` for blending.
+
+### Hillshade (`COMPOSITE_SOURCE_TYPE_HILLSHADE`)
+Drawn as a `HillshadeRasterTileLayer`. Decoder resolved from the DEM source `encoding`
+(`terrarium`/`mapbox`) unless passed explicitly.
+
+| CartoCSS property | Effect | Timing |
+|---|---|---|
+| `hillshade-opacity` | layer opacity | per-frame (smooth) |
+| `hillshade-exaggeration` | relief strength multiplier (shader uniform) | **per-frame (smooth)** |
+| `hillshade-illumination-direction` | light azimuth in degrees (0 = N, clockwise; 45° altitude) | per-frame (smooth) |
+| `hillshade-shadow-color` / `-highlight-color` / `-accent-color` | shading palette | per-frame |
+| `hillshade-method` | `standard`\|`combined`\|`igor`\|`multidirectional`\|`basic` | per-frame |
+| `hillshade-contour-color` / `-contour-width` | GPU contour lines (in the hillshade pass) | per-frame |
+| `hillshade-height-scale` | raw normal-map height scale (baked at decode) | **per zoom level** |
+| `hillshade-contrast` | shading contrast (baked at decode) | **per zoom level** |
+| `hillshade-contour-interval` | GPU contour interval, 0 = off (toggles decode) | **per zoom level** |
+| `hillshade-visible` | hard toggle | per-frame |
+
+**Exaggeration vs height-scale:** `hillshade-exaggeration` is the one to animate — it is a
+per-frame shader uniform (default 1.0 = normal look, higher = stronger), so
+`linear([view::zoom], (4, 0.6), (12, 1.4))` glides smoothly. `hillshade-height-scale` is the
+raw geometric scale baked into the normal map; changing it re-decodes tiles, so it only
+updates when the integer zoom changes (per-zoom-level steps), never continuously.
+
+### Vector / contour (`COMPOSITE_SOURCE_TYPE_VECTOR`, or `addVectorDataSource`)
+Rendered as its own child `VectorTileLayer` over its own source, styled by the master CSS,
+filtered to its layer name. Style it with the normal vector symbolizers on `#name`, e.g. for a
+`ContourTileDataSource` (default layer name `contour`):
+
+```css
+#contour[view::zoom>=12] {
+  line-color: #9a5a12; line-width: 0.8; line-opacity: 0.7;
+  text-name: [ele]; text-face-name: "Noto Sans Regular"; text-size: 9;  // needs a font asset
+}
+```
+
+Optional `ContourTileDataSource` generation parameters (applied to the data source, not
+per frame — they regenerate tiles):
+
+| CartoCSS property | Data source setter |
+|---|---|
+| `contour-base-interval` | `setBaseInterval` |
+| `contour-resolution` | `setResolution` |
+| `contour-min-visible-zoom` | `setMinVisibleZoom` |
+| `contour-simplify-tolerance` | `setSimplifyTolerance` |
+
+Contours render past the DEM's max zoom via the child layer's `MaxOverzoomLevel` (from the
+source) — no need to download the DEM at the target zoom. Set
+`contourSource.setMaxOverzoomLevel(n)`.
+
+## 4. Property evaluation — zoom & interpolation
+
+- **`[view::zoom]`** is the fractional map zoom → evaluated **per frame** (smooth). Use it for
+  animated config.
+- **`zoom`** is the integer tile zoom → steps per zoom level.
+- **Interpolation** keyframes use **parentheses**, not brackets (brackets are field access):
+
+  ```css
+  hillshade-opacity: linear([view::zoom], (11, 0.2), (12, 1.0));   // correct
+  hillshade-opacity: linear([view::zoom], [11, 0.2], [12, 1.0]);   // WRONG - silently ignored
+  ```
+
+  Methods: `linear`, `step`, `cubic`.
+
+- **Illumination direction** is degrees and wraps correctly (any range mods via sin/cos, so
+  `(11, 300), (12, 420)` sweeps 300°→60°). A wide sweep visibly swings the shadows as the light
+  crosses due-south (180°) and due-north (360°) — that is physical, not a glitch. Pick a smaller
+  arc for a gentle change.
+
+- **Smooth vs stepped:** per-frame properties animate smoothly; decode-bound ones
+  (`hillshade-height-scale`, `hillshade-contrast`, `hillshade-contour-interval`) update only at
+  integer-zoom crossings. Prefer `hillshade-exaggeration` (per-frame) over `hillshade-height-scale`
+  for animation.
+
+## 5. Visibility (zoom & nuti)
+
+Gate a source's visibility with rule predicates on its `#name` block:
+
+```css
+#satellite[view::zoom>=13] { raster-opacity: 0.4; }          // only z>=13 (also limits fetching)
+#hillshade[view::zoom>5][view::zoom<=15] { hillshade-opacity: 0.6; }
+#hillshade[nuti::show_relief=true] { hillshade-opacity: 0.6; } // toggled at runtime (see §6)
+```
+
+Raster/hillshade children have their fetch/draw zoom range constrained to the config rules'
+zoom range, so they are not fetched outside the enabled zooms.
+
+## 6. Nuti parameters — runtime visibility toggles
+
+`nuti::` parameters let user settings drive layer visibility/appearance at runtime via
+`decoder.setStyleParameter(name, value)`. **They must be declared in a bundle style's project
+JSON** (`"nutiparameters"`); a raw CartoCSS string cannot declare them (`loadMap` passes none).
+
+Build a self-contained bundle in memory (no external file) with an in-memory zip:
+
+```java
+// project.json declares the nuti parameter, the layer order, and the mss file(s)
+String projectJson =
+    "{ \"styles\": [\"style.mss\"]," +
+    "  \"layers\": [\"place\",\"contour\",\"building\",\"transportation\",\"hillshade\",\"landcover\",\"water\"]," + // top -> bottom
+    "  \"nutiparameters\": { \"show_relief\": { \"default\": true } } }";
+
+String mss =
+    "Map { background-color: #eef2f0; }\n" +
+    "#water { polygon-fill: #9cc3e0; }\n" +
+    "#landcover { polygon-fill: #dbe8cc; }\n" +
+    "#hillshade[nuti::show_relief=true][view::zoom>=4] {\n" +
+    "  hillshade-opacity: linear([view::zoom], (4, 0.4), (12, 0.7));\n" +
+    "  hillshade-exaggeration: linear([view::zoom], (4, 0.6), (12, 1.4));\n" +
+    "}\n" +
+    "#transportation { line-color: #ffffff; line-width: 1.2; }\n" +
+    "#building[view::zoom>=14] { polygon-fill: #d9cfc4; }\n" +
+    "#contour[view::zoom>=12] { line-color: #9a5a12; line-width: 0.8; }\n";
+
+// Zip the two assets in memory -> ZippedAssetPackage -> CompiledStyleSet (loadMapProject)
+java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+java.util.zip.ZipOutputStream zos = new java.util.zip.ZipOutputStream(bos);
+for (String[] entry : new String[][] { {"project.json", projectJson}, {"style.mss", mss} }) {
+    zos.putNextEntry(new java.util.zip.ZipEntry(entry[0]));
+    zos.write(entry[1].getBytes("UTF-8"));
+    zos.closeEntry();
+}
+zos.close();
+CompiledStyleSet styleSet = new CompiledStyleSet(
+    new ZippedAssetPackage(new com.carto.core.BinaryData(bos.toByteArray())));
+MBVectorTileDecoder decoder = new MBVectorTileDecoder(styleSet);
+
+CompositeVectorTileLayer layer = new CompositeVectorTileLayer(baseVectorSource, decoder);
+layer.addExternalDataSource("hillshade", demSource, CompositeSourceType.COMPOSITE_SOURCE_TYPE_HILLSHADE);
+// ... contour, satellite ...
+mapView.getLayers().add(layer);
+
+// Toggle the relief on/off at runtime from a user setting:
+decoder.setStyleParameter("show_relief", "false");  // hides #hillshade live, no re-add
+```
+
+Nuti parameters can be booleans (as above), enums, or numbers; declare enums with a `values`
+map in the project JSON. `setStyleParameter` re-symbolizes and the composite re-evaluates the
+config on the next frame.
+
+## 7. Gotchas & limitations
+
+- **`layers` array is reversed** into draw order (first entry = top). Raw-CSS placement is
+  first-reference = bottom.
+- **Background:** the style `Map { background-color }` is drawn by the bottom group only.
+- **Decode-bound props** (`height-scale`, `contrast`, `contour-interval`) step per zoom level;
+  nuti-driven changes to them take effect on the next zoom change.
+- **Fonts:** text symbolizers (labels) need a font asset in the style bundle; the raw-string
+  demo omits text.
+- **Performance:** the master style is decoded once per style-layer group (groups = external
+  slots + 1). Fine for a few slots; wrap shared sources in a cache so network is fetched once.
+  A single-pass renderer (one decode) is a documented future optimization.
+- **`comp-op` for raster** is not yet applied.

--- a/docs/composite-vector-tile-layer-plan.md
+++ b/docs/composite-vector-tile-layer-plan.md
@@ -690,8 +690,12 @@ layer.removeExternalDataSource("satellite");         // dynamic remove
    `clang -fsyntax-only`. TODO (needs a real build/device): runtime verify slot ordering,
    per-frame opacity/exaggeration, zoom/nuti visibility; illumination-direction mapping;
    interaction of the composite's own rendererLayerFilter with segment filters.
-3. **Merged vector + contour** (B.1 rebuild path): `#contour` styled by master CSS;
-   optional contour config symbolizer for datasource params.
+3. **[DONE]** Merged vector + contour. `addVectorDataSource` folds any MBVT source
+   (incl. `ContourTileDataSource`) into the master via `DynamicMergedMBVTTileDataSource`,
+   styled by the master CSS. `applyVectorSourceConfigs()` (called from `loadData`, with
+   per-source change tracking to avoid setter→reload loops) applies `ContourConfigSymbolizer`
+   values (`contour-base-interval`/`resolution`/`min-visible-zoom`/`simplify-tolerance`,
+   nuti-aware, evaluated at a neutral zoom) to a `ContourTileDataSource`. Compiles.
 4. **Terrain** (`onDrawFrame3D`): children drape correctly; **on-device validation**
    (emulator ≠ device for depth — per prior terrain rounds).
 5. **SWIG + demo + docs** (C, D): Android demo style with all three source kinds and a

--- a/docs/composite-vector-tile-layer-plan.md
+++ b/docs/composite-vector-tile-layer-plan.md
@@ -747,13 +747,37 @@ cd scripts/android-dev && ./gradlew :app:assembleDebug -x lint
 Expected: base fills (water/landcover) → hillshade shading → faint satellite (z>=13) →
 roads → buildings + contour lines (z>=12). Panning/zooming should keep the hillshade under
 the roads; exaggeration should increase with zoom.
-6. **Single-pass segmented renderer** (perf, see open point 5): give `TileRenderer` /
-   `vt::GLTileRenderer` the ability to draw several disjoint style-layer filter ranges,
-   with the external children interleaved, inside **one** `startFrame`/`endFrame` instead
-   of N+1 full passes. Keep it behind a toggle on `CompositeVectorTileLayer` (e.g.
-   `setSinglePassRenderingEnabled(bool)`, default off initially) so the N+1-pass path and
-   the single-pass path can be A/B compared on device before picking the default. Scope to
-   this layer only (no change to plain `VectorTileLayer` behavior).
+6. **Single-pass segmented renderer** (perf, optional, NOT STARTED). Current cost: the master
+   style is decoded once per group (groups = external raster/hillshade/vector slots + 1), because
+   each group is a separate `VectorTileLayer` (the `rendererLayerFilter` is build-time, so one
+   renderer cannot draw disjoint ranges per frame). For typical styles with a few slots this is a
+   few decodes; it grows with the number of interleaved sources.
+   The fix is a **render-time** (not build-time) layer-index gate in `vt::GLTileRenderer`: let one
+   renderer hold all decoded layers and draw a `[minLayerIdx, maxLayerIdx)` range per draw call,
+   with children between. Integration points (all must honor the range consistently):
+   `renderGeometry`/`renderLabels` loops over `renderTile.renderLayers`
+   (GLTileRenderer.cpp:663/734/814/1362/1507/1666/1710) AND the blend-node construction
+   (~1362-1400). Style layer boundaries come from the `layerIdx = layerNum*65536+...` encoding
+   (TileReader.cpp:36), so a slot at style position p bounds a group at `layerIdx < p*65536`.
+   Keep it behind `setSinglePassRenderingEnabled` (already stubbed, default off) and A/B on device
+   before making it default. **Requires on-device validation** (this is the GL hot path; the
+   terrain history shows emulator passes do not guarantee device correctness) - do not merge from
+   a headless/emulator-only check.
+
+**nuti-parameter visibility** works today with **project-bundle styles** (a zip/asset package whose
+project JSON declares `nutiparameters`, e.g. the app's osm.zip): `resolveLayerConfig` evaluates
+`[nuti::x=...]` predicates against the decoder's nuti value map, and `decoder.setStyleParameter`
+toggles them live. It is NOT available with a **raw CartoCSS string** decoder, because
+`CartoCSSMapLoader::loadMap` passes no `nutiParameters` (only `loadMapProject` reads them,
+CartoCSSMapLoader.cpp:133). The demo uses a raw string for self-containment, so it demos zoom-based
+config only. A future enhancement could let raw CartoCSS / the decoder declare nuti params
+programmatically.
+
+## Status: feature complete (2D + 3D terrain), verified on device
+
+Milestones 1-5 done and device-verified (base fills, hillshade woven under roads, satellite raster
+with zoom gating, contour lines with overzoom, style background, 3D terrain). Remaining is the
+optional single-pass perf project (6) and the raw-string nuti enhancement, both above.
 
 ## Open points (leaning defaults)
 

--- a/docs/composite-vector-tile-layer-plan.md
+++ b/docs/composite-vector-tile-layer-plan.md
@@ -1,0 +1,724 @@
+# CompositeVectorTileLayer — Detailed Design & Implementation Plan
+
+Branch: `feat/composite-vector-tile-layer`
+
+## Goal
+
+A layer that renders a **master vector-tile style** but lets you weave **external named
+data sources** (raster, hillshade, extra vector, contour) into the style's layer order.
+Placement, visibility and per-source settings are driven from CartoCSS with zoom and
+`nuti::` expressions:
+
+```css
+/* raster overlay, half-opaque, only mid-zoom, multiply blend */
+#satellite [zoom>=8][zoom<14] {
+  raster-opacity: 0.6;
+  raster-comp-op: multiply;
+}
+
+/* hillshade woven between fills and roads; exaggeration ramps with zoom;
+   toggled by a runtime nuti parameter */
+#hillshade [zoom>5][zoom<=15][nuti::show_relief=true] {
+  hillshade-exaggeration: linear(zoom, [5, 0.3], [12, 1.0]);
+  hillshade-illumination-direction: 315;
+  hillshade-shadow-color: #003040;
+  raster-opacity: 0.8;
+}
+
+/* on-the-fly contour lines — this is a MERGED vector source, so it is styled
+   with the normal line/text symbolizers, no special config symbolizer needed */
+#contour [zoom>=12] {
+  line-width: 1;
+  line-color: #a06010;
+  text-name: [ele];
+  text-face-name: "Noto Sans Regular";
+}
+```
+
+## Confirmed decisions
+
+| Topic | Choice |
+|-------|--------|
+| Class name | `CompositeVectorTileLayer` (extends `VectorTileLayer`) |
+| Config mechanism | Extend libs-carto: real config symbolizers in cartocss+mapnikvt |
+| Terrain | Must work with 3D terrain (draped children, painter-order model) |
+| Extra vector source | Merged into master decoder/style |
+| Contour source | Merged vector (styled by master CSS); params driven by an optional config symbolizer |
+| Dynamic | add/remove external sources at runtime |
+
+---
+
+## Key architectural insight
+
+The property system already does the hard part. From `Properties.h`:
+
+- `FloatFunctionProperty`, `ColorFunctionProperty`, `ColorProperty`, `FloatProperty` all
+  parse a CartoCSS expression and can be **evaluated per-frame** against an
+  `ExpressionContext` + `ViewState` (`getStaticValue(context)` returns the concrete value
+  for the current `view::zoom`).
+- `nuti::` parameters and `zoom` are already resolved by `ExpressionContext`.
+- Rule visibility (`[zoom>5]`, `[nuti::x=true]`) is already encoded as `mvt::Rule`
+  min/max-zoom + a `Filter` predicate (`CartoCSSMapnikTranslator::buildRule`,
+  `CartoCSSMapnikTranslator.cpp:29`).
+
+So the **config symbolizers emit no geometry**. They exist only to (a) let CartoCSS parse
+and validate `hillshade-*` / `raster-*` properties, and (b) act as a typed, evaluable
+container. `CompositeVectorTileLayer` reads their evaluated values every frame via a small
+decoder helper — no changes to the decode/geometry path, no injection into `vt::Tile`.
+
+Zoom-range and nuti visibility fall out for free: if no rule matches the current
+view-zoom / nuti map, the helper returns "no config" ⇒ that external source is not drawn
+this frame.
+
+---
+
+## Part A — libs-carto (submodule `develop`)
+
+> Submodule gotcha: `libs-carto` is often in **detached HEAD**; `git status -sb` there and
+> commit on `develop` before bumping the pointer.
+
+### A.1 New symbolizer base: `LayerConfigSymbolizer`
+
+A symbolizer whose `createFeatureProcessor` returns an empty processor (never touches
+geometry). It just holds evaluable properties.
+
+`libs-carto/mapnikvt/src/mapnikvt/LayerConfigSymbolizer.h`:
+
+```cpp
+#ifndef _CARTO_MAPNIKVT_LAYERCONFIGSYMBOLIZER_H_
+#define _CARTO_MAPNIKVT_LAYERCONFIGSYMBOLIZER_H_
+
+#include "Symbolizer.h"
+
+namespace carto::mvt {
+    // Base for "external source config" symbolizers (raster / hillshade / contour).
+    // Produces NO geometry. Its properties are read out-of-band by the SDK layer via
+    // Symbolizer::getProperty(name) + Property::getExpression(), evaluated per frame.
+    class LayerConfigSymbolizer : public Symbolizer {
+    public:
+        // Never emits geometry.
+        FeatureProcessor createFeatureProcessor(const ExpressionContext&, const SymbolizerContext&) const override {
+            return FeatureProcessor();
+        }
+
+    protected:
+        explicit LayerConfigSymbolizer(std::shared_ptr<Logger> logger) : Symbolizer(std::move(logger)) {
+            // 'visible' lets a style force-hide independent of zoom predicates.
+            bindProperty("visible", &_visible);
+            bindProperty("opacity", &_opacity);
+        }
+
+        BoolProperty        _visible = BoolProperty(true);
+        FloatFunctionProperty _opacity = FloatFunctionProperty(1.0f);
+    };
+}
+#endif
+```
+
+### A.2 `RasterConfigSymbolizer` and `HillshadeConfigSymbolizer`
+
+`libs-carto/mapnikvt/src/mapnikvt/RasterConfigSymbolizer.h`:
+
+```cpp
+#include "LayerConfigSymbolizer.h"
+
+namespace carto::mvt {
+    class RasterConfigSymbolizer : public LayerConfigSymbolizer {
+    public:
+        explicit RasterConfigSymbolizer(std::shared_ptr<Logger> logger) : LayerConfigSymbolizer(std::move(logger)) {
+            bindProperty("filter-mode", &_filterMode);   // nearest | bilinear | bicubic
+            bindProperty("comp-op",     &_compOp);        // already bound by Symbolizer, rebind is fine
+        }
+    protected:
+        StringProperty _filterMode = StringProperty("bilinear");
+    };
+}
+```
+
+`libs-carto/mapnikvt/src/mapnikvt/HillshadeConfigSymbolizer.h`:
+
+```cpp
+#include "LayerConfigSymbolizer.h"
+
+namespace carto::mvt {
+    class HillshadeConfigSymbolizer : public LayerConfigSymbolizer {
+    public:
+        explicit HillshadeConfigSymbolizer(std::shared_ptr<Logger> logger) : LayerConfigSymbolizer(std::move(logger)) {
+            bindProperty("exaggeration",           &_exaggeration);
+            bindProperty("height-scale",           &_heightScale);
+            bindProperty("contrast",               &_contrast);
+            bindProperty("illumination-direction", &_illumDir);
+            bindProperty("shadow-color",           &_shadowColor);
+            bindProperty("highlight-color",        &_highlightColor);
+            bindProperty("accent-color",           &_accentColor);
+            bindProperty("method",                 &_method);        // standard|combined|igor|...
+            bindProperty("contour-interval",       &_contourInterval);
+            bindProperty("contour-color",          &_contourColor);
+            bindProperty("contour-width",          &_contourWidth);
+        }
+    protected:
+        FloatFunctionProperty _exaggeration    = FloatFunctionProperty(1.0f);
+        FloatFunctionProperty _heightScale     = FloatFunctionProperty(1.0f);
+        FloatFunctionProperty _contrast        = FloatFunctionProperty(0.5f);
+        FloatFunctionProperty _illumDir        = FloatFunctionProperty(335.0f);
+        ColorProperty         _shadowColor     = ColorProperty("#000000");
+        ColorProperty         _highlightColor  = ColorProperty("#ffffff");
+        ColorProperty         _accentColor     = ColorProperty("#000000");
+        StringProperty        _method          = StringProperty("standard");
+        FloatFunctionProperty _contourInterval = FloatFunctionProperty(0.0f); // 0 = off
+        ColorProperty         _contourColor    = ColorProperty("#804000");
+        FloatFunctionProperty _contourWidth    = FloatFunctionProperty(1.0f);
+    };
+}
+```
+
+`.cpp` files: only needed if any property needs custom parsing; the above all use
+existing property types, so a trivial `.cpp` (or header-only) suffices.
+
+### A.3 CartoCSS translator wiring (`CartoCSSMapnikTranslator.cpp`)
+
+Three edits, all in existing tables/switch:
+
+1. Add symbolizer ids to `_symbolizerList` (order matters: longest-prefix first, matching
+   the existing `"line-pattern"` before `"line"` convention):
+
+```cpp
+const std::vector<std::string> CartoCSSMapnikTranslator::_symbolizerList = {
+    "line-pattern", "line", "polygon-pattern", "polygon", "point",
+    "text", "marker", "shield", "building",
+    "hillshade", "raster", "contour"          // NEW
+};
+```
+
+2. Add property → mapnik-property rows to `_symbolizerPropertyMap`:
+
+```cpp
+{ "raster-opacity",      "opacity" },
+{ "raster-comp-op",      "comp-op" },
+{ "raster-filter-mode",  "filter-mode" },
+
+{ "hillshade-opacity",               "opacity" },
+{ "hillshade-exaggeration",          "exaggeration" },
+{ "hillshade-height-scale",          "height-scale" },
+{ "hillshade-contrast",              "contrast" },
+{ "hillshade-illumination-direction","illumination-direction" },
+{ "hillshade-shadow-color",          "shadow-color" },
+{ "hillshade-highlight-color",       "highlight-color" },
+{ "hillshade-accent-color",          "accent-color" },
+{ "hillshade-method",                "method" },
+{ "hillshade-contour-interval",      "contour-interval" },
+{ "hillshade-contour-color",         "contour-color" },
+{ "hillshade-contour-width",         "contour-width" },
+{ "hillshade-comp-op",               "comp-op" },
+// contour datasource params (optional; drives ContourTileDataSource setters, not per-frame)
+{ "contour-base-interval",           "base-interval" },
+{ "contour-resolution",              "resolution" },
+```
+
+3. Add construction cases to `createSymbolizer` (mirrors the `polygon`/`line` cases):
+
+```cpp
+else if (symbolizerType == "raster") {
+    mapnikSymbolizer = std::make_shared<mvt::RasterConfigSymbolizer>(_logger);
+}
+else if (symbolizerType == "hillshade") {
+    mapnikSymbolizer = std::make_shared<mvt::HillshadeConfigSymbolizer>(_logger);
+}
+else if (symbolizerType == "contour") {
+    mapnikSymbolizer = std::make_shared<mvt::ContourConfigSymbolizer>(_logger);
+}
+```
+
+Result: `#hillshade { hillshade-exaggeration: … }` compiles into a `Layer("hillshade")`
+holding a `HillshadeConfigSymbolizer`, with zoom/nuti predicates preserved on its
+`mvt::Rule`s — exactly like every other CartoCSS layer.
+
+### A.4 Decoder-side evaluation helper (mapnikvt `Map` or a free function)
+
+Add a helper that, without decoding a tile, returns the evaluated config for a named layer
+at a given view zoom + nuti map. It walks the layer's styles→rules, honoring the rule
+zoom range and filter predicate, and reads the config symbolizer's properties.
+
+`libs-carto/mapnikvt/src/mapnikvt/LayerConfigResolver.h` (sketch):
+
+```cpp
+namespace carto::mvt {
+    struct ResolvedLayerConfig {
+        bool   visible = false;                       // false => no matching rule / hidden
+        std::map<std::string, Value> values;          // "opacity", "exaggeration", ...
+    };
+
+    // viewZoom is fractional (view::zoom). nutiValues comes from the decoder's parameter map.
+    ResolvedLayerConfig resolveLayerConfig(const Map& map,
+                                           const std::string& layerName,
+                                           float viewZoom,
+                                           const std::map<std::string, Value>& nutiValues);
+}
+```
+
+Implementation outline:
+
+```cpp
+ResolvedLayerConfig resolveLayerConfig(const Map& map, const std::string& layerName,
+                                       float viewZoom, const std::map<std::string, Value>& nutiValues) {
+    ResolvedLayerConfig out;
+    std::shared_ptr<const Layer> layer = map.getLayer(layerName);   // add getter if missing
+    if (!layer) return out;
+
+    ExpressionContext ctx;
+    ctx.setAdjustedZoom(static_cast<int>(viewZoom));    // predicate zoom
+    ctx.setNutiParameterValueMap(nutiValues);
+    vt::ViewState viewState; viewState.zoom = viewZoom; // for FloatFunction eval
+
+    for (const auto& styleName : layer->getStyleNames()) {
+        std::shared_ptr<const Style> style = map.getStyle(styleName);
+        for (const std::shared_ptr<const Rule>& rule : style->getRules()) {
+            if (viewZoom < rule->getMinZoom() || viewZoom >= rule->getMaxZoom()) continue;
+            if (rule->getFilter() && !rule->getFilter()->evaluate(ctx)) continue;   // zoom/nuti predicates
+            for (const auto& sym : rule->getSymbolizers()) {
+                auto cfg = std::dynamic_pointer_cast<const LayerConfigSymbolizer>(sym);
+                if (!cfg) continue;
+                out.visible = true;
+                for (const std::string& name : cfg->getPropertyNames()) {
+                    if (const Property* p = cfg->getProperty(name); p && p->isDefined()) {
+                        // Reuse the property's own evaluation. For FloatFunctionProperty this is
+                        // getStaticValue(ctx); a small visitor maps each Property kind to a Value.
+                        out.values[name] = evaluatePropertyValue(*p, ctx, viewState);
+                    }
+                }
+            }
+        }
+    }
+    return out;
+}
+```
+
+`evaluatePropertyValue` is a thin switch over the concrete `Property` subtype (Float/
+Color/String/FloatFunction) calling its existing `getValue`/`getStaticValue`. Some
+`Map`/`Layer`/`Style`/`Rule` getters (`getLayer`, `getStyle`, `getRules`, `getMinZoom`,
+`getFilter`) may need to be added/exposed — verify exact names during impl.
+
+---
+
+## Part B — all/native (main repo)
+
+### B.1 Decoder passthrough (`MBVectorTileDecoder`)
+
+Expose two things the composite needs (thin wrappers over the compiled `_map`):
+
+```cpp
+// MBVectorTileDecoder.h additions
+public:
+    // Ordered master style layer names (the #name order in the CSS).
+    std::vector<std::string> getStyleLayerNames() const;
+    // Evaluate a config layer's properties for the given view zoom (uses current nuti params).
+    mvt::ResolvedLayerConfig resolveLayerConfig(const std::string& layerName, float viewZoom) const;
+```
+
+```cpp
+// MBVectorTileDecoder.cpp
+std::vector<std::string> MBVectorTileDecoder::getStyleLayerNames() const {
+    std::lock_guard<std::mutex> lock(_mutex);
+    std::vector<std::string> names;
+    if (_map) for (const auto& layer : _map->getLayers()) names.push_back(layer->getName());
+    return names;
+}
+
+mvt::ResolvedLayerConfig MBVectorTileDecoder::resolveLayerConfig(const std::string& layerName, float viewZoom) const {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (!_map) return {};
+    return mvt::resolveLayerConfig(*_map, layerName, viewZoom, _parameterValueMap);  // _parameterValueMap already held
+}
+```
+
+### B.2 `CompositeVectorTileLayer` — header
+
+`all/native/layers/CompositeVectorTileLayer.h`:
+
+```cpp
+#ifndef _CARTO_COMPOSITEVECTORTILELAYER_H_
+#define _CARTO_COMPOSITEVECTORTILELAYER_H_
+
+#include "layers/VectorTileLayer.h"
+
+namespace carto {
+    class HillshadeRasterTileLayer;
+    class ElevationDecoder;
+
+    namespace CompositeSourceType {
+        enum CompositeSourceType {
+            COMPOSITE_SOURCE_RASTER,     // drawn as RasterTileLayer
+            COMPOSITE_SOURCE_HILLSHADE,  // drawn as HillshadeRasterTileLayer
+            COMPOSITE_SOURCE_VECTOR,     // merged into master decoder (incl. ContourTileDataSource)
+        };
+    }
+
+    /**
+     * A VectorTileLayer that can weave named external data sources (raster, hillshade,
+     * merged vector / contour) into the master CartoCSS style's layer order. The slot and
+     * per-source settings are taken from a matching '#name { ... }' block in the style.
+     */
+    class CompositeVectorTileLayer : public VectorTileLayer {
+    public:
+        CompositeVectorTileLayer(const std::shared_ptr<TileDataSource>& dataSource,
+                                 const std::shared_ptr<VectorTileDecoder>& decoder);
+        virtual ~CompositeVectorTileLayer();
+
+        // Raster / hillshade: rendered as its own draped child at the '#name' slot.
+        void addExternalDataSource(const std::string& name,
+                                   const std::shared_ptr<TileDataSource>& dataSource,
+                                   CompositeSourceType::CompositeSourceType type,
+                                   const std::shared_ptr<ElevationDecoder>& elevationDecoder = nullptr);
+        // Merged vector (incl. contour): folded into the master source, styled by master CSS.
+        void addVectorDataSource(const std::string& name,
+                                 const std::shared_ptr<TileDataSource>& dataSource);
+
+        bool removeExternalDataSource(const std::string& name);
+        std::vector<std::string> getExternalDataSourceNames() const;
+
+    protected:
+        virtual bool onDrawFrame(float deltaSeconds, const ViewState& viewState);   // 2D
+        virtual bool onDrawFrame3D(float deltaSeconds, const ViewState& viewState); // terrain
+
+        virtual void setComponents(const std::shared_ptr<CancelableThreadPool>& envelopeThreadPool,
+                                   const std::shared_ptr<CancelableThreadPool>& tileThreadPool,
+                                   const std::weak_ptr<Options>& options,
+                                   const std::weak_ptr<MapRenderer>& mapRenderer,
+                                   const std::weak_ptr<TouchHandler>& touchHandler);
+
+    private:
+        struct ExternalSource {
+            std::string name;
+            CompositeSourceType::CompositeSourceType type;
+            std::shared_ptr<TileDataSource> dataSource;
+            std::shared_ptr<Layer> childLayer;   // Raster/Hillshade layer; null for merged vector
+        };
+
+        static std::shared_ptr<ElevationDecoder> resolveElevationDecoder(const std::shared_ptr<TileDataSource>& ds);
+        void rebuildMergedDataSource();          // recompute the MergedMBVT chain for the master source
+        void recomputeSegments();                // order external names against getStyleLayerNames()
+        void applyConfig(const ExternalSource& src, const ViewState& viewState); // push evaluated props
+        std::vector<std::optional<std::regex>> buildGroupFilters() const;        // regex per vt segment
+        bool renderSegmented(float dt, const ViewState& viewState, bool terrain);
+
+        std::vector<ExternalSource> _externalSources;   // registration order
+        std::vector<std::string>    _rasterHillshadeOrder; // subset that occupy slots, in style order
+        std::shared_ptr<TileDataSource> _baseVectorSource; // the original master source (pre-merge)
+        mutable std::recursive_mutex _sourceMutex;
+    };
+}
+#endif
+```
+
+### B.3 `CompositeVectorTileLayer` — key implementation
+
+**Add / remove (dynamic):**
+
+```cpp
+void CompositeVectorTileLayer::addExternalDataSource(const std::string& name,
+        const std::shared_ptr<TileDataSource>& ds, CompositeSourceType::CompositeSourceType type,
+        const std::shared_ptr<ElevationDecoder>& elevDecoder) {
+    std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+    ExternalSource src{ name, type, ds, nullptr };
+    if (type == CompositeSourceType::COMPOSITE_SOURCE_RASTER) {
+        src.childLayer = std::make_shared<RasterTileLayer>(ds);
+    } else if (type == CompositeSourceType::COMPOSITE_SOURCE_HILLSHADE) {
+        // If no decoder is supplied, resolve it from the data source's 'encoding' metadata
+        // (mirrors ContourTileDataSource::resolveDecoder). Building it explicitly (vs the
+        // single-arg HillshadeRasterTileLayer ctor) keeps decoder-based heightScale semantics.
+        std::shared_ptr<ElevationDecoder> decoder = elevDecoder;
+        if (!decoder) decoder = resolveElevationDecoder(ds);   // see helper below
+        src.childLayer = decoder ? std::make_shared<HillshadeRasterTileLayer>(ds, decoder)
+                                 : std::make_shared<HillshadeRasterTileLayer>(ds); // lazy-infer fallback
+    } else {
+        addVectorDataSource(name, ds);   // merged path
+        return;
+    }
+    // Wire the child into the same map context so it fetches + drapes on terrain.
+    if (auto mr = _mapRenderer.lock())
+        src.childLayer->setComponents(_envelopeThreadPool, _tileThreadPool, _options, _mapRenderer, _touchHandler);
+    _externalSources.push_back(std::move(src));
+    recomputeSegments();
+    refresh();
+}
+
+void CompositeVectorTileLayer::addVectorDataSource(const std::string& name,
+        const std::shared_ptr<TileDataSource>& ds) {
+    std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+    _externalSources.push_back({ name, CompositeSourceType::COMPOSITE_SOURCE_VECTOR, ds, nullptr });
+    rebuildMergedDataSource();       // fold into master TileDataSource
+    recomputeSegments();
+    refresh();
+}
+
+void CompositeVectorTileLayer::rebuildMergedDataSource() {
+    std::shared_ptr<TileDataSource> merged = _baseVectorSource;
+    for (const auto& s : _externalSources)
+        if (s.type == CompositeSourceType::COMPOSITE_SOURCE_VECTOR)
+            merged = std::make_shared<MergedMBVTTileDataSource>(merged, s.dataSource);
+    setDataSource(merged);           // TileLayer setter; triggers tile reload
+}
+```
+
+**Elevation decoder resolution from encoding** (used when the hillshade decoder arg is null):
+
+```cpp
+// Resolve an ElevationDecoder from a data source's 'encoding' (TileDataSource::getEncoding()).
+// "mapbox" -> MapBoxElevationDataDecoder, "terrarium"/default -> TerrariumElevationDataDecoder.
+// Returns null if encoding is unset, so the caller can fall back to lazy per-tile inference.
+std::shared_ptr<ElevationDecoder> CompositeVectorTileLayer::resolveElevationDecoder(
+        const std::shared_ptr<TileDataSource>& ds) {
+    std::string encoding = ds ? ds->getEncoding() : std::string();
+    if (encoding.empty())   return nullptr;                 // let HillshadeRasterTileLayer infer per tile
+    if (encoding == "mapbox") return std::make_shared<MapBoxElevationDataDecoder>();
+    return std::make_shared<TerrariumElevationDataDecoder>();  // terrarium is the default
+}
+```
+
+> `ContourTileDataSource` is registered via `addVectorDataSource("contour", contourDS)`:
+> it emits MVT, so it merges and is styled by the master `#contour {}` block. No child
+> layer, no config symbolizer required for basic use. (An optional `#contour {
+> contour-base-interval: …; contour-resolution: … }` config symbolizer can push the
+> datasource setters on style/nuti change — applied in `applyConfig`, NOT per frame,
+> since changing them re-generates tiles.)
+
+**Segment ordering** — split master style layers at external slots:
+
+```cpp
+void CompositeVectorTileLayer::recomputeSegments() {
+    auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
+    if (!decoder) return;
+    // Order comes from the style PROJECT JSON's "layers" array (CartoCSSMapLoader::loadMapProject,
+    // CartoCSSMapLoader.cpp:86) -> mvt::Map::getLayers() -> getStyleLayerNames(). The "layers" array
+    // is what defines both draw order AND which layers are visible; an external source is placed by
+    // adding its name to that array. Names not listed there get no slot (skipped + warned).
+    std::vector<std::string> order = decoder->getStyleLayerNames();
+
+    // Which registered raster/hillshade sources actually have a slot in the style, in style order.
+    std::set<std::string> registered;
+    for (const auto& s : _externalSources)
+        if (s.type != CompositeSourceType::COMPOSITE_SOURCE_VECTOR) registered.insert(s.name);
+
+    _rasterHillshadeOrder.clear();
+    for (const std::string& layerName : order)
+        if (registered.count(layerName)) _rasterHillshadeOrder.push_back(layerName);
+    // A registered-but-unreferenced source has no slot -> not drawn (log a warning).
+}
+```
+
+**Segmented render** — the core. For each frame: render master vt style-layers up to the
+next external slot (via a transient `rendererLayerFilter`), draw the child, continue.
+
+```cpp
+bool CompositeVectorTileLayer::renderSegmented(float dt, const ViewState& viewState, bool terrain) {
+    auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
+    if (!decoder || _rasterHillshadeOrder.empty()) {
+        // No interleaving needed — behave as a plain VectorTileLayer.
+        return terrain ? VectorTileLayer::onDrawFrame3D(dt, viewState)
+                       : VectorTileLayer::onDrawFrame(dt, viewState);
+    }
+    std::vector<std::string> order = decoder->getStyleLayerNames();
+
+    bool refresh = false;
+    std::size_t i = 0;
+    std::string prevBoundary;    // exclusive lower bound (last drawn style layer)
+    for (const std::string& slot : _rasterHillshadeOrder) {
+        // 1) master vt: style layers in (prevBoundary, slot)  via regex filter
+        std::optional<std::regex> filter = buildRangeFilter(order, prevBoundary, /*upTo=*/slot);
+        _tileRenderer->setRendererLayerFilter(filter);
+        refresh |= terrain ? _tileRenderer->onDrawFrame3D(dt, viewState)
+                           : _tileRenderer->onDrawFrame(dt, viewState);
+
+        // 2) the external child at this slot, with per-frame evaluated config
+        const ExternalSource* src = findSource(slot);
+        mvt::ResolvedLayerConfig cfg = decoder->resolveLayerConfig(slot, viewState.getZoom());
+        if (src && cfg.visible) {
+            applyConfig(*src, cfg, viewState);                       // opacity/exaggeration/...
+            refresh |= renderChild(*src, dt, viewState, terrain);    // child->onDrawFrame(3D)
+        }
+        prevBoundary = slot;
+    }
+    // 3) master vt: remaining style layers after the last slot
+    _tileRenderer->setRendererLayerFilter(buildRangeFilter(order, prevBoundary, /*upTo=*/""));
+    refresh |= terrain ? _tileRenderer->onDrawFrame3D(dt, viewState)
+                       : _tileRenderer->onDrawFrame(dt, viewState);
+
+    _tileRenderer->setRendererLayerFilter(std::nullopt);   // restore
+    return refresh;
+}
+
+bool CompositeVectorTileLayer::onDrawFrame(float dt, const ViewState& vs)   { return renderSegmented(dt, vs, false); }
+bool CompositeVectorTileLayer::onDrawFrame3D(float dt, const ViewState& vs) { return renderSegmented(dt, vs, true); }
+```
+
+`buildRangeFilter` builds an ECMA regex matching the qualified names of the master style
+layers strictly between two boundaries — reusing the existing `rendererLayerFilter`
+mechanism (`TileRenderer.cpp:227` re-applies it every `onDrawFrame`). The child layers
+are separate `RasterTileLayer`/`HillshadeRasterTileLayer` instances whose own
+`onDrawFrame`/`onDrawFrame3D` already drape on terrain today, so cross-pass stacking is
+pure painter order — consistent with the established terrain depth model (content never
+writes depth; only per-layer surface pre-pass). **No new depth work.**
+
+**Config application** — map resolved values onto the child's setters:
+
+```cpp
+void CompositeVectorTileLayer::applyConfig(const ExternalSource& src,
+        const mvt::ResolvedLayerConfig& cfg, const ViewState& vs) {
+    auto getF = [&](const char* k, float d){ auto it = cfg.values.find(k);
+        return it==cfg.values.end()? d : (float)mvt::ValueConverter<double>::convert(it->second); };
+    auto getC = [&](const char* k, Color d){ auto it = cfg.values.find(k);
+        return it==cfg.values.end()? d : colorFromValue(it->second); };
+
+    if (src.type == CompositeSourceType::COMPOSITE_SOURCE_RASTER) {
+        src.childLayer->setOpacity(getF("opacity", 1.0f));
+        // comp-op / filter-mode -> RasterTileLayer setters
+    } else if (src.type == CompositeSourceType::COMPOSITE_SOURCE_HILLSHADE) {
+        auto hs = std::static_pointer_cast<HillshadeRasterTileLayer>(src.childLayer);
+        hs->setOpacity(getF("opacity", 1.0f));
+        hs->setHeightScale(getF("exaggeration", 1.0f));   // maps to exaggeration/height scale
+        hs->setContrast(getF("contrast", 0.5f));
+        hs->setShadowColor(getC("shadow-color", Color(0,0,0,255)));
+        hs->setHighlightColor(getC("highlight-color", Color(255,255,255,255)));
+        // illumination-direction, method, contour-* -> matching HillshadeRasterTileLayer setters
+    }
+}
+```
+
+### B.4 `Layer::update` / lifecycle forwarding
+
+Children are real `TileLayer`s: forward `update(cullState)`, `setComponents`, `refresh`,
+`offsetLayerHorizontally`, and teardown to each `childLayer` so their fetch threads/caches
+run. Do this in the composite's overrides of `Layer::update` and `setComponents`.
+
+---
+
+## Part C — SWIG (`all/modules/`)
+
+`all/modules/layers/CompositeVectorTileLayer.i`:
+
+```cpp
+#ifndef _COMPOSITEVECTORTILELAYER_I
+#define _COMPOSITEVECTORTILELAYER_I
+
+%module CompositeVectorTileLayer
+
+!proxy_imports(carto::CompositeVectorTileLayer, datasources.TileDataSource, layers.VectorTileLayer, vectortiles.VectorTileDecoder, rastertiles.ElevationDecoder)
+
+%{
+#include "layers/CompositeVectorTileLayer.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_string.i>
+%include <std_vector.i>
+%include <std_shared_ptr.i>
+%include <cartoswig.i>
+
+%import "layers/VectorTileLayer.i"
+%import "datasources/TileDataSource.i"
+%import "rastertiles/ElevationDecoder.i"
+
+!enum(carto::CompositeSourceType::CompositeSourceType)
+!polymorphic_shared_ptr(carto::CompositeVectorTileLayer, layers.CompositeVectorTileLayer)
+
+%std_exceptions(carto::CompositeVectorTileLayer::CompositeVectorTileLayer)
+
+%include "layers/CompositeVectorTileLayer.h"
+
+#endif
+```
+
+Regenerate proxies manually (gradle does NOT run swig):
+
+```sh
+cd scripts && python3 swigpp-java.py \
+  --profile "standard+valhalla+geocoding+routing+packagemanager" \
+  --swig /Volumes/dev/carto/mobile-swig/swig
+```
+
+Add the module to the swig module list / `all/modules/carto_mobile_sdk.i` include set the
+same way `VectorTileLayer.i` is registered.
+
+---
+
+## Part D — Usage example (target API)
+
+```java
+// master style declares #hillshade, #satellite, #contour blocks (see top of doc)
+MBVectorTileDecoder decoder = new MBVectorTileDecoder(new CartoCSSStyleSet(cartoCss));
+CompositeVectorTileLayer layer = new CompositeVectorTileLayer(baseMvtSource, decoder);
+
+// names "satellite", "hillshade", "contour" MUST appear in the style project JSON "layers"
+// array (defines order + visibility). The #name blocks supply per-source settings.
+layer.addExternalDataSource("satellite", rasterSource, CompositeSourceType.COMPOSITE_SOURCE_RASTER);
+// hillshade decoder arg omitted -> resolved from demSource.getEncoding() ("terrarium"/"mapbox")
+demSource.setEncoding("terrarium");
+layer.addExternalDataSource("hillshade", demSource, CompositeSourceType.COMPOSITE_SOURCE_HILLSHADE);
+layer.addVectorDataSource("contour", new ContourTileDataSource(demSource));  // merged, styled by #contour
+
+mapView.getLayers().add(layer);
+
+// runtime toggle via nuti parameter used in the #hillshade predicate
+decoder.setStyleParameter("show_relief", "false");   // hides hillshade live, no re-add
+layer.removeExternalDataSource("satellite");         // dynamic remove
+```
+
+---
+
+## Milestones
+
+1. **[DONE]** libs-carto config symbolizers (A.1–A.3) + `resolveLayerConfig` (A.4).
+   Files added under `libs-carto/mapnikvt/src/mapnikvt/`: `LayerConfigSymbolizer.h`,
+   `RasterConfigSymbolizer.h`, `HillshadeConfigSymbolizer.h`, `ContourConfigSymbolizer.h`,
+   `LayerConfigResolver.{h,cpp}`. Translator wired in `CartoCSSMapnikTranslator.cpp`
+   (`_symbolizerList`, `_symbolizerPropertyMap`, `createSymbolizer`, includes). Both TUs
+   pass `clang -fsyntax-only`; CMake globs the new `.cpp`. TODO: runtime assertion (CSS
+   with `#hillshade{}` → `resolveLayerConfig` across a zoom sweep + nuti toggle) deferred
+   to a linked build / the demo in Milestone 5.
+2. **[DONE]** CompositeVectorTileLayer 2D + 3D segmented render (B). Added:
+   `MBVectorTileDecoder::getStyleLayerNames()` + `resolveLayerConfig()` (SWIG-ignored);
+   `datasources/DynamicMergedMBVTTileDataSource.{h,cpp}` (mutable N-source MBVT merge —
+   needed because `TileLayer::_dataSource` is `const`, so the master source is wrapped once
+   and vector sources are added/removed inside the wrapper); `layers/CompositeVectorTileLayer.{h,cpp}`
+   (external source registry, raster/hillshade children, `rebuildRenderSteps` splitting the
+   master style-layer order at child slots, `renderSegmented` = one filtered vt pass per
+   group + child draw between, `applyConfig` mapping resolved props to child setters,
+   lifecycle forwarding); `layers/CompositeVectorTileLayer.i`; `friend class
+   CompositeVectorTileLayer;` added to `Layer.h` so the composite can drive child protected
+   virtuals (setComponents/loadData/onDrawFrame/register listeners). All five TUs pass
+   `clang -fsyntax-only`. TODO (needs a real build/device): runtime verify slot ordering,
+   per-frame opacity/exaggeration, zoom/nuti visibility; illumination-direction mapping;
+   interaction of the composite's own rendererLayerFilter with segment filters.
+3. **Merged vector + contour** (B.1 rebuild path): `#contour` styled by master CSS;
+   optional contour config symbolizer for datasource params.
+4. **Terrain** (`onDrawFrame3D`): children drape correctly; **on-device validation**
+   (emulator ≠ device for depth — per prior terrain rounds).
+5. **SWIG + demo + docs** (C, D): Android demo style with all three source kinds and a
+   nuti toggle slider.
+6. **Single-pass segmented renderer** (perf, see open point 5): give `TileRenderer` /
+   `vt::GLTileRenderer` the ability to draw several disjoint style-layer filter ranges,
+   with the external children interleaved, inside **one** `startFrame`/`endFrame` instead
+   of N+1 full passes. Keep it behind a toggle on `CompositeVectorTileLayer` (e.g.
+   `setSinglePassRenderingEnabled(bool)`, default off initially) so the N+1-pass path and
+   the single-pass path can be A/B compared on device before picking the default. Scope to
+   this layer only (no change to plain `VectorTileLayer` behavior).
+
+## Open points (leaning defaults)
+
+1. Placement is by the style **project JSON `layers` array** (order + visibility), not by
+   CSS first-reference. An external source is drawn only if its name is listed there;
+   registered-but-unlisted → **skip + warn**. The `#name { … }` CSS block supplies the
+   per-source settings. (`loadMapProject` reads `layers`, CartoCSSMapLoader.cpp:86.)
+2. Config value plumbing → **typed switch** in `evaluatePropertyValue`/`applyConfig`
+   (safer than a generic map across the SWIG bridge).
+3. Segmented label placement: the group filter must include a slot-group's label layers so
+   `VTLabelPlacementWorker` still culls per group — **verify no cross-group label loss**.
+4. Nuti-driven **reorder** unsupported: order is static per style; nuti drives properties
+   and visibility only. Documented limitation.
+5. Perf: N slots ⇒ N+1 master vt passes/frame over the same GPU tiles. Fine for small N.
+   Milestone 6 adds an optional single-pass segmented renderer (toggle, this layer only)
+   to A/B compare against the N+1-pass path and choose the default on device.
+6. Exact `mvt::Map`/`Layer`/`Style`/`Rule` getter names (`getLayer`, `getStyle`,
+   `getRules`, `getMinZoom`, `getFilter`) to be confirmed/added in A.4.
+```

--- a/docs/composite-vector-tile-layer-plan.md
+++ b/docs/composite-vector-tile-layer-plan.md
@@ -666,6 +666,28 @@ layer.removeExternalDataSource("satellite");         // dynamic remove
 
 ---
 
+## Final rendering architecture (after device testing)
+
+The `rendererLayerFilter` is applied at **tile-build time** (`GLTileRenderer::setVisibleTiles`),
+not per draw call, so a single renderer cannot be re-filtered per frame. The layer therefore
+renders **one stable-filtered layer per style-layer group**:
+
+- Group 0 (style layers before the first external slot) renders on the composite itself.
+- Each later group renders on an internal `VectorTileLayer` over the base source with a fixed
+  filter. Empty intermediate groups create no layer (and empty filters use a true never-match
+  `[^\s\S]`, because `regex_match` full-matches `""` — the per-tile background layer's name — so
+  a naive empty filter would paint the opaque map background over earlier groups).
+- Each external source is a child at its named slot: raster → `RasterTileLayer`, hillshade →
+  `HillshadeRasterTileLayer`, vector/contour → its own `VectorTileLayer` over its own source
+  (master decoder, filtered to its layer name, carrying its `MaxOverzoomLevel`). Vector children
+  are **not merged**, so e.g. contours overzoom (z13+ from z12 DEM) via the child layer.
+- Draw order per frame: group 0, then the draw items in style order (child / group / child ...),
+  pure painter order (consistent with the terrain depth model). Raster/hillshade children gate on
+  their config symbolizer's zoom/nuti visibility; vector children draw always (zoom-filtered by
+  their own decode).
+
+Cost: one vt **decode per group + per vector child**; share network with a cache on the source.
+
 ## Milestones
 
 1. **[DONE]** libs-carto config symbolizers (A.1–A.3) + `resolveLayerConfig` (A.4).
@@ -696,8 +718,11 @@ layer.removeExternalDataSource("satellite");         // dynamic remove
    per-source change tracking to avoid setter→reload loops) applies `ContourConfigSymbolizer`
    values (`contour-base-interval`/`resolution`/`min-visible-zoom`/`simplify-tolerance`,
    nuti-aware, evaluated at a neutral zoom) to a `ContourTileDataSource`. Compiles.
-4. **Terrain** (`onDrawFrame3D`): children drape correctly; **on-device validation**
-   (emulator ≠ device for depth — per prior terrain rounds).
+4. **Terrain** (`onDrawFrame3D`): renderComposite already forwards `onDrawFrame3D` to group 0,
+   the internal group layers and the external children in painter order (the terrain depth model
+   is cross-layer painter order, so this should hold). NEEDS on-device validation: enable terrain
+   in the demo (TerrainOptions on Options) alongside `addCompositeMap`, without the separate
+   `addTerrain` hillshade layer. Watch for depth/see-through between groups (emulator vs device).
 5. **[DEMO PREPPED]** SWIG + demo (C, D). `addCompositeMap(dataPath)` added to
    `SecondFragment.java` (uncommitted, per the never-commit-SecondFragment rule): a
    self-contained CartoCSS over the OpenMapTiles schema (openfreemap) with `#hillshade`

--- a/docs/composite-vector-tile-layer-plan.md
+++ b/docs/composite-vector-tile-layer-plan.md
@@ -698,8 +698,30 @@ layer.removeExternalDataSource("satellite");         // dynamic remove
    nuti-aware, evaluated at a neutral zoom) to a `ContourTileDataSource`. Compiles.
 4. **Terrain** (`onDrawFrame3D`): children drape correctly; **on-device validation**
    (emulator ≠ device for depth — per prior terrain rounds).
-5. **SWIG + demo + docs** (C, D): Android demo style with all three source kinds and a
-   nuti toggle slider.
+5. **[DEMO PREPPED]** SWIG + demo (C, D). `addCompositeMap(dataPath)` added to
+   `SecondFragment.java` (uncommitted, per the never-commit-SecondFragment rule): a
+   self-contained CartoCSS over the OpenMapTiles schema (openfreemap) with `#hillshade`
+   (zoom-ramped exaggeration), `#satellite` (raster, faint, z>=13) and `#contour`
+   (line + `contour-base-interval`) woven by first-reference order; hillshade decoder
+   resolved from the DEM `encoding`; contour merged. Build steps below. Runtime verify +
+   nuti (needs a project-bundle style) still pending on device.
+
+### Build / run the demo
+
+```sh
+# 1. Regenerate SWIG proxies (gradle does NOT run swig)
+cd scripts && python3 swigpp-java.py \
+  --profile "standard+valhalla+geocoding+routing+packagemanager" \
+  --swig /Volumes/dev/carto/mobile-swig/swig
+# 2. Build the native libs + APK
+cd scripts/android-dev && ./gradlew :app:assembleDebug -x lint
+# 3. Install; the demo entry is proceedWithSdCard -> addCompositeMap.
+#    To go back to the normal map, restore addMap/addTerrain in proceedWithSdCard.
+```
+
+Expected: base fills (water/landcover) → hillshade shading → faint satellite (z>=13) →
+roads → buildings + contour lines (z>=12). Panning/zooming should keep the hillshade under
+the roads; exaggeration should increase with zoom.
 6. **Single-pass segmented renderer** (perf, see open point 5): give `TileRenderer` /
    `vt::GLTileRenderer` the ability to draw several disjoint style-layer filter ranges,
    with the external children interleaved, inside **one** `startFrame`/`endFrame` instead

--- a/docs/composite-vector-tile-layer-plan.md
+++ b/docs/composite-vector-tile-layer-plan.md
@@ -764,6 +764,11 @@ the roads; exaggeration should increase with zoom.
    terrain history shows emulator passes do not guarantee device correctness) - do not merge from
    a headless/emulator-only check.
 
+**See [composite-vector-tile-layer-config.md](composite-vector-tile-layer-config.md)** for the
+full style configuration reference (all `raster-*`/`hillshade-*`/`contour-*` properties, smooth
+vs per-zoom-level timing, `[view::zoom]`/interpolation syntax, and a self-contained in-memory
+nuti-bundle demo).
+
 **nuti-parameter visibility** works today with **project-bundle styles** (a zip/asset package whose
 project JSON declares `nutiparameters`, e.g. the app's osm.zip): `resolveLayerConfig` evaluates
 `[nuti::x=...]` predicates against the decoder's nuti value map, and `decoder.setStyleParameter`

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/ui/main/SecondFragment.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/ui/main/SecondFragment.java
@@ -60,6 +60,8 @@ import com.carto.geometry.PolygonGeometry;
 import com.carto.geometry.VectorTileFeatureCollection;
 import com.carto.graphics.Color;
 import com.carto.layers.HillshadeMethod;
+import com.carto.layers.CompositeVectorTileLayer;
+import com.carto.layers.CompositeSourceType;
 import com.carto.layers.CustomRasterTileLayer;
 import com.carto.layers.HillshadeRasterTileLayer;
 import com.carto.layers.RasterTileFilterMode;
@@ -690,6 +692,181 @@ public class SecondFragment extends Fragment {
 //        dataSource.add(sourceWorld);
 //        mainMapLayer  = new RasterTileLayer(sourceHTTP);
     }
+    // ---------------------------------------------------------------------------------------------
+    // CompositeVectorTileLayer demo: one vector-tile layer that weaves external sources (hillshade,
+    // raster, contour) into the master style's layer order. Placement of each external source is
+    // the position of its '#name' first-reference in the CartoCSS below; per-source settings come
+    // from the matching '#name { ... }' block, with zoom-dependent expressions.
+    //
+    // Uses a self-contained CartoCSS over the OpenMapTiles schema (openfreemap) so it does not
+    // depend on osm.zip internals. Text is omitted to avoid needing a font asset package.
+    // NOTE: nuti:: parameters need a project-bundle style (loadMapProject) - a raw CartoCSS string
+    // cannot declare them - so this demo uses zoom-based visibility/config only.
+    // ---------------------------------------------------------------------------------------------
+    CompositeVectorTileLayer compositeLayer;
+    void addCompositeMap(String dataPath) {
+        // Master vector source: OpenMapTiles vector tiles.
+        HTTPTileDataSource baseSource = new HTTPTileDataSource(0, 14, "https://tiles.openfreemap.org/planet/latest/{z}/{x}/{y}.pbf");
+        StringMap headers = new StringMap();
+        headers.set("User-Agent", "AlpiMaps/1.4 (contact: contact@akylas.fr)");
+//        baseSource.setHTTPHeaders(headers);
+        PersistentCacheTileDataSource baseSourceCached = new PersistentCacheTileDataSource(baseSource, getContext().getExternalFilesDir(null) + "/openfreemap_vect.db");
+
+        // First-reference order = slot order: water, landcover, HILLSHADE, SATELLITE,
+        // transportation, building, CONTOUR.
+        String css = String.join("\n",
+            "Map { background-color: #eef2f0; }",
+            "#water { polygon-fill: #9cc3e0; }",
+            "#landcover { polygon-fill: #dbe8cc; }",
+            // hillshade woven above land/water fills, below roads; exaggeration ramps with zoom.
+            "#hillshade[zoom>=4][zoom<=16] {",
+            "  hillshade-opacity: linear([view::zoom], (11, 0.6), (12, 1));",
+            "  hillshade-exaggeration: linear([view::zoom], (11, 0.6), (12, 1.4));",
+            "  hillshade-illumination-direction: 365;",
+            "  hillshade-shadow-color: #103040;",
+            "}",
+                "#satellite[zoom>=13] { raster-opacity: 0.55; raster-comp-op: src-over; }",
+                "#contour[zoom>=5] {",
+                "  line-color: #9a5a12; line-width: 0.8; line-opacity: 0.7;",
+                "  contour-base-interval: 20;",
+                "}",
+            // satellite raster overlay, faint, only high zoom.
+            "#transportation { line-color: #ffffff; line-width: 1.2; }",
+            "#transportation['class'='motorway'] { line-color: #e27d60; line-width: 3; }",
+            "#transportation['class'='primary'] { line-color: #f4c06a; line-width: 2; }",
+            "#building[zoom>=14] { polygon-fill: #d9cfc4; }"
+            // contour lines: merged vector source, styled with normal line symbolizer; the
+            // contour-base-interval config drives the ContourTileDataSource generation.
+
+        );
+        MBVectorTileDecoder styleDecoder = new MBVectorTileDecoder(new CartoCSSStyleSet(css));
+
+        compositeLayer = new CompositeVectorTileLayer(baseSourceCached, styleDecoder);
+
+        // Shared terrarium-encoded DEM for both hillshade and contours (fetched once).
+        HTTPTileDataSource demSource = new HTTPTileDataSource(1, 12, "https://tiles.mapterhorn.com/{z}/{x}/{y}.webp");
+        demSource.setEncoding("terrarium");
+        PersistentCacheTileDataSource cachedDem = new PersistentCacheTileDataSource(demSource, getContext().getExternalFilesDir(null) + "/mapterhorn.db");
+
+        // contour: merged into the master source and styled by '#contour'.
+        ContourTileDataSource contour = new ContourTileDataSource(cachedDem);
+        contour.setMinVisibleZoom(5);
+        contour.setMaxOverzoomLevel(15);
+//        compositeLayer.addVectorDataSource("contour", contour);
+        // hillshade: decoder resolved from the DEM source 'encoding' (terrarium) - no decoder arg.
+        compositeLayer.addExternalDataSource("hillshade", cachedDem, CompositeSourceType.COMPOSITE_SOURCE_TYPE_HILLSHADE);
+        // satellite: a raster source drawn at the '#satellite' slot with the style opacity.
+        HTTPTileDataSource satSource = new HTTPTileDataSource(0, 19, "https://tile.openstreetmap.org/{z}/{x}/{y}.png");
+        satSource.setHTTPHeaders(headers);
+        PersistentCacheTileDataSource cachedSat = new PersistentCacheTileDataSource(satSource, getContext().getExternalFilesDir(null) + "/openstreetmap.db");
+//        compositeLayer.addExternalDataSource("satellite", cachedSat, CompositeSourceType.COMPOSITE_SOURCE_TYPE_RASTER);
+
+        mapView.getLayers().add(compositeLayer);
+
+        // 3D terrain. The decoder is resolved from the data source "encoding" setting
+        // (delegated through the cache wrapper); passing it explicitly works as well.
+        terrainOptions = new com.carto.components.TerrainOptions(cachedDem, new TerrariumElevationDataDecoder());
+        terrainOptions.setExaggeration(1.0f);
+        terrainOptions.setMeshResolution(64);
+//        terrainOptions.set
+        // Optional: cap terrain LOD tile detail at what flat rendering would show
+        // (offset 0), to hide LOD rings if the style renders differently at different
+        // tile zoom levels. Disabled: the LOD rings turned out not to be the cause of
+        // the washed-out alpine faces (style/hillshade appearance).
+        //terrainOptions.setMaxTileZoomOffset(0);
+//        terrainOptions.setBackgroundColor(new Color((short) 255, (short)0,(short)0,(short)255));
+//        terrainOptions.setRegularGridEnabled(true);
+        terrainOptions.setPainterOrderDepthEnabled(true);
+        mapView.getOptions().setTerrainOptions(terrainOptions);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // CompositeVectorTileLayer + nuti parameter demo.
+    // nuti parameters must be declared in a project-bundle style (raw CartoCSS strings cannot declare
+    // them). Here the style is built in-memory (project.json + style.mss zipped) so no external file
+    // is needed. The project declares a boolean nuti parameter 'show_relief'; the hillshade slot is
+    // gated by #hillshade[nuti::show_relief=true]. A repeating handler flips the parameter every few
+    // seconds via decoder.setStyleParameter to demonstrate runtime, user-setting-driven visibility.
+    // ---------------------------------------------------------------------------------------------
+    MBVectorTileDecoder nutiDecoder;
+    boolean nutiReliefOn = true;
+    void addCompositeMapNuti(String dataPath) {
+        // Master vector source (OpenMapTiles), cached so all group sub-layers share one fetch.
+        HTTPTileDataSource baseSource = new HTTPTileDataSource(0, 14, "https://tiles.openfreemap.org/planet/latest/{z}/{x}/{y}.pbf");
+        PersistentCacheTileDataSource baseSourceCached = new PersistentCacheTileDataSource(baseSource, getContext().getExternalFilesDir(null) + "/openfreemap_vect.db");
+
+        // project.json: 'layers' is TOP->BOTTOM (reversed into draw order), plus the nuti parameter.
+        String projectJson = String.join("\n",
+            "{",
+            "  \"styles\": [\"style.mss\"],",
+            "  \"layers\": [\"contour\", \"building\", \"transportation\", \"satellite\", \"hillshade\", \"landcover\", \"water\"],",
+            "  \"nutiparameters\": { \"show_relief\": { \"default\": true } }",
+            "}");
+        String mss = String.join("\n",
+            "Map { background-color: #eef2f0; }",
+            "#water { polygon-fill: #9cc3e0; }",
+            "#landcover { polygon-fill: #dbe8cc; }",
+            // hillshade only when the 'show_relief' user setting is on
+            "#hillshade['nuti::show_relief'=true][zoom>=4] {",
+            "  hillshade-opacity: linear([view::zoom], (4, 0.5), (12, 0.9));",
+            "  hillshade-exaggeration: linear([view::zoom], (4, 0.6), (12, 1.4));",
+            "  hillshade-illumination-direction: 315;",
+            "  hillshade-shadow-color: #103040;",
+            "}",
+            "#satellite[zoom>=13] { raster-opacity: 0.45; }",
+            "#transportation { line-color: #ffffff; line-width: 1.2; }",
+            "#transportation['class'='motorway'] { line-color: #e27d60; line-width: 3; }",
+            "#building[zoom>=14] { polygon-fill: #d9cfc4; }",
+            "#contour[zoom>=12] { line-color: #9a5a12; line-width: 0.8; line-opacity: 0.7; }");
+
+        MBVectorTileDecoder styleDecoder = null;
+        try {
+            java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+            java.util.zip.ZipOutputStream zos = new java.util.zip.ZipOutputStream(bos);
+            String[][] entries = new String[][] { { "project.json", projectJson }, { "style.mss", mss } };
+            for (String[] entry : entries) {
+                zos.putNextEntry(new java.util.zip.ZipEntry(entry[0]));
+                zos.write(entry[1].getBytes("UTF-8"));
+                zos.closeEntry();
+            }
+            zos.close();
+            CompiledStyleSet styleSet = new CompiledStyleSet(new ZippedAssetPackage(new com.carto.core.BinaryData(bos.toByteArray())));
+            styleDecoder = new MBVectorTileDecoder(styleSet);
+        } catch (java.io.IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        nutiDecoder = styleDecoder;
+
+        compositeLayer = new CompositeVectorTileLayer(baseSourceCached, styleDecoder);
+
+        // Shared terrarium DEM for hillshade + contours.
+        HTTPTileDataSource demSource = new HTTPTileDataSource(1, 12, "https://tiles.mapterhorn.com/{z}/{x}/{y}.webp");
+        demSource.setEncoding("terrarium");
+        PersistentCacheTileDataSource cachedDem = new PersistentCacheTileDataSource(demSource, getContext().getExternalFilesDir(null) + "/mapterhorn.db");
+
+        compositeLayer.addExternalDataSource("hillshade", cachedDem, CompositeSourceType.COMPOSITE_SOURCE_TYPE_HILLSHADE);
+
+        ContourTileDataSource contour = new ContourTileDataSource(cachedDem);
+        contour.setMinVisibleZoom(12);
+        contour.setMaxOverzoomLevel(15);
+        compositeLayer.addVectorDataSource("contour", contour);
+
+        mapView.getLayers().add(compositeLayer);
+
+        // Demo: flip the 'show_relief' user setting every 3s so the hillshade fades in/out live.
+        final android.os.Handler handler = new android.os.Handler(android.os.Looper.getMainLooper());
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                nutiReliefOn = !nutiReliefOn;
+                nutiDecoder.setStyleParameter("show_relief", Boolean.toString(nutiReliefOn));
+                Log.d(TAG, "nuti show_relief=" + nutiReliefOn);
+                handler.postDelayed(this, 3000);
+            }
+        }, 3000);
+    }
+
     void addRoutes(String dataPath) {
         MultiTileDataSource  dataSource = new MultiTileDataSource();
         MBTilesTileDataSource sourceFrance = null;
@@ -727,8 +904,11 @@ public class SecondFragment extends Fragment {
         String dataPath = Paths.get(externalPath.getAbsolutePath(), "../../../../alpimaps_mbtiles").normalize().toString();
 
 
-        addMap(dataPath);
-        addTerrain(view, dataPath);
+        // --- CompositeVectorTileLayer demo (2D). Comment this and restore addMap/addTerrain to go back. ---
+        addCompositeMapNuti(dataPath); // nuti-parameter demo: relief toggles every 3s
+//        addCompositeMap(dataPath);
+//        addMap(dataPath);
+//        addTerrain(view, dataPath);
 //        addRoutes(dataPath);
 //        addHillshadeLayer(view, dataPath);
 
@@ -1090,6 +1270,7 @@ public class SecondFragment extends Fragment {
         options.setRestrictedPanning(true);
         options.setSeamlessPanning(true);
         options.setRotatable(true);
+        options.setTiltRange(new MapRange(10, 90));
 //        options.setTileThreadPoolSize(1);
 
 //        options.setRenderProjectionMode(RenderProjectionMode.RENDER_PROJECTION_MODE_SPHERICAL);


### PR DESCRIPTION
A `VectorTileLayer` that weaves named external data sources (raster, hillshade, extra
vector / contour) into a master CartoCSS style's layer order. Each source is placed at the
slot of a matching layer name and configured from a `#name { … }` block, including zoom- and
nuti-parameter-dependent expressions.

Pairs with libs-carto (submodule) PR farfromrefug/mobile-carto-libs#5, which adds the
config symbolizers. The submodule pointer is bumped in this branch.

## What it does
- `addExternalDataSource(name, source, type[, elevationDecoder])` / `addVectorDataSource` /
  `removeExternalDataSource` — dynamic. Types: raster (`RasterTileLayer`), hillshade
  (`HillshadeRasterTileLayer`, decoder resolved from the DEM `encoding`), vector/contour (own
  `VectorTileLayer` over its own source, master-styled, filtered to its layer name, overzooming
  independently via its `MaxOverzoomLevel`).
- CartoCSS config: `raster-opacity`, `hillshade-exaggeration`/`-illumination-direction`/…,
  `contour-base-interval`/…, evaluated per frame. `[view::zoom]` + `nuti::` supported.

## How it renders
The `rendererLayerFilter` is a tile-build-time filter, so a single renderer can't be re-filtered
per frame. Each style-layer group therefore renders on its own stable-filtered layer (group 0 on
this layer; later groups on internal `VectorTileLayer`s over the base source), with the external
children drawn between in painter order. Works in 2D and 3D terrain. The style background is drawn
once by the bottom group.

Also adds `HillshadeRasterTileLayer::get/setExaggeration` — a per-frame relief factor (shader
uniform, no re-decode, default 1.0) so `hillshade-exaggeration` animates smoothly.

## Docs
- `docs/composite-vector-tile-layer-config.md` — full style config reference (all properties,
  smooth vs per-zoom-level timing, `[view::zoom]`/interpolation syntax, in-memory nuti bundle).
- `docs/composite-vector-tile-layer-plan.md` — design, render architecture, follow-ups.

## Demo
`scripts/android-dev` `SecondFragment.addCompositeMap` / `addCompositeMapNuti` — device-verified
(2D, 3D terrain, background, zoom config, contour overzoom, nuti toggle).

## Known / follow-ups
- Master style is decoded once per style-layer group (groups = external slots + 1). A single-pass
  renderer (one decode) is scoped as a documented follow-up (needs on-device validation).
- `raster-comp-op` parsed but not yet applied.
- SWIG proxies must be regenerated (`swigpp-*.py`); new API `CompositeVectorTileLayer` +
  `HillshadeRasterTileLayer.Exaggeration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)