### PR TITLE
feat(layers): single-pass rendering for CompositeVectorTileLayer

### DIFF
--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -3,6 +3,7 @@
 #include "layers/RasterTileLayer.h"
 #include "layers/HillshadeRasterTileLayer.h"
 #include "vectortiles/MBVectorTileDecoder.h"
+#include "renderers/TileRenderer.h"
 #include "rastertiles/ElevationDecoder.h"
 #include "rastertiles/TerrariumElevationDataDecoder.h"
 #include "rastertiles/MapBoxElevationDataDecoder.h"
@@ -16,6 +17,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <variant>
 
 #include <mapnikvt/Value.h>
@@ -189,8 +191,15 @@ namespace carto {
     }
 
     void CompositeVectorTileLayer::setSinglePassRenderingEnabled(bool enabled) {
-        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
-        _singlePassRenderingEnabled = enabled;
+        {
+            std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+            if (_singlePassRenderingEnabled == enabled) {
+                return;
+            }
+            _singlePassRenderingEnabled = enabled;
+            rebuildDrawItems(); // switch between per-group layers and single-pass segments
+        }
+        refresh();
     }
 
     std::shared_ptr<ElevationDecoder> CompositeVectorTileLayer::resolveElevationDecoder(const std::shared_ptr<TileDataSource>& dataSource) {
@@ -288,6 +297,14 @@ namespace carto {
             if (s.childLayer) {
                 applyExternalChildZoomRange(s);
             }
+        }
+
+        _singlePassSegments.clear();
+        if (_singlePassRenderingEnabled) {
+            // Single-pass: no per-group layers; this layer renders all groups via layer-index ranges.
+            VectorTileLayer::setRendererLayerFilter(""); // no build-time filter - the range gate selects
+            rebuildSinglePassSegments(order);
+            return;
         }
 
         auto isChildSlot = [&](const std::string& layerName) {
@@ -538,13 +555,38 @@ namespace carto {
         }
     }
 
-    bool CompositeVectorTileLayer::renderComposite(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain) {
-        auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
+    bool CompositeVectorTileLayer::drawExternalChild(const std::string& slot, float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain) {
+        const ExternalSource* source = findExternalSource(slot);
+        if (!source || !source->childLayer) {
+            return false;
+        }
+        bool visible = true;
+        // Raster/hillshade children are gated by their config symbolizer's zoom/nuti visibility.
+        // Vector children have no config symbolizer (they are styled by normal line/text rules,
+        // which the child's own decode already zoom-filters), so they always draw.
+        if (source->type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR) {
+            if (auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder())) {
+                mvt::ResolvedLayerConfig config = decoder->resolveLayerConfig(slot, viewState.getZoom());
+                applyConfig(*source, config, viewState);
+                visible = config.visible;
+            }
+        }
+        if (!visible) {
+            return false;
+        }
+        return terrain ? source->childLayer->onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
+                       : source->childLayer->onDrawFrame(deltaSeconds, billboardSorter, viewState);
+    }
 
+    bool CompositeVectorTileLayer::renderComposite(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain) {
         std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
 
-        // Group 0 renders on this layer itself (with the group-0 rendererLayerFilter set in
-        // rebuildDrawItems). When there are no external child slots, this draws everything.
+        if (_singlePassRenderingEnabled) {
+            return renderSinglePass(deltaSeconds, billboardSorter, viewState, terrain);
+        }
+
+        // Multi-layer: group 0 renders on this layer itself (with the group-0 rendererLayerFilter set
+        // in rebuildDrawItems), later groups on internal layers, external children between.
         bool refresh = terrain ? VectorTileLayer::onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
                                : VectorTileLayer::onDrawFrame(deltaSeconds, billboardSorter, viewState);
 
@@ -556,25 +598,67 @@ namespace carto {
                 }
                 continue;
             }
-            const ExternalSource* source = findExternalSource(item.slot);
-            if (!source || !source->childLayer) {
-                continue;
-            }
-            bool visible = true;
-            // Raster/hillshade children are gated by their config symbolizer's zoom/nuti visibility.
-            // Vector children have no config symbolizer (they are styled by normal line/text rules,
-            // which the child's own decode already zoom-filters), so they always draw.
-            if (source->type != CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR && decoder) {
-                mvt::ResolvedLayerConfig config = decoder->resolveLayerConfig(item.slot, viewState.getZoom());
-                applyConfig(*source, config, viewState);
-                visible = config.visible;
-            }
-            if (visible) {
-                refresh = (terrain ? source->childLayer->onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
-                                   : source->childLayer->onDrawFrame(deltaSeconds, billboardSorter, viewState)) || refresh;
-            }
+            refresh = drawExternalChild(item.slot, deltaSeconds, billboardSorter, viewState, terrain) || refresh;
         }
         return refresh;
+    }
+
+    bool CompositeVectorTileLayer::renderSinglePass(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain) {
+        // Caller holds _sourceMutex. This layer decodes once and draws each segment as a layer-index
+        // range on its own renderer (the render-time gate), with external children between. Labels are
+        // rendered once, on the last segment, on top (this layer's labelRenderOrder is hidden on the
+        // other segments). The frame delta is passed only to the first segment so blend/animation state
+        // advances once per frame rather than once per segment.
+        if (_singlePassSegments.empty()) {
+            return terrain ? VectorTileLayer::onDrawFrame3D(deltaSeconds, billboardSorter, viewState)
+                           : VectorTileLayer::onDrawFrame(deltaSeconds, billboardSorter, viewState);
+        }
+
+        VectorTileRenderOrder::VectorTileRenderOrder savedLabelOrder = getLabelRenderOrder();
+        bool refresh = false;
+        for (std::size_t i = 0; i < _singlePassSegments.size(); i++) {
+            const SinglePassSegment& segment = _singlePassSegments[i];
+            bool lastSegment = (i + 1 == _singlePassSegments.size());
+
+            _tileRenderer->setRendererLayerIndexRange(std::make_pair(segment.loIndex, segment.hiIndex));
+            setLabelRenderOrder(lastSegment ? savedLabelOrder : VectorTileRenderOrder::VECTOR_TILE_RENDER_ORDER_HIDDEN);
+
+            float segmentDelta = (i == 0) ? deltaSeconds : 0.0f;
+            refresh = (terrain ? VectorTileLayer::onDrawFrame3D(segmentDelta, billboardSorter, viewState)
+                               : VectorTileLayer::onDrawFrame(segmentDelta, billboardSorter, viewState)) || refresh;
+
+            if (!segment.childSlot.empty()) {
+                refresh = drawExternalChild(segment.childSlot, deltaSeconds, billboardSorter, viewState, terrain) || refresh;
+            }
+        }
+        _tileRenderer->setRendererLayerIndexRange(std::nullopt);
+        setLabelRenderOrder(savedLabelOrder);
+        return refresh;
+    }
+
+    void CompositeVectorTileLayer::rebuildSinglePassSegments(const std::vector<std::string>& order) {
+        // Caller holds _sourceMutex. Style layer at position i has tile layerIndex in
+        // [i*65536, (i+1)*65536) (TileReader: styleLayerIdx = layerNum*65536 + ...). A group covering
+        // positions [a, b) is the layer-index range [a*65536, b*65536); segment 0 starts at INT_MIN so
+        // the empty-named background layer (layerIndex -1) is drawn in the bottom segment.
+        _singlePassSegments.clear();
+
+        std::vector<std::pair<int, std::string> > slots; // (style position, external source name)
+        for (int i = 0; i < static_cast<int>(order.size()); i++) {
+            const ExternalSource* source = findExternalSource(order[i]);
+            if (source && source->childLayer) {
+                slots.emplace_back(i, order[i]);
+            }
+        }
+
+        int lo = std::numeric_limits<int>::min();
+        for (const std::pair<int, std::string>& slot : slots) {
+            int hi = slot.first * 65536;
+            _singlePassSegments.push_back({ lo, hi, slot.second });
+            lo = hi;
+        }
+        // Trailing segment: everything after the last slot; carries the single label pass.
+        _singlePassSegments.push_back({ lo, std::numeric_limits<int>::max(), std::string() });
     }
 
 }

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -79,7 +79,7 @@ namespace carto {
         _externalSources(),
         _drawItems(),
         _lastVectorConfig(),
-        _singlePassRenderingEnabled(false),
+        _singlePassRenderingEnabled(true),
         _componentsSet(false),
         _childOptions(),
         _childMapRenderer(),

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -149,6 +149,16 @@ namespace carto {
                                                // Layer so protected virtuals are reachable via friend
         };
 
+        // Single-pass mode: this layer decodes once and draws each style-layer group as a
+        // layer-index range on its own renderer (render-time gate), with the external children
+        // between and labels rendered once on the last segment. Avoids the per-group decode of the
+        // default multi-layer path. Opt-in via setSinglePassRenderingEnabled.
+        struct SinglePassSegment {
+            int loIndex;           // draw self tile layers with layerIndex in [loIndex, hiIndex)
+            int hiIndex;
+            std::string childSlot; // external child drawn after this segment ("" = none)
+        };
+
         static std::shared_ptr<ElevationDecoder> resolveElevationDecoder(const std::shared_ptr<TileDataSource>& dataSource);
         // includeBackground: also match the empty-named per-tile background layer (only the bottom
         // group 0 should, so the style Map background-color is drawn once at the bottom).
@@ -166,9 +176,13 @@ namespace carto {
         // render thread (from loadData); only re-applies changed values to avoid reload loops.
         void applyVectorSourceConfigs();
         bool renderComposite(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain);
+        bool renderSinglePass(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain);
+        bool drawExternalChild(const std::string& slot, float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain);
+        void rebuildSinglePassSegments(const std::vector<std::string>& order); // fills _singlePassSegments from style order
 
         std::vector<ExternalSource> _externalSources;
         std::vector<DrawItem> _drawItems;
+        std::vector<SinglePassSegment> _singlePassSegments;
         std::map<std::string, std::map<std::string, float> > _lastVectorConfig; // per-source applied contour params
         std::map<std::string, std::map<std::string, float> > _lastChildConfig;  // per-source last-applied decode-affecting values (avoid per-frame re-decode)
         bool _singlePassRenderingEnabled;

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -101,14 +101,16 @@ namespace carto {
         std::vector<std::string> getExternalDataSourceNames() const;
 
         /**
-         * Returns whether single-pass segmented rendering is enabled (Milestone 6, optional).
-         * @return True if single-pass rendering is enabled. The default is false.
+         * Returns whether single-pass rendering is enabled.
+         * @return True if single-pass rendering is enabled. The default is true.
          */
         bool isSinglePassRenderingEnabled() const;
         /**
-         * Sets whether to use the optional single-pass segmented renderer instead of the
-         * default one-vt-pass-per-segment path. Intended for A/B comparison; currently a
-         * no-op placeholder until the single-pass renderer lands.
+         * Sets the rendering strategy. When enabled (the default), the master style is decoded once
+         * and each style-layer group is drawn as a layer-index range on a single renderer, with the
+         * external children interleaved and labels drawn once on top. When disabled, each group is
+         * decoded and rendered by its own internal VectorTileLayer (more decoding, but per-group
+         * label placement). Note: with single-pass, keep this layer's opacity at 1.0.
          * @param enabled True to enable single-pass rendering.
          */
         void setSinglePassRenderingEnabled(bool enabled);

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -52,6 +52,7 @@ namespace carto {
         _normalMapAccentColor(0, 0, 0, 255),
         _normalMapHighlightColor(255, 255, 255, 255),
         _rendererLayerFilter(),
+        _rendererLayerIndexRange(),
         _clickHandlerLayerFilter(),
         _horizontalLayerOffset(0),
         _viewDir(0, 0, 0),
@@ -195,6 +196,11 @@ namespace carto {
         _rendererLayerFilter = filter;
     }
 
+    void TileRenderer::setRendererLayerIndexRange(const std::optional<std::pair<int, int> >& range) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _rendererLayerIndexRange = range;
+    }
+
     void TileRenderer::setClickHandlerLayerFilter(const std::optional<std::regex>& filter) {
         std::lock_guard<std::mutex> lock(_mutex);
         _clickHandlerLayerFilter = filter;
@@ -225,6 +231,7 @@ namespace carto {
         tileRenderer->setLayerBlendingSpeed(_layerBlendingSpeed);
         tileRenderer->setLabelBlendingSpeed(_labelBlendingSpeed);
         tileRenderer->setRendererLayerFilter(_rendererLayerFilter);
+        tileRenderer->setRendererLayerIndexRange(_rendererLayerIndexRange);
 
         // Terrain state: enable depth-based terrain rendering and rebuild tile surfaces
         // when the elevation data changes (new DEM tiles, exaggeration change). The rebuild

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -72,6 +72,9 @@ namespace carto {
         void setHillshadeMethod(int method);
         void setHillshadeExaggeration(float exaggeration);
         void setRendererLayerFilter(const std::optional<std::regex>& filter);
+        // Per-frame layer-index gate: draw only tile layers with layerIndex in [first, second).
+        // nullopt (default) = no effect. Used by CompositeVectorTileLayer single-pass rendering.
+        void setRendererLayerIndexRange(const std::optional<std::pair<int, int> >& range);
         void setClickHandlerLayerFilter(const std::optional<std::regex>& filter);
 
         void offsetLayerHorizontally(double offset);
@@ -122,6 +125,7 @@ namespace carto {
         Color _normalMapContourColor;
         float _normalMapContourWidth = 0.75f; // contour half-width in screen pixels
         std::optional<std::regex> _rendererLayerFilter;
+        std::optional<std::pair<int, int> > _rendererLayerIndexRange;
         std::optional<std::regex> _clickHandlerLayerFilter;
 
         double _horizontalLayerOffset;

--- a/docs/composite-vector-tile-layer-config.md
+++ b/docs/composite-vector-tile-layer-config.md
@@ -202,11 +202,10 @@ config on the next frame.
   nuti-driven changes to them take effect on the next zoom change.
 - **Fonts:** text symbolizers (labels) need a font asset in the style bundle; the raw-string
   demo omits text.
-- **Performance:** by default the master style is decoded once per style-layer group (groups =
-  external slots + 1). Fine for a few slots; wrap shared sources in a cache so network is fetched
-  once. An **experimental single-pass mode** (`layer.setSinglePassRenderingEnabled(true)`) decodes
-  the master style once and draws each group as a layer-index range on one renderer (labels render
-  once on top). It removes the per-group decode but is not yet the default — validate on device
-  (blend timing, label order, mid-frame child draws) before relying on it. Note: with single-pass,
-  the composite's own `opacity` should stay 1.0 (per-segment opacity FBO is not handled).
+- **Performance:** by default the master style is decoded **once** and each style-layer group is
+  drawn as a layer-index range on a single renderer (single-pass), with labels rendered once on top.
+  `setSinglePassRenderingEnabled(false)` switches to the multi-layer path (one internal
+  `VectorTileLayer` per group — more decoding, but per-group label placement). With single-pass keep
+  the composite's own `opacity` at 1.0 (per-segment opacity FBO is not handled), and note that all
+  labels render on top of the interleaved children.
 - **`comp-op` for raster** is not yet applied.

--- a/docs/composite-vector-tile-layer-config.md
+++ b/docs/composite-vector-tile-layer-config.md
@@ -202,7 +202,11 @@ config on the next frame.
   nuti-driven changes to them take effect on the next zoom change.
 - **Fonts:** text symbolizers (labels) need a font asset in the style bundle; the raw-string
   demo omits text.
-- **Performance:** the master style is decoded once per style-layer group (groups = external
-  slots + 1). Fine for a few slots; wrap shared sources in a cache so network is fetched once.
-  A single-pass renderer (one decode) is a documented future optimization.
+- **Performance:** by default the master style is decoded once per style-layer group (groups =
+  external slots + 1). Fine for a few slots; wrap shared sources in a cache so network is fetched
+  once. An **experimental single-pass mode** (`layer.setSinglePassRenderingEnabled(true)`) decodes
+  the master style once and draws each group as a layer-index range on one renderer (labels render
+  once on top). It removes the per-group decode but is not yet the default — validate on device
+  (blend timing, label order, mid-frame child draws) before relying on it. Note: with single-pass,
+  the composite's own `opacity` should stay 1.0 (per-segment opacity FBO is not handled).
 - **`comp-op` for raster** is not yet applied.


### PR DESCRIPTION
Stacked on Akylas/mobile-sdk#19 (retarget to master once that merges). Pairs with libs-carto
(submodule) PR farfromrefug/mobile-carto-libs#6.

Makes `CompositeVectorTileLayer` decode the master style **once** instead of once per style-layer
group. Device-validated; now the default (`setSinglePassRenderingEnabled(false)` restores the
multi-layer path).

## How
- **Render-time layer-index gate** (submodule): `TileRenderer::setRendererLayerIndexRange`, plumbed
  to `GLTileRenderer`, no-op by default.
- The layer decodes once and draws each group as a layer-index range (`position*65536`; bottom
  segment from `INT_MIN` so the background draws) on its own renderer, with external children
  between. **Labels render once**, on the last segment (label order hidden on the others); the frame
  delta is passed only to the first segment so blend/animation advances once per frame.
- `rebuildDrawItems` branches on the toggle; child-draw shared via `drawExternalChild`.

## Notes
- All labels render on top of the interleaved children (single label pass).
- Keep the composite's own `opacity` at 1.0 (per-segment opacity FBO not handled).
- The default can be flipped back per-layer via `setSinglePassRenderingEnabled(false)` for A/B.

Also bundles the smooth per-frame `hillshade-exaggeration` fix and the style config reference doc
carried up from the composite branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)