### PR TITLE
fix(datasources): do not dereference a failed tile in PersistentCacheTileDataSource

### DIFF
--- a/all/native/datasources/PersistentCacheTileDataSource.cpp
+++ b/all/native/datasources/PersistentCacheTileDataSource.cpp
@@ -93,9 +93,11 @@ namespace carto {
         if (!_cacheOnlyMode) {
             lock.unlock();
             tileData = _dataSource->loadTile(mapTile);
-            std::map<std::string, std::shared_ptr<Variant>> metadata = _dataSource->buildTileMetadata(mapTile);
-            for (const auto& entry : metadata) {
-                tileData->setMetadata(entry.first, entry.second);
+            if (tileData) { // loading can fail (network errors), in which case there is nothing to annotate
+                std::map<std::string, std::shared_ptr<Variant>> metadata = _dataSource->buildTileMetadata(mapTile);
+                for (const auto& entry : metadata) {
+                    tileData->setMetadata(entry.first, entry.second);
+                }
             }
             lock.lock();
         }


### PR DESCRIPTION
## Problem

A tile that fails to load (network error) crashes the app instead of being skipped:

```
E carto-mobile-sdk: HTTPTileDataSource::loadTile: Exception while loading tile 5/16/10: Unable to connect: https://tiles.mapterhorn.com/5/16/10.webp
F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x48 in tid 1803 (Thread-5)
```

Symbolized backtrace:

```
#01 std::mutex::lock()
#02 std::lock_guard<std::mutex>::lock_guard
#03 carto::TileData::setMetadata            (TileData.cpp:70)
#04 carto::PersistentCacheTileDataSource::loadTile  (PersistentCacheTileDataSource.cpp:98)
#06 carto::ElevationManager::loadTileGrid   (ElevationManager.cpp:394)
#07 carto::ElevationManager::getTileGrid    (ElevationManager.cpp:196)
#08 carto::TileLayer::FetchTaskBase::run    (TileLayer.cpp:888)
```

`HTTPTileDataSource::loadTile` catches the network exception and returns a null `TileData`, as designed. `PersistentCacheTileDataSource::loadTile` then applied the source metadata to that null pointer, so `setMetadata` locked its mutex at offset `0x48` of a null object.

## Fix

Guard the metadata pass on a non-null tile — the same null check the cache-hit path a few lines above already does, and what `TileDataSource::applyTileMetadata` does.

## Verification

Reproduced on the Android emulator: terrain + hillshade over a `PersistentCacheTileDataSource` elevation source, airplane mode enabled, app crashed within seconds of launch on the first failed elevation tile. With the fix, failed tiles are logged and skipped, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)