### PR TITLE
fix(terrain): make camera clearance a zoom bound instead of a corrective event

### DIFF
--- a/all/native/graphics/ViewState.cpp
+++ b/all/native/graphics/ViewState.cpp
@@ -6,6 +6,7 @@
 #include "utils/GeneralUtils.h"
 #include "utils/Log.h"
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <cglib/mat.h>
@@ -72,6 +73,21 @@ namespace carto {
             _terrainHeightMax = maxZ;
             _cameraChanged = true; // force near/far plane recalculation
         }
+    }
+
+    void ViewState::setTerrainMinCameraZ(double minCameraZ) {
+        _terrainMinCameraZ = minCameraZ;
+    }
+
+    float ViewState::getTerrainMaxZoom() const {
+        // The camera height above the (z=0) focus plane is zoom0Distance*cos(tilt)/2^zoom,
+        // so the zoom is bounded by the clearance shell through the ratio of the current
+        // height to the minimum height - no need to know the tilt or zoom0Distance, and no
+        // frame lag: the bound is re-derived from the live camera state on every use.
+        if (!(_terrainMinCameraZ > 0) || !(_cameraPos(2) > 0)) {
+            return std::numeric_limits<float>::infinity();
+        }
+        return _zoom + static_cast<float>(std::log2(_cameraPos(2) / _terrainMinCameraZ));
     }
 
     void ViewState::setCameraPos(const cglib::vec3<double>& cameraPos) {
@@ -297,12 +313,14 @@ namespace carto {
     }
 
     void ViewState::clampZoom(const Options& options) {
-        if (!options.isRestrictedPanning() || _width <= 0 || _height <= 0) {
+        // The terrain bound applies regardless of restricted panning - it is a property of
+        // the terrain, not of the pan bounds.
+        float maxZoom = std::min(options.getZoomRange().getMax(), getTerrainMaxZoom());
+        if ((!options.isRestrictedPanning() && _zoom <= maxZoom) || _width <= 0 || _height <= 0) {
             return;
         }
 
-        MapRange zoomRange = options.getZoomRange();
-        float zoom = GeneralUtils::Clamp(_zoom, getMinZoom(), zoomRange.getMax());
+        float zoom = GeneralUtils::Clamp(_zoom, getMinZoom(), maxZoom);
 
         if (zoom != getZoom() && _zoom0Distance > 0) {
             double length = _zoom0Distance / std::pow(2.0f, zoom);

--- a/all/native/graphics/ViewState.h
+++ b/all/native/graphics/ViewState.h
@@ -183,7 +183,26 @@ namespace carto {
          * @param maxZ The maximum terrain height.
          */
         void setTerrainHeightRange(float minZ, float maxZ);
-    
+
+        /**
+         * Sets the minimum camera height (in internal units) imposed by the terrain
+         * clearance, or 0 to disable the terrain zoom bound. Published once per frame
+         * by the renderer from the elevation under the camera.
+         * @param minCameraZ The minimum camera height, 0 to disable.
+         */
+        void setTerrainMinCameraZ(double minCameraZ);
+        /**
+         * Returns the maximum zoom allowed by the terrain clearance, or infinity when
+         * no terrain bound is active. Evaluated against the CURRENT camera state, so it
+         * carries no frame lag: zooming in by this delta lands the camera exactly on the
+         * clearance shell. Every zoom path (gesture, animation, kinetic fling, API) is
+         * clamped by it, which is what keeps the camera from being pushed into the
+         * terrain and then corrected back out - the correction/gesture fight that makes
+         * zooming jump back and forth.
+         * @return The terrain-imposed maximum zoom.
+         */
+        float getTerrainMaxZoom() const;
+
         /**
          * Returns the vertical field of view angle.
          * @return The vertical field of view angle in degrees.
@@ -411,6 +430,7 @@ namespace carto {
 
         float _terrainHeightMin = 0.0f;
         float _terrainHeightMax = 0.0f;
+        double _terrainMinCameraZ = 0.0; // 0 = no terrain zoom bound
     
         int _fovY;
         float _halfFOVY;

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1082,25 +1082,40 @@ namespace carto {
                         _terrainRenderer->updateDepthBuffer(viewState, terrainOptions, _glResourceManager);
                     }
 
-                    // Camera terrain-following: keep the camera at least the configured
-                    // clearance above the terrain surface. The correction goes through the
-                    // normal camera event path (a zoom-out; instant by default, optionally
-                    // animated), never by mutating the view state directly.
+                    // Camera terrain-following. The clearance is expressed as a BOUND on the
+                    // zoom (ViewState::setTerrainMinCameraZ -> getTerrainMaxZoom), which every
+                    // zoom path clamps against, rather than as a corrective zoom-out issued
+                    // after the camera has already broken through. A corrective event fights
+                    // whatever is driving the camera down - the pinch gesture, the double-tap
+                    // zoom animation, a kinetic fling - so the camera oscillates for as long as
+                    // the gesture lasts, and an animation that keeps its absolute target snaps
+                    // back to it on its final tick (the "double tap jumps back" symptom). As a
+                    // bound, the gesture simply comes to rest against the terrain.
+                    // A correction is still needed for the paths that change the camera height
+                    // WITHOUT going through a zoom event - panning into a hillside, tilting, or
+                    // new elevation tiles raising the ground under a stationary camera. Like
+                    // tangram (View::updateMatrices), that correction is strictly
+                    // one-directional (it only ever zooms out, never back in) and lands exactly
+                    // on the clearance shell, so it cannot oscillate.
                     float cameraClearance = terrainOptions->getCameraClearance();
                     float clampDuration = terrainOptions->getCameraClampDuration();
-                    auto now = std::chrono::steady_clock::now();
-                    bool debounced = (clampDuration > 0 && now - _lastTerrainCameraClampTime < std::chrono::milliseconds(static_cast<int>(clampDuration * 1000)));
-                    if (cameraClearance > 0 && !debounced) {
+                    if (cameraClearance > 0) {
                         std::shared_ptr<ElevationManager> elevationManager = terrainOptions->getElevationManager();
                         cglib::vec3<double> cameraPos = viewState.getCameraPos();
                         double terrainZ = elevationManager->getDisplayHeight(cameraPos(0), cameraPos(1), ElevationManager::LoadMode::CACHED_ONLY);
                         double minCameraZ = terrainZ + cameraClearance * elevationManager->getDisplayScale(cameraPos(1));
+                        {
+                            std::lock_guard<std::recursive_mutex> lock(_mutex);
+                            _viewState.setTerrainMinCameraZ(minCameraZ);
+                        }
                         if (cameraPos(2) > 0 && cameraPos(2) < minCameraZ) {
-                            _lastTerrainCameraClampTime = now;
                             CameraZoomEvent zoomEvent;
-                            zoomEvent.setZoomDelta(static_cast<float>(std::log2(cameraPos(2) / minCameraZ)) * 1.05f); // negative: zoom out just past the clearance
+                            zoomEvent.setZoomDelta(static_cast<float>(std::log2(cameraPos(2) / minCameraZ))); // negative: zoom out onto the clearance
                             calculateCameraEvent(zoomEvent, clampDuration, false);
                         }
+                    } else {
+                        std::lock_guard<std::recursive_mutex> lock(_mutex);
+                        _viewState.setTerrainMinCameraZ(0);
                     }
                 }
             }
@@ -1111,6 +1126,8 @@ namespace carto {
                     tileLayer->setTerrainDepthWriteMode(false);
                 }
             }
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            _viewState.setTerrainMinCameraZ(0); // release the terrain zoom bound
         }
 
         // Create new billboard sorter instance

--- a/all/native/renderers/MapRenderer.h
+++ b/all/native/renderers/MapRenderer.h
@@ -216,7 +216,6 @@ namespace carto {
         std::string _postProcessShaderName;
         std::optional<std::chrono::steady_clock::time_point> _postProcessStartTime;
         std::unique_ptr<TerrainRenderer> _terrainRenderer;
-        std::chrono::steady_clock::time_point _lastTerrainCameraClampTime; // debounces camera terrain-following corrections
 
         unsigned int _layersElevationVersion = 0;
         std::optional<std::chrono::steady_clock::time_point> _lastElevationRefreshTime;

--- a/all/native/renderers/cameraevents/CameraZoomEvent.cpp
+++ b/all/native/renderers/cameraevents/CameraZoomEvent.cpp
@@ -9,6 +9,8 @@
 #include "utils/Log.h"
 #include "utils/GeneralUtils.h"
 
+#include <algorithm>
+
 namespace carto {
 
     CameraZoomEvent::CameraZoomEvent() :
@@ -92,8 +94,14 @@ namespace carto {
             targetPos = projectionSurface->calculatePosition(_targetPos);
         }
     
+        // Bound the zoom by the terrain clearance here, at the single point every zoom
+        // path funnels through (pinch, double-tap animation, kinetic fling, API calls).
+        // Clamping the REQUESTED zoom makes the gesture come to rest against the terrain;
+        // letting it through and correcting the camera afterwards makes the two fight
+        // every frame, which is what made zooming jump back and forth.
         MapRange zoomRange = options.getZoomRange();
-        float zoom = GeneralUtils::Clamp(viewState.getZoom() + _zoomDelta, viewState.getMinZoom(), zoomRange.getMax());
+        float maxZoom = std::min(zoomRange.getMax(), viewState.getTerrainMaxZoom());
+        float zoom = GeneralUtils::Clamp(viewState.getZoom() + _zoomDelta, viewState.getMinZoom(), maxZoom);
         double scale = std::pow(2.0f, viewState.getZoom() - zoom);
         cglib::mat4x4<double> shiftTransform = projectionSurface->calculateTranslateMatrix(focusPos, targetPos, 1.0 - scale);
 


### PR DESCRIPTION
## Problem

Zooming near the terrain jumped back and forth, and double-tap-to-zoom bounced back when close to the ground.

The per-frame camera terrain-following clamp let the gesture push the camera through the clearance shell, then issued a corrective zoom-out event (with a 1.05 overshoot) to pull it back. That fights whatever is driving the camera down — pinch, the double-tap zoom animation, a kinetic fling — so both controllers act on the same variable every frame and the camera oscillates for the duration of the gesture.

Double-tap was worse: `AnimationHandler::calculateZoom` snaps to its **absolute** `_zoomTarget` on its final tick, so it always yanked back to the unreachable target right after the clamp had pushed out.

## Fix

Express the clearance as a **bound on the zoom** rather than a reaction to violating it.

- `ViewState::setTerrainMinCameraZ` / `getTerrainMaxZoom` — the renderer publishes the minimum camera height each frame; the max zoom is re-derived from the live camera state on every use, so the bound carries no frame lag.
- Enforced in `CameraZoomEvent::calculate` — the single point every zoom path funnels through (pinch, animation tick, kinetic fling, API) — and in `ViewState::clampZoom`.
- The corrective event survives only for paths that change camera height *without* a zoom event (panning into a hillside, tilting, elevation tiles loading under a parked camera). It is now strictly one-directional and lands exactly on the clearance shell, so it cannot oscillate.
- The clamp debounce and its `_lastTerrainCameraClampTime` member are no longer needed.

This mirrors how [tangram-ng](https://github.com/farfromrefug/tangram-ng) keeps its terrain correction and its gestures off the same variable — gestures drive the *effective* zoom while the terrain correction rewrites only the *base* zoom, and the correction only ever decreases it (`View::updateMatrices`: *"decrease base zoom if too close to terrain (but never increase)"*).

## Testing

Verified on the Android emulator: pinch zoom now comes to rest against the terrain instead of oscillating, and double-tap no longer bounces back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)