### PR TITLE
3D terrain: RTT fill draping, depth-model fixes, and zoom perf

### DIFF
--- a/all/modules/components/TerrainOptions.i
+++ b/all/modules/components/TerrainOptions.i
@@ -31,6 +31,7 @@
 %attribute(carto::TerrainOptions, float, SourceDensityDrapeSlack, getSourceDensityDrapeSlack, setSourceDensityDrapeSlack)
 %attribute(carto::TerrainOptions, bool, DrapeFillsEnabled, isDrapeFillsEnabled, setDrapeFillsEnabled)
 %attribute(carto::TerrainOptions, bool, DrapeLinesEnabled, isDrapeLinesEnabled, setDrapeLinesEnabled)
+%attribute(carto::TerrainOptions, float, ElementTerrainSlack, getElementTerrainSlack, setElementTerrainSlack)
 %attribute(carto::TerrainOptions, int, MinZoom, getMinZoom, setMinZoom)
 %attribute(carto::TerrainOptions, int, MaxTileZoomOffset, getMaxTileZoomOffset, setMaxTileZoomOffset)
 %attributeval(carto::TerrainOptions, carto::Color, BackgroundColor, getBackgroundColor, setBackgroundColor)

--- a/all/modules/components/TerrainOptions.i
+++ b/all/modules/components/TerrainOptions.i
@@ -30,6 +30,7 @@
 %attribute(carto::TerrainOptions, bool, SourceDensityDrapingEnabled, isSourceDensityDrapingEnabled, setSourceDensityDrapingEnabled)
 %attribute(carto::TerrainOptions, float, SourceDensityDrapeSlack, getSourceDensityDrapeSlack, setSourceDensityDrapeSlack)
 %attribute(carto::TerrainOptions, bool, DrapeFillsEnabled, isDrapeFillsEnabled, setDrapeFillsEnabled)
+%attribute(carto::TerrainOptions, bool, DrapeLinesEnabled, isDrapeLinesEnabled, setDrapeLinesEnabled)
 %attribute(carto::TerrainOptions, int, MinZoom, getMinZoom, setMinZoom)
 %attribute(carto::TerrainOptions, int, MaxTileZoomOffset, getMaxTileZoomOffset, setMaxTileZoomOffset)
 %attributeval(carto::TerrainOptions, carto::Color, BackgroundColor, getBackgroundColor, setBackgroundColor)

--- a/all/modules/components/TerrainOptions.i
+++ b/all/modules/components/TerrainOptions.i
@@ -27,6 +27,8 @@
 %attribute(carto::TerrainOptions, int, MeshResolution, getMeshResolution, setMeshResolution)
 %attribute(carto::TerrainOptions, bool, RegularGridEnabled, isRegularGridEnabled, setRegularGridEnabled)
 %attribute(carto::TerrainOptions, bool, PainterOrderDepthEnabled, isPainterOrderDepthEnabled, setPainterOrderDepthEnabled)
+%attribute(carto::TerrainOptions, bool, SourceDensityDrapingEnabled, isSourceDensityDrapingEnabled, setSourceDensityDrapingEnabled)
+%attribute(carto::TerrainOptions, float, SourceDensityDrapeSlack, getSourceDensityDrapeSlack, setSourceDensityDrapeSlack)
 %attribute(carto::TerrainOptions, int, MinZoom, getMinZoom, setMinZoom)
 %attribute(carto::TerrainOptions, int, MaxTileZoomOffset, getMaxTileZoomOffset, setMaxTileZoomOffset)
 %attributeval(carto::TerrainOptions, carto::Color, BackgroundColor, getBackgroundColor, setBackgroundColor)

--- a/all/modules/components/TerrainOptions.i
+++ b/all/modules/components/TerrainOptions.i
@@ -29,6 +29,7 @@
 %attribute(carto::TerrainOptions, bool, PainterOrderDepthEnabled, isPainterOrderDepthEnabled, setPainterOrderDepthEnabled)
 %attribute(carto::TerrainOptions, bool, SourceDensityDrapingEnabled, isSourceDensityDrapingEnabled, setSourceDensityDrapingEnabled)
 %attribute(carto::TerrainOptions, float, SourceDensityDrapeSlack, getSourceDensityDrapeSlack, setSourceDensityDrapeSlack)
+%attribute(carto::TerrainOptions, bool, DrapeFillsEnabled, isDrapeFillsEnabled, setDrapeFillsEnabled)
 %attribute(carto::TerrainOptions, int, MinZoom, getMinZoom, setMinZoom)
 %attribute(carto::TerrainOptions, int, MaxTileZoomOffset, getMaxTileZoomOffset, setMaxTileZoomOffset)
 %attributeval(carto::TerrainOptions, carto::Color, BackgroundColor, getBackgroundColor, setBackgroundColor)

--- a/all/modules/components/TerrainOptions.i
+++ b/all/modules/components/TerrainOptions.i
@@ -27,8 +27,6 @@
 %attribute(carto::TerrainOptions, int, MeshResolution, getMeshResolution, setMeshResolution)
 %attribute(carto::TerrainOptions, bool, RegularGridEnabled, isRegularGridEnabled, setRegularGridEnabled)
 %attribute(carto::TerrainOptions, bool, PainterOrderDepthEnabled, isPainterOrderDepthEnabled, setPainterOrderDepthEnabled)
-%attribute(carto::TerrainOptions, bool, SourceDensityDrapingEnabled, isSourceDensityDrapingEnabled, setSourceDensityDrapingEnabled)
-%attribute(carto::TerrainOptions, float, SourceDensityDrapeSlack, getSourceDensityDrapeSlack, setSourceDensityDrapeSlack)
 %attribute(carto::TerrainOptions, bool, DrapeFillsEnabled, isDrapeFillsEnabled, setDrapeFillsEnabled)
 %attribute(carto::TerrainOptions, bool, DrapeLinesEnabled, isDrapeLinesEnabled, setDrapeLinesEnabled)
 %attribute(carto::TerrainOptions, float, ElementTerrainSlack, getElementTerrainSlack, setElementTerrainSlack)

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -22,6 +22,7 @@ namespace carto {
         _sourceDensityDrapingEnabled(false),
         _sourceDensityDrapeSlack(12.0f),
         _drapeFillsEnabled(false),
+        _drapeLinesEnabled(false),
         _minZoom(5),
         _maxTileZoomOffset(100),
         _backgroundColorARGB(0),
@@ -129,6 +130,16 @@ namespace carto {
     void TerrainOptions::setDrapeFillsEnabled(bool enabled) {
         if (_drapeFillsEnabled.exchange(enabled) != enabled) {
             notifyOptionChanged("DrapeFillsEnabled");
+        }
+    }
+
+    bool TerrainOptions::isDrapeLinesEnabled() const {
+        return _drapeLinesEnabled.load();
+    }
+
+    void TerrainOptions::setDrapeLinesEnabled(bool enabled) {
+        if (_drapeLinesEnabled.exchange(enabled) != enabled) {
+            notifyOptionChanged("DrapeLinesEnabled");
         }
     }
 

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -21,6 +21,7 @@ namespace carto {
         _painterOrderDepthEnabled(false),
         _sourceDensityDrapingEnabled(false),
         _sourceDensityDrapeSlack(12.0f),
+        _drapeFillsEnabled(false),
         _minZoom(5),
         _maxTileZoomOffset(100),
         _backgroundColorARGB(0),
@@ -118,6 +119,16 @@ namespace carto {
         float clamped = std::min(256.0f, std::max(0.0f, slack));
         if (_sourceDensityDrapeSlack.exchange(clamped) != clamped) {
             notifyOptionChanged("SourceDensityDrapeSlack");
+        }
+    }
+
+    bool TerrainOptions::isDrapeFillsEnabled() const {
+        return _drapeFillsEnabled.load();
+    }
+
+    void TerrainOptions::setDrapeFillsEnabled(bool enabled) {
+        if (_drapeFillsEnabled.exchange(enabled) != enabled) {
+            notifyOptionChanged("DrapeFillsEnabled");
         }
     }
 

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -19,6 +19,8 @@ namespace carto {
         _meshResolution(32),
         _regularGridEnabled(false),
         _painterOrderDepthEnabled(false),
+        _sourceDensityDrapingEnabled(false),
+        _sourceDensityDrapeSlack(12.0f),
         _minZoom(5),
         _maxTileZoomOffset(100),
         _backgroundColorARGB(0),
@@ -95,6 +97,27 @@ namespace carto {
     void TerrainOptions::setPainterOrderDepthEnabled(bool painterOrderDepthEnabled) {
         if (_painterOrderDepthEnabled.exchange(painterOrderDepthEnabled) != painterOrderDepthEnabled) {
             notifyOptionChanged("PainterOrderDepthEnabled");
+        }
+    }
+
+    bool TerrainOptions::isSourceDensityDrapingEnabled() const {
+        return _sourceDensityDrapingEnabled.load();
+    }
+
+    void TerrainOptions::setSourceDensityDrapingEnabled(bool enabled) {
+        if (_sourceDensityDrapingEnabled.exchange(enabled) != enabled) {
+            notifyOptionChanged("SourceDensityDrapingEnabled");
+        }
+    }
+
+    float TerrainOptions::getSourceDensityDrapeSlack() const {
+        return _sourceDensityDrapeSlack.load();
+    }
+
+    void TerrainOptions::setSourceDensityDrapeSlack(float slack) {
+        float clamped = std::min(256.0f, std::max(0.0f, slack));
+        if (_sourceDensityDrapeSlack.exchange(clamped) != clamped) {
+            notifyOptionChanged("SourceDensityDrapeSlack");
         }
     }
 

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -23,6 +23,7 @@ namespace carto {
         _sourceDensityDrapeSlack(12.0f),
         _drapeFillsEnabled(false),
         _drapeLinesEnabled(false),
+        _elementTerrainSlack(2.0f),
         _minZoom(5),
         _maxTileZoomOffset(100),
         _backgroundColorARGB(0),
@@ -140,6 +141,17 @@ namespace carto {
     void TerrainOptions::setDrapeLinesEnabled(bool enabled) {
         if (_drapeLinesEnabled.exchange(enabled) != enabled) {
             notifyOptionChanged("DrapeLinesEnabled");
+        }
+    }
+
+    float TerrainOptions::getElementTerrainSlack() const {
+        return _elementTerrainSlack.load();
+    }
+
+    void TerrainOptions::setElementTerrainSlack(float slack) {
+        float clamped = std::min(64.0f, std::max(0.0f, slack));
+        if (_elementTerrainSlack.exchange(clamped) != clamped) {
+            notifyOptionChanged("ElementTerrainSlack");
         }
     }
 

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -19,8 +19,6 @@ namespace carto {
         _meshResolution(32),
         _regularGridEnabled(false),
         _painterOrderDepthEnabled(false),
-        _sourceDensityDrapingEnabled(false),
-        _sourceDensityDrapeSlack(12.0f),
         _drapeFillsEnabled(false),
         _drapeLinesEnabled(false),
         _elementTerrainSlack(2.0f),
@@ -100,27 +98,6 @@ namespace carto {
     void TerrainOptions::setPainterOrderDepthEnabled(bool painterOrderDepthEnabled) {
         if (_painterOrderDepthEnabled.exchange(painterOrderDepthEnabled) != painterOrderDepthEnabled) {
             notifyOptionChanged("PainterOrderDepthEnabled");
-        }
-    }
-
-    bool TerrainOptions::isSourceDensityDrapingEnabled() const {
-        return _sourceDensityDrapingEnabled.load();
-    }
-
-    void TerrainOptions::setSourceDensityDrapingEnabled(bool enabled) {
-        if (_sourceDensityDrapingEnabled.exchange(enabled) != enabled) {
-            notifyOptionChanged("SourceDensityDrapingEnabled");
-        }
-    }
-
-    float TerrainOptions::getSourceDensityDrapeSlack() const {
-        return _sourceDensityDrapeSlack.load();
-    }
-
-    void TerrainOptions::setSourceDensityDrapeSlack(float slack) {
-        float clamped = std::min(256.0f, std::max(0.0f, slack));
-        if (_sourceDensityDrapeSlack.exchange(clamped) != clamped) {
-            notifyOptionChanged("SourceDensityDrapeSlack");
         }
     }
 

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -140,43 +140,6 @@ namespace carto {
         void setPainterOrderDepthEnabled(bool painterOrderDepthEnabled);
 
         /**
-         * Returns whether source-density (tangram-style) draping is used.
-         * @return True if draped content is left at source density, false for terrain subdivision. The default is false.
-         */
-        bool isSourceDensityDrapingEnabled() const;
-        /**
-         * Enables or disables source-density draping (experimental, tangram-ng model). When enabled,
-         * draped polygon FILLS are NOT subdivided to follow the terrain surface at tile build time -
-         * they are left at source density and displaced per-vertex by the GPU draping shader. Fills are
-         * the dominant CPU cost of terrain vs flat rendering (a full-tile fill red-green splits to
-         * ~MeshResolution^2 triangles), so skipping their subdivision gives near-flat tile decode speed.
-         * LINES stay subdivided (they are cheap and must hug the terrain closely - contours lie exactly
-         * on the surface). The un-subdivided fills need a lifting depth slack (SourceDensityDrapeSlack)
-         * to clear the fine surface occluder without holes; a larger slack fills holes but lets fills
-         * further behind a ridge shine through. The terrain surface itself stays at MeshResolution (the
-         * shared grid occluder is unaffected). Requires RegularGridEnabled or PainterOrderDepthEnabled.
-         * Only takes effect in GPU draping mode (vertex texture fetch, planar).
-         * @param enabled True to leave draped fills at source density, false to subdivide them.
-         */
-        void setSourceDensityDrapingEnabled(bool enabled);
-
-        /**
-         * Returns the lifting depth slack used for source-density draping.
-         * @return The drape slack in clip units. The default is 12.
-         */
-        float getSourceDensityDrapeSlack() const;
-        /**
-         * Sets the lifting depth slack applied to source-density draped FILLS, in the same clip units
-         * as the internal terrain slack (scaled by tile size and projection depth so it grows with
-         * distance, tracking the chord sag of un-subdivided fills below the surface). Only used when
-         * SourceDensityDrapingEnabled is true; lines are unaffected (they stay subdivided). Increase
-         * until holes over convex terrain/landcover disappear; decrease to reduce fills shining through
-         * behind ridges. Typical range 4..64.
-         * @param slack The new drape slack in clip units (clamped to 0..256).
-         */
-        void setSourceDensityDrapeSlack(float slack);
-
-        /**
          * Returns whether polygon fills are draped as a render-to-texture surface.
          * @return True if fills are baked to a per-tile texture and sampled on the surface. The default is false.
          */
@@ -391,8 +354,6 @@ namespace carto {
         std::atomic<int> _meshResolution;
         std::atomic<bool> _regularGridEnabled;
         std::atomic<bool> _painterOrderDepthEnabled;
-        std::atomic<bool> _sourceDensityDrapingEnabled;
-        std::atomic<float> _sourceDensityDrapeSlack;
         std::atomic<bool> _drapeFillsEnabled;
         std::atomic<bool> _drapeLinesEnabled;
         std::atomic<float> _elementTerrainSlack;

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -210,6 +210,22 @@ namespace carto {
         void setDrapeLinesEnabled(bool enabled);
 
         /**
+         * Returns the painter-order clearance slack applied to draped vector elements.
+         * @return The element terrain slack in clip units. The default is 2.
+         */
+        float getElementTerrainSlack() const;
+        /**
+         * Sets the painter-order clearance slack for draped VectorLayer elements (lines, polygons),
+         * in the same clip units as the internal terrain slack (scaled by tile size, projection depth
+         * and mesh resolution so it tracks the grid cell size). Only used when PainterOrderDepthEnabled
+         * is true. Elements are not lattice-clamped onto the grid surface like tile content, so at low
+         * zoom the coarse grid pokes through them (cracks); increase this until the cracks disappear.
+         * Decrease it if elements behind a ridge shine through. Typical range 0..12.
+         * @param slack The new element terrain slack in clip units (clamped to 0..64).
+         */
+        void setElementTerrainSlack(float slack);
+
+        /**
          * Returns the minimum tile zoom level with 3D terrain.
          * @return The minimum zoom level. The default is 5.
          */
@@ -379,6 +395,7 @@ namespace carto {
         std::atomic<float> _sourceDensityDrapeSlack;
         std::atomic<bool> _drapeFillsEnabled;
         std::atomic<bool> _drapeLinesEnabled;
+        std::atomic<float> _elementTerrainSlack;
         std::atomic<int> _minZoom;
         std::atomic<int> _maxTileZoomOffset;
         std::atomic<int> _backgroundColorARGB;

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -140,6 +140,42 @@ namespace carto {
         void setPainterOrderDepthEnabled(bool painterOrderDepthEnabled);
 
         /**
+         * Returns whether source-density (tangram-style) draping is used.
+         * @return True if draped content is left at source density, false for terrain subdivision. The default is false.
+         */
+        bool isSourceDensityDrapingEnabled() const;
+        /**
+         * Enables or disables source-density draping (experimental, tangram-ng model). When enabled,
+         * draped vector content is NOT subdivided to follow the terrain surface at tile build time -
+         * it is left at its source density and displaced per-vertex by the GPU draping shader, exactly
+         * like tangram. This removes the per-tile red-green tesselation, which is the dominant CPU cost
+         * of terrain vs flat rendering, giving near-flat tile decode speed. The trade-off: content only
+         * follows the terrain at its own vertex resolution (long segments / coarse fills fly straight
+         * over dips instead of hugging), and it needs a lifting depth slack (SourceDensityDrapeSlack) so
+         * the un-subdivided content clears the fine surface occluder without holes; a larger slack fills
+         * holes but lets content further behind a ridge shine through. The terrain surface itself stays
+         * at MeshResolution (the shared grid occluder is unaffected). Requires RegularGridEnabled or
+         * PainterOrderDepthEnabled. Only takes effect in GPU draping mode (vertex texture fetch, planar).
+         * @param enabled True to leave draped content at source density, false to subdivide it.
+         */
+        void setSourceDensityDrapingEnabled(bool enabled);
+
+        /**
+         * Returns the lifting depth slack used for source-density draping.
+         * @return The drape slack in clip units. The default is 12.
+         */
+        float getSourceDensityDrapeSlack() const;
+        /**
+         * Sets the lifting depth slack applied to source-density draped content, in the same clip units
+         * as the internal terrain slack (scaled by tile size and projection depth so it grows with
+         * distance, tracking the chord sag of un-subdivided content below the surface). Only used when
+         * SourceDensityDrapingEnabled is true. Increase until holes over convex terrain disappear;
+         * decrease to reduce content shining through behind ridges. Typical range 4..64.
+         * @param slack The new drape slack in clip units (clamped to 0..256).
+         */
+        void setSourceDensityDrapeSlack(float slack);
+
+        /**
          * Returns the minimum tile zoom level with 3D terrain.
          * @return The minimum zoom level. The default is 5.
          */
@@ -305,6 +341,8 @@ namespace carto {
         std::atomic<int> _meshResolution;
         std::atomic<bool> _regularGridEnabled;
         std::atomic<bool> _painterOrderDepthEnabled;
+        std::atomic<bool> _sourceDensityDrapingEnabled;
+        std::atomic<float> _sourceDensityDrapeSlack;
         std::atomic<int> _minZoom;
         std::atomic<int> _maxTileZoomOffset;
         std::atomic<int> _backgroundColorARGB;

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -177,6 +177,23 @@ namespace carto {
         void setSourceDensityDrapeSlack(float slack);
 
         /**
+         * Returns whether polygon fills are draped as a render-to-texture surface.
+         * @return True if fills are baked to a per-tile texture and sampled on the surface. The default is false.
+         */
+        bool isDrapeFillsEnabled() const;
+        /**
+         * Enables or disables maplibre-style render-to-texture fill draping (experimental, spike). When
+         * enabled, polygon fills are rendered FLAT into a per-tile offscreen texture and then sampled as
+         * the color of the terrain surface mesh, instead of being drawn as displaced geometry. Because the
+         * fills become the surface's texture they follow the terrain exactly - no chord sag, so no holes,
+         * no see-through, and no depth slack - at flat-render (2D) fill cost. Lines/contours and labels are
+         * unaffected (still drawn as sharp geometry on top). Only native (non-overzoomed) fills are draped.
+         * Requires RegularGridEnabled or PainterOrderDepthEnabled and GPU draping mode (planar).
+         * @param enabled True to drape fills as a texture, false to draw them as geometry.
+         */
+        void setDrapeFillsEnabled(bool enabled);
+
+        /**
          * Returns the minimum tile zoom level with 3D terrain.
          * @return The minimum zoom level. The default is 5.
          */
@@ -344,6 +361,7 @@ namespace carto {
         std::atomic<bool> _painterOrderDepthEnabled;
         std::atomic<bool> _sourceDensityDrapingEnabled;
         std::atomic<float> _sourceDensityDrapeSlack;
+        std::atomic<bool> _drapeFillsEnabled;
         std::atomic<int> _minZoom;
         std::atomic<int> _maxTileZoomOffset;
         std::atomic<int> _backgroundColorARGB;

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -146,17 +146,17 @@ namespace carto {
         bool isSourceDensityDrapingEnabled() const;
         /**
          * Enables or disables source-density draping (experimental, tangram-ng model). When enabled,
-         * draped vector content is NOT subdivided to follow the terrain surface at tile build time -
-         * it is left at its source density and displaced per-vertex by the GPU draping shader, exactly
-         * like tangram. This removes the per-tile red-green tesselation, which is the dominant CPU cost
-         * of terrain vs flat rendering, giving near-flat tile decode speed. The trade-off: content only
-         * follows the terrain at its own vertex resolution (long segments / coarse fills fly straight
-         * over dips instead of hugging), and it needs a lifting depth slack (SourceDensityDrapeSlack) so
-         * the un-subdivided content clears the fine surface occluder without holes; a larger slack fills
-         * holes but lets content further behind a ridge shine through. The terrain surface itself stays
-         * at MeshResolution (the shared grid occluder is unaffected). Requires RegularGridEnabled or
-         * PainterOrderDepthEnabled. Only takes effect in GPU draping mode (vertex texture fetch, planar).
-         * @param enabled True to leave draped content at source density, false to subdivide it.
+         * draped polygon FILLS are NOT subdivided to follow the terrain surface at tile build time -
+         * they are left at source density and displaced per-vertex by the GPU draping shader. Fills are
+         * the dominant CPU cost of terrain vs flat rendering (a full-tile fill red-green splits to
+         * ~MeshResolution^2 triangles), so skipping their subdivision gives near-flat tile decode speed.
+         * LINES stay subdivided (they are cheap and must hug the terrain closely - contours lie exactly
+         * on the surface). The un-subdivided fills need a lifting depth slack (SourceDensityDrapeSlack)
+         * to clear the fine surface occluder without holes; a larger slack fills holes but lets fills
+         * further behind a ridge shine through. The terrain surface itself stays at MeshResolution (the
+         * shared grid occluder is unaffected). Requires RegularGridEnabled or PainterOrderDepthEnabled.
+         * Only takes effect in GPU draping mode (vertex texture fetch, planar).
+         * @param enabled True to leave draped fills at source density, false to subdivide them.
          */
         void setSourceDensityDrapingEnabled(bool enabled);
 
@@ -166,11 +166,12 @@ namespace carto {
          */
         float getSourceDensityDrapeSlack() const;
         /**
-         * Sets the lifting depth slack applied to source-density draped content, in the same clip units
+         * Sets the lifting depth slack applied to source-density draped FILLS, in the same clip units
          * as the internal terrain slack (scaled by tile size and projection depth so it grows with
-         * distance, tracking the chord sag of un-subdivided content below the surface). Only used when
-         * SourceDensityDrapingEnabled is true. Increase until holes over convex terrain disappear;
-         * decrease to reduce content shining through behind ridges. Typical range 4..64.
+         * distance, tracking the chord sag of un-subdivided fills below the surface). Only used when
+         * SourceDensityDrapingEnabled is true; lines are unaffected (they stay subdivided). Increase
+         * until holes over convex terrain/landcover disappear; decrease to reduce fills shining through
+         * behind ridges. Typical range 4..64.
          * @param slack The new drape slack in clip units (clamped to 0..256).
          */
         void setSourceDensityDrapeSlack(float slack);

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -194,6 +194,22 @@ namespace carto {
         void setDrapeFillsEnabled(bool enabled);
 
         /**
+         * Returns whether vt tile lines are also draped (in addition to fills).
+         * @return True if tile lines are baked into the drape texture. The default is false.
+         */
+        bool isDrapeLinesEnabled() const;
+        /**
+         * Enables or disables draping of vt tile lines (roads, contours) in addition to fills
+         * (experimental, spike; only has effect when DrapeFillsEnabled is also true). When enabled,
+         * tile lines are baked into the per-tile drape texture and follow the terrain exactly (no
+         * leak, no cracks) - but they become texture-rasterized, so they are softer than sharp
+         * displaced geometry, and their width is approximate (calibrated in the offscreen texture).
+         * When disabled, lines stay sharp displaced geometry drawn on top of the drape surface.
+         * @param enabled True to drape tile lines too, false to keep them as sharp geometry.
+         */
+        void setDrapeLinesEnabled(bool enabled);
+
+        /**
          * Returns the minimum tile zoom level with 3D terrain.
          * @return The minimum zoom level. The default is 5.
          */
@@ -362,6 +378,7 @@ namespace carto {
         std::atomic<bool> _sourceDensityDrapingEnabled;
         std::atomic<float> _sourceDensityDrapeSlack;
         std::atomic<bool> _drapeFillsEnabled;
+        std::atomic<bool> _drapeLinesEnabled;
         std::atomic<int> _minZoom;
         std::atomic<int> _maxTileZoomOffset;
         std::atomic<int> _backgroundColorARGB;

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -265,7 +265,8 @@ namespace carto {
             // stalls fast zooms. Draping fills therefore implies source-density (no fill
             // subdivision), exactly like the tangram source-density mode.
             bool terrainSourceDensity = terrainOptions && (terrainOptions->isSourceDensityDrapingEnabled() || terrainOptions->isDrapeFillsEnabled());
-            if (_terrainOptions.lock() != terrainOptions || _terrainEnabled != terrainEnabled || _terrainExaggeration != terrainExaggeration || _terrainMeshResolution != terrainMeshResolution || _terrainMinZoom != terrainMinZoom || _terrainRegularGrid != terrainRegularGrid || _terrainSourceDensity != terrainSourceDensity) {
+            bool terrainSourceDensityLines = terrainOptions && terrainOptions->isDrapeLinesEnabled();
+            if (_terrainOptions.lock() != terrainOptions || _terrainEnabled != terrainEnabled || _terrainExaggeration != terrainExaggeration || _terrainMeshResolution != terrainMeshResolution || _terrainMinZoom != terrainMinZoom || _terrainRegularGrid != terrainRegularGrid || _terrainSourceDensity != terrainSourceDensity || _terrainSourceDensityLines != terrainSourceDensityLines) {
                 clearTileCaches(true);
                 resetTileTransformer();
                 _terrainOptions = terrainOptions;
@@ -275,6 +276,7 @@ namespace carto {
                 _terrainMinZoom = terrainMinZoom;
                 _terrainRegularGrid = terrainRegularGrid;
                 _terrainSourceDensity = terrainSourceDensity;
+                _terrainSourceDensityLines = terrainSourceDensityLines;
             }
         }
 
@@ -781,7 +783,7 @@ namespace carto {
             }
             else if (auto terrainOptions = options->getTerrainOptions()) {
                 if (terrainOptions->isEnabled()) {
-                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled(), terrainOptions->isSourceDensityDrapingEnabled() || terrainOptions->isDrapeFillsEnabled());
+                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled(), terrainOptions->isSourceDensityDrapingEnabled() || terrainOptions->isDrapeFillsEnabled(), terrainOptions->isDrapeLinesEnabled());
                 }
             }
         }

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -260,7 +260,8 @@ namespace carto {
             int terrainMeshResolution = terrainOptions ? terrainOptions->getMeshResolution() : 0;
             int terrainMinZoom = terrainOptions ? terrainOptions->getMinZoom() : 0;
             bool terrainRegularGrid = terrainOptions && (terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled());
-            if (_terrainOptions.lock() != terrainOptions || _terrainEnabled != terrainEnabled || _terrainExaggeration != terrainExaggeration || _terrainMeshResolution != terrainMeshResolution || _terrainMinZoom != terrainMinZoom || _terrainRegularGrid != terrainRegularGrid) {
+            bool terrainSourceDensity = terrainOptions && terrainOptions->isSourceDensityDrapingEnabled();
+            if (_terrainOptions.lock() != terrainOptions || _terrainEnabled != terrainEnabled || _terrainExaggeration != terrainExaggeration || _terrainMeshResolution != terrainMeshResolution || _terrainMinZoom != terrainMinZoom || _terrainRegularGrid != terrainRegularGrid || _terrainSourceDensity != terrainSourceDensity) {
                 clearTileCaches(true);
                 resetTileTransformer();
                 _terrainOptions = terrainOptions;
@@ -269,6 +270,7 @@ namespace carto {
                 _terrainMeshResolution = terrainMeshResolution;
                 _terrainMinZoom = terrainMinZoom;
                 _terrainRegularGrid = terrainRegularGrid;
+                _terrainSourceDensity = terrainSourceDensity;
             }
         }
 
@@ -775,7 +777,7 @@ namespace carto {
             }
             else if (auto terrainOptions = options->getTerrainOptions()) {
                 if (terrainOptions->isEnabled()) {
-                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled());
+                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled(), terrainOptions->isSourceDensityDrapingEnabled());
                 }
             }
         }

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -260,7 +260,11 @@ namespace carto {
             int terrainMeshResolution = terrainOptions ? terrainOptions->getMeshResolution() : 0;
             int terrainMinZoom = terrainOptions ? terrainOptions->getMinZoom() : 0;
             bool terrainRegularGrid = terrainOptions && (terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled());
-            bool terrainSourceDensity = terrainOptions && terrainOptions->isSourceDensityDrapingEnabled();
+            // Draped fills are baked FLAT into the drape texture, so their terrain subdivision is
+            // wasted work - and the subdivided fill VBOs are uploaded on the render thread, which
+            // stalls fast zooms. Draping fills therefore implies source-density (no fill
+            // subdivision), exactly like the tangram source-density mode.
+            bool terrainSourceDensity = terrainOptions && (terrainOptions->isSourceDensityDrapingEnabled() || terrainOptions->isDrapeFillsEnabled());
             if (_terrainOptions.lock() != terrainOptions || _terrainEnabled != terrainEnabled || _terrainExaggeration != terrainExaggeration || _terrainMeshResolution != terrainMeshResolution || _terrainMinZoom != terrainMinZoom || _terrainRegularGrid != terrainRegularGrid || _terrainSourceDensity != terrainSourceDensity) {
                 clearTileCaches(true);
                 resetTileTransformer();
@@ -777,7 +781,7 @@ namespace carto {
             }
             else if (auto terrainOptions = options->getTerrainOptions()) {
                 if (terrainOptions->isEnabled()) {
-                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled(), terrainOptions->isSourceDensityDrapingEnabled());
+                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled(), terrainOptions->isSourceDensityDrapingEnabled() || terrainOptions->isDrapeFillsEnabled());
                 }
             }
         }

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -264,7 +264,7 @@ namespace carto {
             // wasted work - and the subdivided fill VBOs are uploaded on the render thread, which
             // stalls fast zooms. Draping fills therefore implies source-density (no fill
             // subdivision), exactly like the tangram source-density mode.
-            bool terrainSourceDensity = terrainOptions && (terrainOptions->isSourceDensityDrapingEnabled() || terrainOptions->isDrapeFillsEnabled());
+            bool terrainSourceDensity = terrainOptions && terrainOptions->isDrapeFillsEnabled();
             bool terrainSourceDensityLines = terrainOptions && terrainOptions->isDrapeLinesEnabled();
             if (_terrainOptions.lock() != terrainOptions || _terrainEnabled != terrainEnabled || _terrainExaggeration != terrainExaggeration || _terrainMeshResolution != terrainMeshResolution || _terrainMinZoom != terrainMinZoom || _terrainRegularGrid != terrainRegularGrid || _terrainSourceDensity != terrainSourceDensity || _terrainSourceDensityLines != terrainSourceDensityLines) {
                 clearTileCaches(true);
@@ -783,7 +783,7 @@ namespace carto {
             }
             else if (auto terrainOptions = options->getTerrainOptions()) {
                 if (terrainOptions->isEnabled()) {
-                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled(), terrainOptions->isSourceDensityDrapingEnabled() || terrainOptions->isDrapeFillsEnabled(), terrainOptions->isDrapeLinesEnabled());
+                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled(), terrainOptions->isDrapeFillsEnabled(), terrainOptions->isDrapeLinesEnabled());
                 }
             }
         }

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -456,6 +456,7 @@ namespace carto {
         int _terrainMinZoom = 0;
         bool _terrainRegularGrid = false;
         bool _terrainSourceDensity = false;
+        bool _terrainSourceDensityLines = false;
     };
     
 }

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -455,6 +455,7 @@ namespace carto {
         int _terrainMeshResolution = 0;
         int _terrainMinZoom = 0;
         bool _terrainRegularGrid = false;
+        bool _terrainSourceDensity = false;
     };
     
 }

--- a/all/native/layers/VectorLayer.cpp
+++ b/all/native/layers/VectorLayer.cpp
@@ -182,13 +182,23 @@ namespace carto {
                     if (auto terrainOptions = options->getTerrainOptions()) {
                         if (terrainOptions->isEnabled() && terrainOptions->isPainterOrderDepthEnabled()) {
                             // Painter-order: the vt renderer pushes the terrain surface BACK to
-                            // give draped content clearance, so elements draw at their REAL depth
-                            // (no forward bias/slack). Nothing is pulled towards the viewer, so an
-                            // element can not leak in front of a near ridge; the pushed-back
-                            // surface keeps it above the coincident tile content.
+                            // give draped content clearance. Tile content is lattice-clamped onto
+                            // the grid surface, so the constant push-back suffices for it. Elements
+                            // are NOT lattice-clamped - they sample the full-resolution bilinear
+                            // height field, which over convex/coarse-grid cells rises above the
+                            // rendered grid surface, so the grid pokes through the element (cracks),
+                            // worst at low zoom where the cell is large. A small distance-scaled
+                            // clearance (ElementTerrainSlack) clears that in-cell mismatch; keep it
+                            // as low as possible since, like any clip-space slack, too much lets an
+                            // element behind a ridge shine through.
                             terrainPainterOrder = true;
-                            elementDepthBias = 0.0f;
-                            elementDepthBiasClip = 0.0f;
+                            elementDepthBias = 2.0f / 524288.0f;
+                            float tileSize = static_cast<float>(Const::WORLD_SIZE / std::pow(2.0, std::floor(viewState.getZoom())));
+                            float projScaleZ = static_cast<float>(std::abs(viewState.getProjectionMat()(2, 2)));
+                            float refTileSize = static_cast<float>(Const::WORLD_SIZE / 2048.0);
+                            float slackScale = tileSize * std::min(4.0f, tileSize / refTileSize);
+                            float resolutionRatio = 32.0f / std::max(32, terrainOptions->getMeshResolution());
+                            elementDepthBiasClip = terrainOptions->getElementTerrainSlack() * 0.001f * slackScale * projScaleZ * resolutionRatio * resolutionRatio;
                         } else if (terrainOptions->isEnabled()) {
                             terrainDepthOffset = true;
                             // Element heights are the same bilinear elevation samples the GPU

--- a/all/native/layers/VectorLayer.cpp
+++ b/all/native/layers/VectorLayer.cpp
@@ -181,24 +181,18 @@ namespace carto {
                 if (options->getRenderProjectionMode() == RenderProjectionMode::RENDER_PROJECTION_MODE_PLANAR) {
                     if (auto terrainOptions = options->getTerrainOptions()) {
                         if (terrainOptions->isEnabled() && terrainOptions->isPainterOrderDepthEnabled()) {
-                            // Painter-order: the vt renderer pushes the terrain surface BACK to
-                            // give draped content clearance. Tile content is lattice-clamped onto
-                            // the grid surface, so the constant push-back suffices for it. Elements
-                            // are NOT lattice-clamped - they sample the full-resolution bilinear
-                            // height field, which over convex/coarse-grid cells rises above the
-                            // rendered grid surface, so the grid pokes through the element (cracks),
-                            // worst at low zoom where the cell is large. A small distance-scaled
-                            // clearance (ElementTerrainSlack) clears that in-cell mismatch; keep it
-                            // as low as possible since, like any clip-space slack, too much lets an
-                            // element behind a ridge shine through.
+                            // Painter-order + true-depth terrain occluder: elements are drawn with
+                            // GL_LEQUAL and ZERO forward bias, exactly like the lattice-clamped tile
+                            // content. Elements sit at (bilinear height + small world lift), so they
+                            // pass the depth test where they are at/above the surface and are
+                            // occluded (fail) behind a near ridge. A forward clip bias is what let
+                            // the whole element line shine through terrain at distance - drop it.
+                            // Residual concave cracks are cleared by the world-space height lift
+                            // (TerrainProjectionSurface), which does not grow with distance so it
+                            // can not leak over ridges.
                             terrainPainterOrder = true;
-                            elementDepthBias = 2.0f / 524288.0f;
-                            float tileSize = static_cast<float>(Const::WORLD_SIZE / std::pow(2.0, std::floor(viewState.getZoom())));
-                            float projScaleZ = static_cast<float>(std::abs(viewState.getProjectionMat()(2, 2)));
-                            float refTileSize = static_cast<float>(Const::WORLD_SIZE / 2048.0);
-                            float slackScale = tileSize * std::min(4.0f, tileSize / refTileSize);
-                            float resolutionRatio = 32.0f / std::max(32, terrainOptions->getMeshResolution());
-                            elementDepthBiasClip = terrainOptions->getElementTerrainSlack() * 0.001f * slackScale * projScaleZ * resolutionRatio * resolutionRatio;
+                            elementDepthBias = 0.0f;
+                            elementDepthBiasClip = 0.0f;
                         } else if (terrainOptions->isEnabled()) {
                             terrainDepthOffset = true;
                             // Element heights are the same bilinear elevation samples the GPU
@@ -248,12 +242,19 @@ namespace carto {
                 glEnable(GL_POLYGON_OFFSET_FILL);
                 glPolygonOffset(0.0f, -2.0f);
             }
+            if (terrainPainterOrder) {
+                // Coincident-with-surface content: pass at equal depth, occlude behind ridges.
+                glDepthFunc(GL_LEQUAL);
+            }
 
             bool refresh = _billboardRenderer->onDrawFrame(deltaSeconds, billboardSorter, viewState);
             _geometryCollectionRenderer->onDrawFrame(deltaSeconds, viewState);
             _lineRenderer->onDrawFrame(deltaSeconds, viewState);
             _pointRenderer->onDrawFrame(deltaSeconds, viewState);
             _polygonRenderer->onDrawFrame(deltaSeconds, viewState);
+            if (terrainPainterOrder) {
+                glDepthFunc(GL_LESS);
+            }
 
             if (terrainDepthOffset) {
                 glDisable(GL_POLYGON_OFFSET_FILL);

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -331,6 +331,10 @@ namespace carto {
         bool regularGrid = painterOrder || (terrainMode && activeTerrainOptions && activeTerrainOptions->isRegularGridEnabled() && (bool) terrainTextureProvider);
         tileRenderer->setTerrainRegularGrid(regularGrid, activeTerrainOptions ? activeTerrainOptions->getMeshResolution() : 0);
         tileRenderer->setTerrainPainterOrder(painterOrder);
+        // Source-density (tangram) draping: content is left at source density (no per-tile
+        // subdivision) and lifted above the surface occluder by a distance-scaled slack.
+        bool sourceDensity = terrainMode && activeTerrainOptions && activeTerrainOptions->isSourceDensityDrapingEnabled() && (bool) terrainTextureProvider;
+        tileRenderer->setTerrainSourceDensityDrape(sourceDensity, activeTerrainOptions ? activeTerrainOptions->getSourceDensityDrapeSlack() : 0.0f);
         tileRenderer->setTerrainDepthWrite(terrainMode && _terrainDepthWriteMode);
         tileRenderer->setDebugWireframe(false); // debug: terrain mesh wireframe + stencil overlay
         tileRenderer->setDebugSurfacePrefill(false); // debug: facing-coded terrain pre-fill (magenta front / cyan back)

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -331,11 +331,7 @@ namespace carto {
         bool regularGrid = painterOrder || (terrainMode && activeTerrainOptions && activeTerrainOptions->isRegularGridEnabled() && (bool) terrainTextureProvider);
         tileRenderer->setTerrainRegularGrid(regularGrid, activeTerrainOptions ? activeTerrainOptions->getMeshResolution() : 0);
         tileRenderer->setTerrainPainterOrder(painterOrder);
-        // Source-density (tangram) draping: content is left at source density (no per-tile
-        // subdivision) and lifted above the surface occluder by a distance-scaled slack.
-        bool sourceDensity = terrainMode && activeTerrainOptions && activeTerrainOptions->isSourceDensityDrapingEnabled() && (bool) terrainTextureProvider;
-        tileRenderer->setTerrainSourceDensityDrape(sourceDensity, activeTerrainOptions ? activeTerrainOptions->getSourceDensityDrapeSlack() : 0.0f);
-        // Maplibre-style render-to-texture fill draping (spike).
+        // Maplibre-style render-to-texture fill draping.
         bool drapeFills = terrainMode && activeTerrainOptions && activeTerrainOptions->isDrapeFillsEnabled() && (bool) terrainTextureProvider;
         tileRenderer->setTerrainDrapeFills(drapeFills, activeTerrainOptions && activeTerrainOptions->isDrapeLinesEnabled());
         tileRenderer->setTerrainDepthWrite(terrainMode && _terrainDepthWriteMode);

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -285,7 +285,6 @@ namespace carto {
                     }
                 }
                 if (_elevationTextureCache) {
-                    _elevationTextureCache->beginFrame(); // reset the per-frame new-texture creation budget
                     std::shared_ptr<ElevationTextureCache> elevationTextureCache = _elevationTextureCache;
                     terrainTextureProvider = [elevationTextureCache](const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture) {
                         return elevationTextureCache->getTexture(tileId, terrainTexture);

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -337,7 +337,7 @@ namespace carto {
         tileRenderer->setTerrainSourceDensityDrape(sourceDensity, activeTerrainOptions ? activeTerrainOptions->getSourceDensityDrapeSlack() : 0.0f);
         // Maplibre-style render-to-texture fill draping (spike).
         bool drapeFills = terrainMode && activeTerrainOptions && activeTerrainOptions->isDrapeFillsEnabled() && (bool) terrainTextureProvider;
-        tileRenderer->setTerrainDrapeFills(drapeFills);
+        tileRenderer->setTerrainDrapeFills(drapeFills, activeTerrainOptions && activeTerrainOptions->isDrapeLinesEnabled());
         tileRenderer->setTerrainDepthWrite(terrainMode && _terrainDepthWriteMode);
         tileRenderer->setDebugWireframe(false); // debug: terrain mesh wireframe + stencil overlay
         tileRenderer->setDebugSurfacePrefill(false); // debug: facing-coded terrain pre-fill (magenta front / cyan back)

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -285,6 +285,7 @@ namespace carto {
                     }
                 }
                 if (_elevationTextureCache) {
+                    _elevationTextureCache->beginFrame(); // reset the per-frame new-texture creation budget
                     std::shared_ptr<ElevationTextureCache> elevationTextureCache = _elevationTextureCache;
                     terrainTextureProvider = [elevationTextureCache](const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture) {
                         return elevationTextureCache->getTexture(tileId, terrainTexture);

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -335,6 +335,9 @@ namespace carto {
         // subdivision) and lifted above the surface occluder by a distance-scaled slack.
         bool sourceDensity = terrainMode && activeTerrainOptions && activeTerrainOptions->isSourceDensityDrapingEnabled() && (bool) terrainTextureProvider;
         tileRenderer->setTerrainSourceDensityDrape(sourceDensity, activeTerrainOptions ? activeTerrainOptions->getSourceDensityDrapeSlack() : 0.0f);
+        // Maplibre-style render-to-texture fill draping (spike).
+        bool drapeFills = terrainMode && activeTerrainOptions && activeTerrainOptions->isDrapeFillsEnabled() && (bool) terrainTextureProvider;
+        tileRenderer->setTerrainDrapeFills(drapeFills);
         tileRenderer->setTerrainDepthWrite(terrainMode && _terrainDepthWriteMode);
         tileRenderer->setDebugWireframe(false); // debug: terrain mesh wireframe + stencil overlay
         tileRenderer->setDebugSurfacePrefill(false); // debug: facing-coded terrain pre-fill (magenta front / cyan back)

--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -58,8 +58,17 @@ namespace carto {
         long long gridTileId = gridTile.getTileId();
         auto it = _cache.find(gridTileId);
         if (it == _cache.end() || it->second.grid != grid || it->second.neighbours != neighbours) {
-            if (_cache.size() >= MAX_CACHED_TEXTURES) {
-                _cache.clear(); // simple full flush; textures are cheap to rebuild from cached grids
+            if (_cache.size() >= MAX_CACHED_TEXTURES && _cache.find(gridTileId) == _cache.end()) {
+                // Evict the least-recently-used entry, NOT the whole cache. A full flush
+                // re-encodes+re-uploads every texture whenever the working set exceeds the cap,
+                // which stalls the render thread on fast multi-level zooms (the working set of
+                // visible + neighbour DEM tiles briefly exceeds the cap). LRU keeps the warm set.
+                auto lru = std::min_element(_cache.begin(), _cache.end(), [](const std::pair<const long long, CacheEntry>& a, const std::pair<const long long, CacheEntry>& b) {
+                    return a.second.lastUsed < b.second.lastUsed;
+                });
+                if (lru != _cache.end()) {
+                    _cache.erase(lru);
+                }
             }
             CacheEntry entry;
             entry.grid = grid;
@@ -74,6 +83,7 @@ namespace carto {
             entry.texture = _glResourceManager->create<Texture>(bitmap, false, false); // no mipmaps, clamp to edge
             it = _cache.insert_or_assign(gridTileId, std::move(entry)).first;
         }
+        it->second.lastUsed = ++_accessCounter;
         const CacheEntry& entry = it->second;
         if (!entry.texture || entry.texture->getTexId() == 0) {
             return false;

--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -57,31 +57,46 @@ namespace carto {
 
         long long gridTileId = gridTile.getTileId();
         auto it = _cache.find(gridTileId);
-        if (it == _cache.end() || it->second.grid != grid || it->second.neighbours != neighbours) {
-            if (_cache.size() >= MAX_CACHED_TEXTURES && _cache.find(gridTileId) == _cache.end()) {
-                // Evict the least-recently-used entry, NOT the whole cache. A full flush
-                // re-encodes+re-uploads every texture whenever the working set exceeds the cap,
-                // which stalls the render thread on fast multi-level zooms (the working set of
-                // visible + neighbour DEM tiles briefly exceeds the cap). LRU keeps the warm set.
-                auto lru = std::min_element(_cache.begin(), _cache.end(), [](const std::pair<const long long, CacheEntry>& a, const std::pair<const long long, CacheEntry>& b) {
-                    return a.second.lastUsed < b.second.lastUsed;
-                });
-                if (lru != _cache.end()) {
-                    _cache.erase(lru);
+        bool needsCreate = (it == _cache.end() || it->second.grid != grid || it->second.neighbours != neighbours);
+        if (needsCreate) {
+            bool haveUsableTexture = (it != _cache.end() && it->second.texture && it->second.texture->getTexId() != 0);
+            // Budget new-texture creation per frame: encodeTextureWithBorders + glTexImage2D
+            // run on the render thread, and a fast zoom surfaces many new tiles at once - doing
+            // them all in one frame stalls the render thread (the terrain-only zoom hang). Over
+            // budget, render this tile flat this frame (or keep its slightly stale texture); it
+            // gets a fresh texture on a later frame.
+            if (_frameCreations >= MAX_CREATIONS_PER_FRAME) {
+                if (!haveUsableTexture) {
+                    return false;
                 }
+                // else: reuse the existing texture; do not re-encode/upload this frame
+            } else {
+                if (_cache.size() >= MAX_CACHED_TEXTURES && it == _cache.end()) {
+                    // Evict the least-recently-used entry, NOT the whole cache. A full flush
+                    // re-encodes+re-uploads every texture whenever the working set exceeds the cap,
+                    // which stalls the render thread on fast multi-level zooms (the working set of
+                    // visible + neighbour DEM tiles briefly exceeds the cap). LRU keeps the warm set.
+                    auto lru = std::min_element(_cache.begin(), _cache.end(), [](const std::pair<const long long, CacheEntry>& a, const std::pair<const long long, CacheEntry>& b) {
+                        return a.second.lastUsed < b.second.lastUsed;
+                    });
+                    if (lru != _cache.end()) {
+                        _cache.erase(lru);
+                    }
+                }
+                CacheEntry entry;
+                entry.grid = grid;
+                entry.neighbours = neighbours;
+                std::vector<std::uint8_t> rgbaData;
+                grid->encodeTextureWithBorders(neighbours, rgbaData, entry.decode);
+                // The encoded rows are south-to-north, i.e. already bottom-up in the Bitmap
+                // convention. Bitmap treats a POSITIVE stride as top-down input and flips the
+                // rows - pass a negative stride so the data is taken as-is (a flipped texture
+                // mirrors every tile's terrain north-south).
+                auto bitmap = std::make_shared<Bitmap>(rgbaData.data(), grid->getWidth() + 2, grid->getHeight() + 2, ColorFormat::COLOR_FORMAT_RGBA, -static_cast<int>(4 * (grid->getWidth() + 2)));
+                entry.texture = _glResourceManager->create<Texture>(bitmap, false, false); // no mipmaps, clamp to edge
+                it = _cache.insert_or_assign(gridTileId, std::move(entry)).first;
+                _frameCreations++;
             }
-            CacheEntry entry;
-            entry.grid = grid;
-            entry.neighbours = neighbours;
-            std::vector<std::uint8_t> rgbaData;
-            grid->encodeTextureWithBorders(neighbours, rgbaData, entry.decode);
-            // The encoded rows are south-to-north, i.e. already bottom-up in the Bitmap
-            // convention. Bitmap treats a POSITIVE stride as top-down input and flips the
-            // rows - pass a negative stride so the data is taken as-is (a flipped texture
-            // mirrors every tile's terrain north-south).
-            auto bitmap = std::make_shared<Bitmap>(rgbaData.data(), grid->getWidth() + 2, grid->getHeight() + 2, ColorFormat::COLOR_FORMAT_RGBA, -static_cast<int>(4 * (grid->getWidth() + 2)));
-            entry.texture = _glResourceManager->create<Texture>(bitmap, false, false); // no mipmaps, clamp to edge
-            it = _cache.insert_or_assign(gridTileId, std::move(entry)).first;
         }
         it->second.lastUsed = ++_accessCounter;
         const CacheEntry& entry = it->second;
@@ -101,6 +116,10 @@ namespace carto {
         terrainTexture.metersToInternal = static_cast<float>(_elevationManager->getExaggeration() * Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE);
         terrainTexture.mercatorYScale = static_cast<float>(2.0 * Const::PI / Const::WORLD_SIZE);
         return true;
+    }
+
+    void ElevationTextureCache::beginFrame() {
+        _frameCreations = 0;
     }
 
     void ElevationTextureCache::clear() {

--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -57,46 +57,31 @@ namespace carto {
 
         long long gridTileId = gridTile.getTileId();
         auto it = _cache.find(gridTileId);
-        bool needsCreate = (it == _cache.end() || it->second.grid != grid || it->second.neighbours != neighbours);
-        if (needsCreate) {
-            bool haveUsableTexture = (it != _cache.end() && it->second.texture && it->second.texture->getTexId() != 0);
-            // Budget new-texture creation per frame: encodeTextureWithBorders + glTexImage2D
-            // run on the render thread, and a fast zoom surfaces many new tiles at once - doing
-            // them all in one frame stalls the render thread (the terrain-only zoom hang). Over
-            // budget, render this tile flat this frame (or keep its slightly stale texture); it
-            // gets a fresh texture on a later frame.
-            if (_frameCreations >= MAX_CREATIONS_PER_FRAME) {
-                if (!haveUsableTexture) {
-                    return false;
+        if (it == _cache.end() || it->second.grid != grid || it->second.neighbours != neighbours) {
+            if (_cache.size() >= MAX_CACHED_TEXTURES && it == _cache.end()) {
+                // Evict the least-recently-used entry, NOT the whole cache. A full flush
+                // re-encodes+re-uploads every texture whenever the working set exceeds the cap,
+                // which stalls the render thread on fast multi-level zooms (the working set of
+                // visible + neighbour DEM tiles briefly exceeds the cap). LRU keeps the warm set.
+                auto lru = std::min_element(_cache.begin(), _cache.end(), [](const std::pair<const long long, CacheEntry>& a, const std::pair<const long long, CacheEntry>& b) {
+                    return a.second.lastUsed < b.second.lastUsed;
+                });
+                if (lru != _cache.end()) {
+                    _cache.erase(lru);
                 }
-                // else: reuse the existing texture; do not re-encode/upload this frame
-            } else {
-                if (_cache.size() >= MAX_CACHED_TEXTURES && it == _cache.end()) {
-                    // Evict the least-recently-used entry, NOT the whole cache. A full flush
-                    // re-encodes+re-uploads every texture whenever the working set exceeds the cap,
-                    // which stalls the render thread on fast multi-level zooms (the working set of
-                    // visible + neighbour DEM tiles briefly exceeds the cap). LRU keeps the warm set.
-                    auto lru = std::min_element(_cache.begin(), _cache.end(), [](const std::pair<const long long, CacheEntry>& a, const std::pair<const long long, CacheEntry>& b) {
-                        return a.second.lastUsed < b.second.lastUsed;
-                    });
-                    if (lru != _cache.end()) {
-                        _cache.erase(lru);
-                    }
-                }
-                CacheEntry entry;
-                entry.grid = grid;
-                entry.neighbours = neighbours;
-                std::vector<std::uint8_t> rgbaData;
-                grid->encodeTextureWithBorders(neighbours, rgbaData, entry.decode);
-                // The encoded rows are south-to-north, i.e. already bottom-up in the Bitmap
-                // convention. Bitmap treats a POSITIVE stride as top-down input and flips the
-                // rows - pass a negative stride so the data is taken as-is (a flipped texture
-                // mirrors every tile's terrain north-south).
-                auto bitmap = std::make_shared<Bitmap>(rgbaData.data(), grid->getWidth() + 2, grid->getHeight() + 2, ColorFormat::COLOR_FORMAT_RGBA, -static_cast<int>(4 * (grid->getWidth() + 2)));
-                entry.texture = _glResourceManager->create<Texture>(bitmap, false, false); // no mipmaps, clamp to edge
-                it = _cache.insert_or_assign(gridTileId, std::move(entry)).first;
-                _frameCreations++;
             }
+            CacheEntry entry;
+            entry.grid = grid;
+            entry.neighbours = neighbours;
+            std::vector<std::uint8_t> rgbaData;
+            grid->encodeTextureWithBorders(neighbours, rgbaData, entry.decode);
+            // The encoded rows are south-to-north, i.e. already bottom-up in the Bitmap
+            // convention. Bitmap treats a POSITIVE stride as top-down input and flips the
+            // rows - pass a negative stride so the data is taken as-is (a flipped texture
+            // mirrors every tile's terrain north-south).
+            auto bitmap = std::make_shared<Bitmap>(rgbaData.data(), grid->getWidth() + 2, grid->getHeight() + 2, ColorFormat::COLOR_FORMAT_RGBA, -static_cast<int>(4 * (grid->getWidth() + 2)));
+            entry.texture = _glResourceManager->create<Texture>(bitmap, false, false); // no mipmaps, clamp to edge
+            it = _cache.insert_or_assign(gridTileId, std::move(entry)).first;
         }
         it->second.lastUsed = ++_accessCounter;
         const CacheEntry& entry = it->second;
@@ -116,10 +101,6 @@ namespace carto {
         terrainTexture.metersToInternal = static_cast<float>(_elevationManager->getExaggeration() * Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE);
         terrainTexture.mercatorYScale = static_cast<float>(2.0 * Const::PI / Const::WORLD_SIZE);
         return true;
-    }
-
-    void ElevationTextureCache::beginFrame() {
-        _frameCreations = 0;
     }
 
     void ElevationTextureCache::clear() {

--- a/all/native/renderers/utils/ElevationTextureCache.h
+++ b/all/native/renderers/utils/ElevationTextureCache.h
@@ -50,6 +50,7 @@ namespace carto {
             std::array<std::shared_ptr<ElevationTileGrid>, 8> neighbours; // border sources; entry rebuilds when a neighbour grid loads
             std::shared_ptr<Texture> texture;
             std::array<float, 4> decode = { { 0, 0, 0, 0 } };
+            std::uint64_t lastUsed = 0; // LRU stamp
         };
 
         static constexpr std::size_t MAX_CACHED_TEXTURES = 96; // ~24MB of RGBA 256x256 textures
@@ -57,6 +58,7 @@ namespace carto {
         const std::shared_ptr<ElevationManager> _elevationManager;
         const std::shared_ptr<GLResourceManager> _glResourceManager;
         std::map<long long, CacheEntry> _cache; // keyed by the grid tile id
+        std::uint64_t _accessCounter = 0; // monotonic LRU clock
     };
 }
 

--- a/all/native/renderers/utils/ElevationTextureCache.h
+++ b/all/native/renderers/utils/ElevationTextureCache.h
@@ -42,6 +42,9 @@ namespace carto {
          */
         bool getTexture(const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture);
 
+        // Resets the per-frame new-texture creation budget. Call once per frame before rendering.
+        void beginFrame();
+
         void clear();
 
     private:
@@ -54,11 +57,13 @@ namespace carto {
         };
 
         static constexpr std::size_t MAX_CACHED_TEXTURES = 96; // ~24MB of RGBA 256x256 textures
+        static constexpr std::size_t MAX_CREATIONS_PER_FRAME = 4; // spread encode+upload of new tiles over frames (avoid a fast-zoom render-thread burst)
 
         const std::shared_ptr<ElevationManager> _elevationManager;
         const std::shared_ptr<GLResourceManager> _glResourceManager;
         std::map<long long, CacheEntry> _cache; // keyed by the grid tile id
         std::uint64_t _accessCounter = 0; // monotonic LRU clock
+        std::size_t _frameCreations = 0; // new textures created this frame
     };
 }
 

--- a/all/native/renderers/utils/ElevationTextureCache.h
+++ b/all/native/renderers/utils/ElevationTextureCache.h
@@ -42,9 +42,6 @@ namespace carto {
          */
         bool getTexture(const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture);
 
-        // Resets the per-frame new-texture creation budget. Call once per frame before rendering.
-        void beginFrame();
-
         void clear();
 
     private:
@@ -57,13 +54,11 @@ namespace carto {
         };
 
         static constexpr std::size_t MAX_CACHED_TEXTURES = 96; // ~24MB of RGBA 256x256 textures
-        static constexpr std::size_t MAX_CREATIONS_PER_FRAME = 4; // spread encode+upload of new tiles over frames (avoid a fast-zoom render-thread burst)
 
         const std::shared_ptr<ElevationManager> _elevationManager;
         const std::shared_ptr<GLResourceManager> _glResourceManager;
         std::map<long long, CacheEntry> _cache; // keyed by the grid tile id
         std::uint64_t _accessCounter = 0; // monotonic LRU clock
-        std::size_t _frameCreations = 0; // new textures created this frame
     };
 }
 

--- a/all/native/terrain/TerrainTileTransformer.cpp
+++ b/all/native/terrain/TerrainTileTransformer.cpp
@@ -9,12 +9,13 @@
 
 namespace carto {
 
-    TerrainTileTransformer::TerrainVertexTransformer::TerrainVertexTransformer(const vt::TileId& tileId, double scale, std::shared_ptr<ElevationTileGrid> grid, float exaggeration, float divideThreshold) :
+    TerrainTileTransformer::TerrainVertexTransformer::TerrainVertexTransformer(const vt::TileId& tileId, double scale, std::shared_ptr<ElevationTileGrid> grid, float exaggeration, float divideThreshold, float lineDivideThreshold) :
         _tileId(tileId),
         _scale(scale),
         _grid(std::move(grid)),
         _exaggeration(exaggeration),
-        _divideThreshold(divideThreshold)
+        _divideThreshold(divideThreshold),
+        _lineDivideThreshold(lineDivideThreshold)
     {
         int tileMask = (1 << tileId.zoom) - 1;
         double zoomScale = 1.0 / (1 << tileId.zoom);
@@ -88,7 +89,7 @@ namespace carto {
     }
 
     void TerrainTileTransformer::TerrainVertexTransformer::tesselateSegment(const cglib::vec2<float>& pos0, const cglib::vec2<float>& pos1, float dist, vt::VertexArray<cglib::vec2<float>>& points) const {
-        if (dist > _divideThreshold) {
+        if (dist > _lineDivideThreshold) {
             cglib::vec2<float> posM = (pos0 + pos1) * 0.5f;
             tesselateSegment(pos0, posM, dist * 0.5f, points);
             tesselateSegment(posM, pos1, dist * 0.5f, points);
@@ -241,6 +242,7 @@ namespace carto {
         }
 
         float divideThreshold = std::numeric_limits<float>::infinity();
+        float lineDivideThreshold = std::numeric_limits<float>::infinity();
         if (grid && grid->getMaxHeight() - grid->getMinHeight() > FLAT_HEIGHT_RANGE_EPSILON) {
             double tileScaleMeters = EARTH_CIRCUMFERENCE / (1 << tileId.zoom);
             double threshold = tileScaleMeters / _meshResolution;
@@ -256,15 +258,27 @@ namespace carto {
                 // (no per-tile red-green tesselation) and the lattice clamp are the wins.
                 // Do NOT clamp to the DEM texel size here: the grid, not the DEM, is the
                 // surface geometry the draped content is tested against.
+                //
+                // One cell puts every draped VERTEX on the grid surface (lattice clamp), but
+                // the straight SEGMENT between two vertices in different cell triangles chords
+                // across the cell's anti-diagonal fold and sags below it. Under painter-order
+                // (zero depth slack) that sag is depth-occluded -> draped LINES crack over
+                // convex terrain, worst at low zoom where the cell / fold amplitude is largest.
+                // Raising _meshResolution shrinks the fold but costs O(res^2) in the shared grid
+                // AND subdivides fills the same amount. Instead subdivide only the LINES finer
+                // than the grid (cheap, 1D); the sag falls linearly with the sub-segment length
+                // at no surface-grid cost. Fills stay at one cell (their sag is bounded there).
                 divideThreshold = static_cast<float>(threshold);
+                lineDivideThreshold = static_cast<float>(threshold * REGULAR_GRID_LINE_SUBDIVISION);
             } else {
                 // No point in subdividing finer than the elevation grid resolution
                 double gridInternalWidth = grid->getInternalBounds().getMax().getX() - grid->getInternalBounds().getMin().getX();
                 double demTexelMeters = gridInternalWidth / grid->getWidth() * EARTH_CIRCUMFERENCE / _scale;
                 divideThreshold = static_cast<float>(std::max(threshold, demTexelMeters));
+                lineDivideThreshold = divideThreshold;
             }
         }
 
-        return std::make_shared<TerrainVertexTransformer>(tileId, _scale, std::move(grid), _elevationManager->getExaggeration(), divideThreshold);
+        return std::make_shared<TerrainVertexTransformer>(tileId, _scale, std::move(grid), _elevationManager->getExaggeration(), divideThreshold, lineDivideThreshold);
     }
 }

--- a/all/native/terrain/TerrainTileTransformer.cpp
+++ b/all/native/terrain/TerrainTileTransformer.cpp
@@ -182,13 +182,14 @@ namespace carto {
         }
     }
 
-    TerrainTileTransformer::TerrainTileTransformer(float scale, const std::shared_ptr<ElevationManager>& elevationManager, int meshResolution, int minZoom, bool regularGrid, bool sourceDensity) :
+    TerrainTileTransformer::TerrainTileTransformer(float scale, const std::shared_ptr<ElevationManager>& elevationManager, int meshResolution, int minZoom, bool regularGrid, bool sourceDensity, bool sourceDensityLines) :
         _scale(scale),
         _elevationManager(elevationManager),
         _meshResolution(std::max(1, meshResolution)),
         _minZoom(minZoom),
         _regularGrid(regularGrid),
-        _sourceDensity(sourceDensity)
+        _sourceDensity(sourceDensity),
+        _sourceDensityLines(sourceDensityLines)
     {
     }
 
@@ -278,7 +279,8 @@ namespace carto {
                 // lift slack that shines everything through). So only the fill threshold goes to
                 // infinity here; the line threshold is unchanged.
                 divideThreshold = _sourceDensity ? std::numeric_limits<float>::infinity() : static_cast<float>(threshold);
-                lineDivideThreshold = static_cast<float>(threshold * REGULAR_GRID_LINE_SUBDIVISION);
+                // Draped lines are baked flat too, so skip their subdivision as well.
+                lineDivideThreshold = _sourceDensityLines ? std::numeric_limits<float>::infinity() : static_cast<float>(threshold * REGULAR_GRID_LINE_SUBDIVISION);
             } else {
                 // No point in subdividing finer than the elevation grid resolution
                 double gridInternalWidth = grid->getInternalBounds().getMax().getX() - grid->getInternalBounds().getMin().getX();

--- a/all/native/terrain/TerrainTileTransformer.cpp
+++ b/all/native/terrain/TerrainTileTransformer.cpp
@@ -244,13 +244,6 @@ namespace carto {
 
         float divideThreshold = std::numeric_limits<float>::infinity();
         float lineDivideThreshold = std::numeric_limits<float>::infinity();
-        // Source-density (tangram) mode: do NOT subdivide draped content to follow the surface.
-        // Leave it at source density (infinite threshold = no splits) and let the GPU draping
-        // shader displace each vertex; the surface occluder stays fine and a lifting depth slack
-        // (GLTileRenderer source-density draw path) keeps the un-subdivided content above it.
-        if (_sourceDensity) {
-            return std::make_shared<TerrainVertexTransformer>(tileId, _scale, std::move(grid), _elevationManager->getExaggeration(), divideThreshold, lineDivideThreshold);
-        }
         if (grid && grid->getMaxHeight() - grid->getMinHeight() > FLAT_HEIGHT_RANGE_EPSILON) {
             double tileScaleMeters = EARTH_CIRCUMFERENCE / (1 << tileId.zoom);
             double threshold = tileScaleMeters / _meshResolution;
@@ -276,7 +269,15 @@ namespace carto {
                 // AND subdivides fills the same amount. Instead subdivide only the LINES finer
                 // than the grid (cheap, 1D); the sag falls linearly with the sub-segment length
                 // at no surface-grid cost. Fills stay at one cell (their sag is bounded there).
-                divideThreshold = static_cast<float>(threshold);
+                //
+                // Source-density (tangram) mode targets the expensive part - the fills (a full
+                // tile fill red-green splits to ~meshResolution^2 triangles). It skips FILL
+                // subdivision (source density, lifted by a per-draw fill slack in the renderer)
+                // but KEEPS line subdivision: lines are cheap (1D) and MUST follow the terrain
+                // closely (contours lie exactly on the surface - un-subdivided they need a huge
+                // lift slack that shines everything through). So only the fill threshold goes to
+                // infinity here; the line threshold is unchanged.
+                divideThreshold = _sourceDensity ? std::numeric_limits<float>::infinity() : static_cast<float>(threshold);
                 lineDivideThreshold = static_cast<float>(threshold * REGULAR_GRID_LINE_SUBDIVISION);
             } else {
                 // No point in subdividing finer than the elevation grid resolution

--- a/all/native/terrain/TerrainTileTransformer.cpp
+++ b/all/native/terrain/TerrainTileTransformer.cpp
@@ -182,12 +182,13 @@ namespace carto {
         }
     }
 
-    TerrainTileTransformer::TerrainTileTransformer(float scale, const std::shared_ptr<ElevationManager>& elevationManager, int meshResolution, int minZoom, bool regularGrid) :
+    TerrainTileTransformer::TerrainTileTransformer(float scale, const std::shared_ptr<ElevationManager>& elevationManager, int meshResolution, int minZoom, bool regularGrid, bool sourceDensity) :
         _scale(scale),
         _elevationManager(elevationManager),
         _meshResolution(std::max(1, meshResolution)),
         _minZoom(minZoom),
-        _regularGrid(regularGrid)
+        _regularGrid(regularGrid),
+        _sourceDensity(sourceDensity)
     {
     }
 
@@ -243,6 +244,13 @@ namespace carto {
 
         float divideThreshold = std::numeric_limits<float>::infinity();
         float lineDivideThreshold = std::numeric_limits<float>::infinity();
+        // Source-density (tangram) mode: do NOT subdivide draped content to follow the surface.
+        // Leave it at source density (infinite threshold = no splits) and let the GPU draping
+        // shader displace each vertex; the surface occluder stays fine and a lifting depth slack
+        // (GLTileRenderer source-density draw path) keeps the un-subdivided content above it.
+        if (_sourceDensity) {
+            return std::make_shared<TerrainVertexTransformer>(tileId, _scale, std::move(grid), _elevationManager->getExaggeration(), divideThreshold, lineDivideThreshold);
+        }
         if (grid && grid->getMaxHeight() - grid->getMinHeight() > FLAT_HEIGHT_RANGE_EPSILON) {
             double tileScaleMeters = EARTH_CIRCUMFERENCE / (1 << tileId.zoom);
             double threshold = tileScaleMeters / _meshResolution;

--- a/all/native/terrain/TerrainTileTransformer.h
+++ b/all/native/terrain/TerrainTileTransformer.h
@@ -60,7 +60,7 @@ namespace carto {
             double _localFromInternal;
         };
 
-        TerrainTileTransformer(float scale, const std::shared_ptr<ElevationManager>& elevationManager, int meshResolution, int minZoom, bool regularGrid);
+        TerrainTileTransformer(float scale, const std::shared_ptr<ElevationManager>& elevationManager, int meshResolution, int minZoom, bool regularGrid, bool sourceDensity);
         virtual ~TerrainTileTransformer() = default;
 
         std::shared_ptr<ElevationManager> getElevationManager() const { return _elevationManager; }
@@ -88,6 +88,7 @@ namespace carto {
         const int _meshResolution;
         const int _minZoom; // tiles below this zoom level are rendered flat
         const bool _regularGrid; // shared regular-grid surface mode: subdivide draped geometry to one grid cell (follow the shared grid surface), no DEM-texel floor
+        const bool _sourceDensity; // source-density (tangram) mode: do not subdivide draped content at all; GPU-displace at source density + lifting depth slack
     };
 }
 

--- a/all/native/terrain/TerrainTileTransformer.h
+++ b/all/native/terrain/TerrainTileTransformer.h
@@ -60,7 +60,7 @@ namespace carto {
             double _localFromInternal;
         };
 
-        TerrainTileTransformer(float scale, const std::shared_ptr<ElevationManager>& elevationManager, int meshResolution, int minZoom, bool regularGrid, bool sourceDensity);
+        TerrainTileTransformer(float scale, const std::shared_ptr<ElevationManager>& elevationManager, int meshResolution, int minZoom, bool regularGrid, bool sourceDensity, bool sourceDensityLines);
         virtual ~TerrainTileTransformer() = default;
 
         std::shared_ptr<ElevationManager> getElevationManager() const { return _elevationManager; }
@@ -88,7 +88,8 @@ namespace carto {
         const int _meshResolution;
         const int _minZoom; // tiles below this zoom level are rendered flat
         const bool _regularGrid; // shared regular-grid surface mode: subdivide draped geometry to one grid cell (follow the shared grid surface), no DEM-texel floor
-        const bool _sourceDensity; // source-density (tangram) mode: do not subdivide draped content at all; GPU-displace at source density + lifting depth slack
+        const bool _sourceDensity; // source-density (tangram) mode: do not subdivide draped fills; GPU-displace at source density + lifting depth slack
+        const bool _sourceDensityLines; // also skip line subdivision (draped lines are baked flat)
     };
 }
 

--- a/all/native/terrain/TerrainTileTransformer.h
+++ b/all/native/terrain/TerrainTileTransformer.h
@@ -29,7 +29,7 @@ namespace carto {
     public:
         class TerrainVertexTransformer final : public VertexTransformer {
         public:
-            TerrainVertexTransformer(const vt::TileId& tileId, double scale, std::shared_ptr<ElevationTileGrid> grid, float exaggeration, float divideThreshold);
+            TerrainVertexTransformer(const vt::TileId& tileId, double scale, std::shared_ptr<ElevationTileGrid> grid, float exaggeration, float divideThreshold, float lineDivideThreshold);
             virtual ~TerrainVertexTransformer() = default;
 
             virtual cglib::vec3<float> calculatePoint(const cglib::vec2<float>& pos) const override;
@@ -52,7 +52,8 @@ namespace carto {
             const double _scale;
             const std::shared_ptr<ElevationTileGrid> _grid;
             const float _exaggeration;
-            const float _divideThreshold; // in EPSG3857 meters; infinity disables subdivision
+            const float _divideThreshold; // triangle subdivision, EPSG3857 meters; infinity disables subdivision
+            const float _lineDivideThreshold; // line subdivision, EPSG3857 meters; finer than the triangle threshold in regular-grid mode
             cglib::vec2<double> _tileOffsetInternal; // internal coordinates of the tile origin (min x, min y)
             double _tileScaleInternal;
             double _tileScaleMeters;
@@ -75,6 +76,12 @@ namespace carto {
 
     private:
         static constexpr float FLAT_HEIGHT_RANGE_EPSILON = 0.001f;
+        // Regular-grid draped LINES are subdivided this fraction of a surface grid cell
+        // (< 1 = finer than the grid) so segments stop chording the cell's anti-diagonal fold
+        // and cracking under zero-slack painter-order depth. Lower = fewer cracks, more line
+        // vertices (lines are 1D, cheap). Triangles stay at one cell (their sag is bounded and
+        // subdividing area content 1/factor^2 is expensive). Decoupled from the surface grid.
+        static constexpr double REGULAR_GRID_LINE_SUBDIVISION = 0.35;
 
         const double _scale;
         const std::shared_ptr<ElevationManager> _elevationManager;

--- a/docs/terrain-3d-draping.md
+++ b/docs/terrain-3d-draping.md
@@ -1,0 +1,112 @@
+# 3D terrain draping — architecture, comparison, and roadmap
+
+How CARTO drapes vector map content over 3D terrain, how it compares to tangram-ng
+and MapLibre Native, and where to take it next.
+
+## The problem
+
+Draped content (polygon fills, lines/contours, and VectorLayer elements like routes)
+must **follow the terrain surface exactly**. Get it wrong and you see one of:
+
+- **cracks / poke-through** — the terrain mesh rises above the content and occludes it in
+  patches;
+- **see-through** — content behind a ridge shows *over* a nearer ridge;
+- **holes** — fills sag below the surface and are occluded.
+
+All three come from the same root: content and the terrain **occluder surface** are two
+different piecewise-linear approximations of the same height field, and any depth bias used
+to separate them trades one artifact for another (the depth-slack tuning that dominated the
+terrain work).
+
+## Three approaches
+
+| | CARTO (this SDK) | tangram-ng | MapLibre Native |
+|---|---|---|---|
+| Drape mechanism | VTF vertex displacement; **fills draped as RTT texture** | VTF vertex displacement, no subdivision | **render content flat → texture → drape onto mesh** |
+| Surface mesh | shared regular grid (meshResolution), DEM-displaced in VTF | shared 64-grid, VTF | shared 128-grid, VTF |
+| Fill/line hug | RTT fills (exact) + lattice-clamped geometry lines | source-density, one global `depth_shift` | RTT (exact) for all drapeable layers |
+| Occlusion of draped content | true-depth drape surface writes depth; content `GL_LEQUAL`, zero bias | one global constant bias (accepts leak, fog hides) | none needed — content is baked into the surface texture |
+| Labels/symbols over terrain | elevated + billboard-occluded (CPU) | CPU elevation + depth-readback | not wired on the terrain-3d branch |
+| Decode cost vs flat | ~flat for draped content (no subdivision) | flat (no subdivision) | flat (flat render) |
+
+**Key lesson:** the artifact-free approaches (CARTO RTT fills, MapLibre) never let draped
+content depth-interact with the terrain — the content *is* the surface's texture, so there
+is nothing to z-fight. tangram's single-bias model is cheap but has a permanent quality
+ceiling (it leaks; fog hides it). CARTO takes the MapLibre route for fills and keeps sharp
+geometry for lines/elements where texture softness would matter.
+
+## Current state (what this PR ships)
+
+- **Fills** — maplibre-style render-to-texture drape (`TerrainOptions.DrapeFillsEnabled`).
+  Baked flat per tile, sampled on the terrain grid surface, cached per tile. Zero holes /
+  see-through by construction. The drape surface writes **true depth** and is the terrain
+  occluder.
+- **Contours / tile lines** — sharp displaced geometry, lattice-clamped to the grid, drawn
+  `GL_LEQUAL` + zero bias (no leak). Optionally draped too (`DrapeLinesEnabled`) — softer but
+  zero-cost hug. The anti-diagonal crack is fixed by finer line subdivision
+  (`REGULAR_GRID_LINE_SUBDIVISION`).
+- **Vector elements** (blue line) — `GL_LEQUAL` + zero clip bias, tunable painter-order
+  clearance (`ElementTerrainSlack`). Far-distance leak fixed; **low-zoom leak remains** (see
+  below).
+- **Perf** — draped content skips terrain subdivision (baked flat), so its VBOs upload at
+  source density instead of ~meshResolution² per tile. LRU elevation-texture cache (no full
+  flush). Together these cut the fast-zoom render-thread stall.
+
+Working config:
+
+```java
+terrainOptions.setPainterOrderDepthEnabled(true);
+terrainOptions.setDrapeFillsEnabled(true);   // also the true-depth occluder
+terrainOptions.setDrapeLinesEnabled(true);   // optional: cheap+draped contours
+terrainOptions.setMeshResolution(64);
+```
+
+## Roadmap — next improvements
+
+Ranked by value / tractability.
+
+### 1. RTT draping for VectorLayer elements (fixes the low-zoom element leak)
+The blue element line still leaks at low zoom: it is CPU-baked to the **fine bilinear**
+height while the low-zoom occluder is a **coarse grid**, so it rides above the surface and
+`GL_LEQUAL` passes it behind ridges. No depth bias wins this (above→leak, below→crack).
+The MapLibre fix applies: bake the element layer flat into the per-tile drape texture so it
+*becomes* the surface. **Cross-layer work** — elements live in different layers than the
+terrain-tile layer that owns the drape textures; needs a drape-element callback from the tile
+renderer into the element renderers (per-tile ortho, flat render into the drape FBO), plus an
+MVP-override draw path on `LineRenderer`/`PolygonRenderer`. Softens the line (texture).
+
+### 2. Stream / off-thread geometry VBO upload (zoom hang for sharp content)
+`buildCompiledTileGeometry` uploads each tile's VBO with `glBufferData` on the **render
+thread** on first draw. Draped content now skips subdivision, but **sharp** contours/roads
+(DrapeLines off) still upload subdivided geometry — a fast-zoom tile burst stalls. Options:
+per-frame upload budget (careful: content pop-in), or a proper async/streamed upload path
+(PBO / worker context). This is the remaining first-zoom cost when sharp geometry is kept.
+
+### 3. Drape-texture productionization
+Per-tile drape textures are cached and bake-once. Follow-ups: fade-in (currently pops in at
+full opacity), re-bake on progressive multi-layer load (a late layer can miss the cached
+bake), configurable drape resolution (currently 512²; thin content sharpness vs memory), and
+a shared texture pool to avoid alloc churn.
+
+### 4. Zero-slack regular-grid surfaces (backlog)
+Tile surfaces are red-green edge-local refinements, not a true regular grid, so the shader
+lattice-clamp only approximates them. A genuinely regular grid surface (tangram/maplibre
+style, one shared static grid VBO) would let the shader lattice-clamp *exactly* (zero slack)
+and remove the per-tile surface tesselation entirely. Groundwork exists
+(`RegularGridEnabled`, `buildRegularGridSurface`, in-shader `uElevationLatticeCell`).
+
+### 5. Comp-op / overlay layers bypass terrain occlusion
+`_overlayBuffer2D` has no depth attachment, so comp-op style layers render without terrain
+depth testing (they would draw over terrain). Fine today (default styles have none) but a gap
+if such styles are used with terrain.
+
+### 6. Labels
+Label re-anchoring re-samples elevation per point on every tile-set change (mutex per point).
+It is correct but not cheap; a batched or grid-cached elevation query would reduce the cost
+without the placement-instability that a naive per-label defer caused (reverted). MapLibre
+Native has not solved terrain symbols at all — CARTO is ahead here.
+
+## References
+- tangram-ng: `core/src/style/rasterStyle.cpp`, `core/shaders/*.vs`, `maps/assets/scenes/{terrain-3d,elevation}.yaml`
+- MapLibre Native (feature/terrain-3d): `src/mbgl/renderer/{render_terrain,texture_pool,render_target}.cpp`, `include/mbgl/shaders/gl/terrain.hpp`
+- CARTO: `libs-carto/vt/src/vt/GLTileRenderer.cpp` (drape pass, depth model), `all/native/terrain/TerrainTileTransformer.cpp` (subdivision), `all/native/components/TerrainOptions.h` (API)

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/ui/main/SecondFragment.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/ui/main/SecondFragment.java
@@ -280,17 +280,17 @@ public class SecondFragment extends Fragment {
         // The base class of HillshadeRasterTileLayer. The shader gets getRawColor() (the untouched RGBA
         // texel), getMapZoom() and vUV, and returns a PREMULTIPLIED color. Here: a hypsometric tint that
         // decodes terrarium elevation from the raw RGB terrain tile and colors it by height. (Uncomment.)
-         final CustomRasterTileLayer tinted = new CustomRasterTileLayer(cachedDemSource);
-         tinted.setShaderSource(
-             "vec4 applyLighting(lowp vec4 color, mediump vec3 normal, mediump vec3 surfaceNormal, mediump float intensity) {\n" +
-             "  vec4 c = getRawColor();\n" +
-             "  float h = (c.r * 255.0 * 256.0 + c.g * 255.0 + c.b * 255.0 / 256.0) - 32768.0;\n" + // terrarium metres
-             "  float t = clamp(h / 3000.0, 0.0, 1.0);\n" +
-             "  vec3 col = mix(vec3(0.2, 0.4, 0.8), vec3(0.9, 0.9, 0.4), t);\n" +          // blue -> yellow
-             "  col = mix(col, vec3(0.5, 0.3, 0.1), clamp((h - 1500.0) / 1500.0, 0.0, 1.0));\n" + // -> brown high
-             "  return vec4(col, 1.0);\n" +
-             "}\n");
-         mapView.getLayers().add(tinted);
+//         final CustomRasterTileLayer tinted = new CustomRasterTileLayer(cachedDemSource);
+//         tinted.setShaderSource(
+//             "vec4 applyLighting(lowp vec4 color, mediump vec3 normal, mediump vec3 surfaceNormal, mediump float intensity) {\n" +
+//             "  vec4 c = getRawColor();\n" +
+//             "  float h = (c.r * 255.0 * 256.0 + c.g * 255.0 + c.b * 255.0 / 256.0) - 32768.0;\n" + // terrarium metres
+//             "  float t = clamp(h / 3000.0, 0.0, 1.0);\n" +
+//             "  vec3 col = mix(vec3(0.2, 0.4, 0.8), vec3(0.9, 0.9, 0.4), t);\n" +          // blue -> yellow
+//             "  col = mix(col, vec3(0.5, 0.3, 0.1), clamp((h - 1500.0) / 1500.0, 0.0, 1.0));\n" + // -> brown high
+//             "  return vec4(col, 1.0);\n" +
+//             "}\n");
+//         mapView.getLayers().add(tinted);
 
         // Piece 3 test: on-the-fly contour lines generated from the SAME shared elevation
         // source (no second download/decode of terrain tiles). The generated vector tiles
@@ -340,7 +340,7 @@ public class SecondFragment extends Fragment {
                 "}\n";
         MBVectorTileDecoder decoder = new MBVectorTileDecoder(new CartoCSSStyleSet(contourCss));
             final VectorTileLayer contourLayer = new VectorTileLayer(contourSource, decoder);
-//            mapView.getLayers().add(contourLayer);
+            mapView.getLayers().add(contourLayer);
 
 //        } catch (IOException e) {
 //            throw new RuntimeException(e);
@@ -704,12 +704,12 @@ public class SecondFragment extends Fragment {
     // cannot declare them - so this demo uses zoom-based visibility/config only.
     // ---------------------------------------------------------------------------------------------
     CompositeVectorTileLayer compositeLayer;
-    void addCompositeMap(String dataPath) {
+    void addCompositeMap(View view, String dataPath) {
         // Master vector source: OpenMapTiles vector tiles.
         HTTPTileDataSource baseSource = new HTTPTileDataSource(0, 14, "https://tiles.openfreemap.org/planet/latest/{z}/{x}/{y}.pbf");
         StringMap headers = new StringMap();
         headers.set("User-Agent", "AlpiMaps/1.4 (contact: contact@akylas.fr)");
-//        baseSource.setHTTPHeaders(headers);
+        baseSource.setHTTPHeaders(headers);
         PersistentCacheTileDataSource baseSourceCached = new PersistentCacheTileDataSource(baseSource, getContext().getExternalFilesDir(null) + "/openfreemap_vect.db");
 
         // First-reference order = slot order: water, landcover, HILLSHADE, SATELLITE,
@@ -719,17 +719,14 @@ public class SecondFragment extends Fragment {
             "#water { polygon-fill: #9cc3e0; }",
             "#landcover { polygon-fill: #dbe8cc; }",
             // hillshade woven above land/water fills, below roads; exaggeration ramps with zoom.
+                "#satellite[zoom>=11] { raster-opacity: 1; raster-comp-op: src-over; }",
             "#hillshade[zoom>=4][zoom<=16] {",
-            "  hillshade-opacity: linear([view::zoom], (11, 0.6), (12, 1));",
-            "  hillshade-exaggeration: linear([view::zoom], (11, 0.6), (12, 1.0));",
+//            "  hillshade-opacity: linear([view::zoom], (11, 0.6), (12, 1));",
+//            "  hillshade-exaggeration: linear([view::zoom], (11, 0.6), (12, 1.0));",
             "  hillshade-illumination-direction: 365;",
             "  hillshade-shadow-color: #103040;",
             "}",
-                "#satellite[zoom>=13] { raster-opacity: 0.55; raster-comp-op: src-over; }",
             // satellite raster overlay, faint, only high zoom.
-            "#transportation { line-color: #ffffff; line-width: 1.2; }",
-            "#transportation['class'='motorway'] { line-color: #e27d60; line-width: 3; }",
-            "#transportation['class'='primary'] { line-color: #f4c06a; line-width: 2; }",
             "#building[zoom>=14] { polygon-fill: #d9cfc4; }",
 
                 "#contour[zoom>=5] {",
@@ -741,11 +738,11 @@ public class SecondFragment extends Fragment {
 
         );
         MBVectorTileDecoder decoder = null;
-        try {
-            decoder = getStyleDecoder(dataPath);
-        } catch (IOException e) {
+//        try {
+//            decoder = getStyleDecoder(dataPath);
+//        } catch (IOException e) {
             decoder = new MBVectorTileDecoder(new CartoCSSStyleSet(css));
-        }
+//        }
         compositeLayer = new CompositeVectorTileLayer(baseSourceCached, decoder);
 
         // Shared terrarium-encoded DEM for both hillshade and contours (fetched once).
@@ -757,9 +754,9 @@ public class SecondFragment extends Fragment {
         ContourTileDataSource contour = new ContourTileDataSource(cachedDem);
         contour.setMinVisibleZoom(5);
         contour.setMaxOverzoomLevel(15);
-//        compositeLayer.addVectorDataSource("contour", contour);
+        compositeLayer.addVectorDataSource("contour", contour);
         // hillshade: decoder resolved from the DEM source 'encoding' (terrarium) - no decoder arg.
-//        compositeLayer.addExternalDataSource("hillshade", cachedDem, CompositeSourceType.COMPOSITE_SOURCE_TYPE_HILLSHADE);
+        compositeLayer.addExternalDataSource("hillshade", cachedDem, CompositeSourceType.COMPOSITE_SOURCE_TYPE_HILLSHADE);
         // satellite: a raster source drawn at the '#satellite' slot with the style opacity.
         HTTPTileDataSource satSource = new HTTPTileDataSource(0, 19, "https://tile.openstreetmap.org/{z}/{x}/{y}.png");
         satSource.setHTTPHeaders(headers);
@@ -774,17 +771,21 @@ public class SecondFragment extends Fragment {
         // (delegated through the cache wrapper); passing it explicitly works as well.
         terrainOptions = new com.carto.components.TerrainOptions(cachedDem, new TerrariumElevationDataDecoder());
         terrainOptions.setExaggeration(1.0f);
-        terrainOptions.setMeshResolution(64);
-//        terrainOptions.set
-        // Optional: cap terrain LOD tile detail at what flat rendering would show
-        // (offset 0), to hide LOD rings if the style renders differently at different
-        // tile zoom levels. Disabled: the LOD rings turned out not to be the cause of
-        // the washed-out alpine faces (style/hillshade appearance).
-        //terrainOptions.setMaxTileZoomOffset(0);
-//        terrainOptions.setBackgroundColor(new Color((short) 255, (short)0,(short)0,(short)255));
-//        terrainOptions.setRegularGridEnabled(true);
         terrainOptions.setPainterOrderDepthEnabled(true);
+        terrainOptions.setMeshResolution(128);
+        terrainOptions.setDrapeFillsEnabled(true);
+        terrainOptions.setDrapeLinesEnabled(false);
         mapView.getOptions().setTerrainOptions(terrainOptions);
+
+
+        addTerrainTestElements();
+        addTerrainControls(view);
+        // Start tilted over the Alps (Grenoble). Note: setFocusPos expects base projection
+        // coordinates, so WGS84 positions must be converted first.
+        Projection proj = mapView.getOptions().getBaseProjection();
+        mapView.setFocusPos(proj.fromWgs84(new MapPos(5.763110, 45.218065)), 0);
+        mapView.setZoom(11.38f, 0);
+        mapView.setTilt(90f, 0);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -913,13 +914,12 @@ public class SecondFragment extends Fragment {
 
         // --- CompositeVectorTileLayer demo (2D). Comment this and restore addMap/addTerrain to go back. ---
 //        addCompositeMapNuti(dataPath); // nuti-parameter demo: relief toggles every 3s
-        addCompositeMap(dataPath);
+        addCompositeMap(view, dataPath);
 //        addMap(dataPath);
 //        addTerrain(view, dataPath);
 //        addRoutes(dataPath);
 //        addHillshadeLayer(view, dataPath);
 
-//        try {
 //            MBTilesTileDataSource dataSource = new MBTilesTileDataSource(dataPath+"/france/france_terrain.etiles");
 //            RasterTileLayer layer = new RasterTileLayer(dataSource);
 //            mapView.getLayers().add(layer);


### PR DESCRIPTION
Makes draped vector content (fills, contours, vector elements) render correctly and
fast over 3D terrain, by moving fills to a MapLibre-style render-to-texture drape and
fixing the painter-order depth model. Grew out of comparing CARTO's approach to
tangram-ng and MapLibre Native (see `docs/terrain-3d-draping.md`).

## What it does

**Fills — render-to-texture drape** (`TerrainOptions.DrapeFillsEnabled`)
- Polygon fills (+ backgrounds) are baked FLAT into a per-tile offscreen texture, sampled
  as the color of the terrain grid surface. Fills become the surface's texture, so they
  follow terrain exactly — zero holes, zero see-through, no depth slack.
- The drape surface writes TRUE depth and is the terrain occluder, so a near ridge blocks
  the far slope's raster/contours/elements (shared depth buffer).
- Cached per tile (bake once, reuse) — steady state does no offscreen work.

**Contours / tile lines** — sharp displaced geometry, lattice-clamped, drawn `GL_LEQUAL`
+ zero bias (no ridge leak). The anti-diagonal crack is fixed by finer line subdivision.
Optionally draped too (`DrapeLinesEnabled`) — softer but zero-cost hug.

**Vector elements** (routes) — `GL_LEQUAL` + zero clip bias + tunable painter-order
clearance (`ElementTerrainSlack`). Fixes the far-distance leak.

**Perf** — draped content skips terrain subdivision (baked flat), so VBOs upload at source
density instead of ~meshResolution² per tile; LRU elevation-texture cache (no full flush).
Together they cut the fast-zoom render-thread stall.

## Depth model (painter-order)
- Surface (drape) writes true depth = occluder; content draws `GL_LEQUAL` + zero forward
  bias → coincident content visible, behind-ridge content occluded, no distance leak.
- Removed the stray forward bias and the experimental source-density fill/line slack split.

## Known limitation
Low-zoom **VectorLayer element** lines still leak (CPU-baked to fine bilinear vs coarse
low-zoom occluder — no depth bias wins it). Fix is RTT element draping (cross-layer);
scoped as roadmap item 1.

## API
New: `TerrainOptions.DrapeFillsEnabled`, `DrapeLinesEnabled`, `ElementTerrainSlack`.
Removed: experimental `SourceDensityDrapingEnabled` / `SourceDensityDrapeSlack`.

Recommended config:
```java
terrainOptions.setPainterOrderDepthEnabled(true);
terrainOptions.setDrapeFillsEnabled(true);
terrainOptions.setMeshResolution(64);
```

## Notes
- libs-carto submodule bumped (pushed to `develop`).
- Roadmap + carto/tangram-ng/maplibre comparison in `docs/terrain-3d-draping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)