### PR TITLE
feat(network): report the underlying Java exception on Android HTTP failures

### DIFF
--- a/android/native/network/HTTPClientAndroidImpl.cpp
+++ b/android/native/network/HTTPClientAndroidImpl.cpp
@@ -92,6 +92,18 @@ namespace carto {
         }
     };
     
+    struct HTTPClient::AndroidImpl::ThrowableClass {
+        JNIUniqueGlobalRef<jclass> clazz;
+        jmethodID toString;
+        jmethodID getCause;
+
+        explicit ThrowableClass(JNIEnv* jenv) {
+            clazz = JNIUniqueGlobalRef<jclass>(jenv, jenv->NewGlobalRef(jenv->FindClass("java/lang/Throwable")));
+            toString = jenv->GetMethodID(clazz, "toString", "()Ljava/lang/String;");
+            getCause = jenv->GetMethodID(clazz, "getCause", "()Ljava/lang/Throwable;");
+        }
+    };
+
     HTTPClient::AndroidImpl::AndroidImpl(bool log) :
         _log(log),
         _timeout(-1)
@@ -113,15 +125,13 @@ namespace carto {
         // Create URL
         jobject url = jenv->NewObject(GetURLClass()->clazz, GetURLClass()->constructor, jenv->NewStringUTF(request.url.c_str()));
         if (jenv->ExceptionCheck()) {
-            jenv->ExceptionClear();
-            throw NetworkException("Invalid URL", request.url);
+            throw BuildNetworkException(jenv, "Invalid URL", request.url); // clears the pending Java exception
         }
 
         // Open HTTP connection
         jobject conn = jenv->CallObjectMethod(url, GetURLClass()->openConnection);
         if (jenv->ExceptionCheck()) {
-            jenv->ExceptionClear();
-            throw NetworkException("Unable to open connection", request.url);
+            throw BuildNetworkException(jenv, "Unable to open connection", request.url); // clears the pending Java exception
         }
         
         // Configure connection parameters
@@ -148,8 +158,7 @@ namespace carto {
         if (!request.contentType.empty()) {
             jobject outputStream = jenv->CallObjectMethod(conn, GetHttpURLConnectionClass()->getOutputStream);
             if (jenv->ExceptionCheck()) {
-                jenv->ExceptionClear();
-                throw NetworkException("Unable to get output stream", request.url);
+                throw BuildNetworkException(jenv, "Unable to get output stream", request.url); // clears the pending Java exception
             }
 
             jbyteArray jbuf = jenv->NewByteArray(request.body.size());
@@ -157,28 +166,30 @@ namespace carto {
 
             jenv->CallVoidMethod(outputStream, GetOutputStreamClass()->write, jbuf);
             if (jenv->ExceptionCheck()) {
-                jenv->ExceptionClear();
-                throw NetworkException("Unable to write data", request.url);
+                throw BuildNetworkException(jenv, "Unable to write data", request.url); // clears the pending Java exception
             }
             jenv->CallVoidMethod(outputStream, GetOutputStreamClass()->close);
             if (jenv->ExceptionCheck()) {
-                jenv->ExceptionClear();
-                throw NetworkException("Unable to write data", request.url);
+                throw BuildNetworkException(jenv, "Unable to write data", request.url); // clears the pending Java exception
             }
         }
 
         // Connect
         jenv->CallVoidMethod(conn, GetHttpURLConnectionClass()->connect);
         if (jenv->ExceptionCheck()) {
-            jenv->ExceptionClear();
-            throw NetworkException("Unable to connect", request.url);
+            // Include the configured timeout: a plain SocketTimeoutException does not say whether
+            // the SDK-level timeout or the platform default was in effect.
+            std::string msg = "Unable to connect";
+            if (timeout > 0) {
+                msg += " (connect/read timeout " + boost::lexical_cast<std::string>(timeout) + " ms)";
+            }
+            throw BuildNetworkException(jenv, msg, request.url); // clears the pending Java exception
         }
         
         // Read response header
         jint responseCode = jenv->CallIntMethod(conn, GetHttpURLConnectionClass()->getResponseCode);
         if (jenv->ExceptionCheck()) {
-            jenv->ExceptionClear();
-            throw NetworkException("Unable to read response code", request.url);
+            throw BuildNetworkException(jenv, "Unable to read response code", request.url); // clears the pending Java exception
         }
         std::map<std::string, std::string> headers;
         for (int i = 0; true; i++) {
@@ -206,8 +217,7 @@ namespace carto {
             jenv->ExceptionClear();
             inputStream = jenv->CallObjectMethod(conn, GetHttpURLConnectionClass()->getErrorStream);
             if (jenv->ExceptionCheck()) {
-                jenv->ExceptionClear();
-                throw NetworkException("Unable to get input stream", request.url);
+                throw BuildNetworkException(jenv, "Unable to get input stream", request.url); // clears the pending Java exception
             }
         }
         
@@ -220,8 +230,7 @@ namespace carto {
                 jint numBytesRead = jenv->CallIntMethod(inputStream, GetInputStreamClass()->read, jbuf);
 
                 if (jenv->ExceptionCheck()) {
-                    jenv->ExceptionClear();
-                    throw NetworkException("Unable to read data", request.url);
+                    throw BuildNetworkException(jenv, "Unable to read data", request.url); // clears the pending Java exception
                 }
                 if (numBytesRead < 0) {
                     break;
@@ -278,5 +287,55 @@ namespace carto {
         static std::unique_ptr<OutputStreamClass> cls(new OutputStreamClass(AndroidUtils::GetCurrentThreadJNIEnv()));
         return cls;
     }
-    
+
+    std::unique_ptr<HTTPClient::AndroidImpl::ThrowableClass>& HTTPClient::AndroidImpl::GetThrowableClass() {
+        static std::unique_ptr<ThrowableClass> cls(new ThrowableClass(AndroidUtils::GetCurrentThreadJNIEnv()));
+        return cls;
+    }
+
+    std::string HTTPClient::AndroidImpl::DescribePendingException(JNIEnv* jenv) {
+        JNIUniqueLocalRef<jthrowable> throwable(jenv, jenv->ExceptionOccurred());
+        if (!throwable) {
+            return std::string();
+        }
+        jenv->ExceptionClear(); // any JNI call below is illegal while an exception is pending
+
+        // Walk the cause chain: the interesting detail ("Failed to connect to .../10.0.2.16:443",
+        // "Chain validation failed", ...) is often only in the cause, not in the top exception.
+        std::string description;
+        for (int depth = 0; throwable && depth < MAX_EXCEPTION_CAUSE_DEPTH; depth++) {
+            JNIUniqueLocalRef<jstring> text(jenv, jenv->CallObjectMethod(throwable, GetThrowableClass()->toString));
+            if (jenv->ExceptionCheck()) {
+                jenv->ExceptionClear();
+                break;
+            }
+            if (text) {
+                if (const char* textStr = jenv->GetStringUTFChars(text, NULL)) {
+                    description += (description.empty() ? "" : ", caused by ");
+                    description += textStr;
+                    jenv->ReleaseStringUTFChars(text, textStr);
+                }
+            }
+
+            JNIUniqueLocalRef<jthrowable> cause(jenv, jenv->CallObjectMethod(throwable, GetThrowableClass()->getCause));
+            if (jenv->ExceptionCheck()) {
+                jenv->ExceptionClear();
+                break;
+            }
+            if (cause && jenv->IsSameObject(cause, throwable)) {
+                break; // self-referencing cause
+            }
+            throwable = std::move(cause);
+        }
+        return description;
+    }
+
+    NetworkException HTTPClient::AndroidImpl::BuildNetworkException(JNIEnv* jenv, const std::string& msg, const std::string& url) {
+        std::string description = DescribePendingException(jenv);
+        if (description.empty()) {
+            return NetworkException(msg, url);
+        }
+        return NetworkException(msg + " (" + description + ")", url);
+    }
+
 }

--- a/android/native/network/HTTPClientAndroidImpl.h
+++ b/android/native/network/HTTPClientAndroidImpl.h
@@ -8,8 +8,12 @@
 #define _CARTO_HTTPCLIENTANDROIDIMPL_H_
 
 #include "network/HTTPClient.h"
+#include "components/Exceptions.h"
 
 #include <atomic>
+#include <string>
+
+#include <jni.h>
 
 namespace carto {
 
@@ -25,11 +29,28 @@ namespace carto {
         struct HttpURLConnectionClass;
         struct InputStreamClass;
         struct OutputStreamClass;
-        
+        struct ThrowableClass;
+
         static std::unique_ptr<URLClass>& GetURLClass();
         static std::unique_ptr<HttpURLConnectionClass>& GetHttpURLConnectionClass();
         static std::unique_ptr<InputStreamClass>& GetInputStreamClass();
         static std::unique_ptr<OutputStreamClass>& GetOutputStreamClass();
+        static std::unique_ptr<ThrowableClass>& GetThrowableClass();
+
+        /**
+         * Clears the pending Java exception and returns its description, including its cause
+         * chain ("java.net.ConnectException: Failed to connect to ..., caused by ..."). Returns
+         * an empty string if no exception is pending.
+         */
+        static std::string DescribePendingException(JNIEnv* jenv);
+
+        /**
+         * Builds a NetworkException for a failed JNI call, clearing the pending Java exception and
+         * folding its description into the exception message.
+         */
+        static NetworkException BuildNetworkException(JNIEnv* jenv, const std::string& msg, const std::string& url);
+
+        static const int MAX_EXCEPTION_CAUSE_DEPTH = 4;
 
         const bool _log;
         std::atomic<int> _timeout;


### PR DESCRIPTION
## Problem

Android HTTP failures were unusable for diagnosis. Every JNI call site did `ExceptionClear()` and threw a fixed string, discarding the Java exception:

```
E carto-mobile-sdk: HTTPTileDataSource::loadTile: Exception while loading tile 11/1056/736: Unable to connect: https://tiles.mapterhorn.com/11/1056/736.webp
```

"Unable to connect" covers a connect timeout, `UnknownHostException`, an SSL handshake failure, and fd/socket exhaustion equally — and none of them is distinguishable from the log, even when the same URL loads fine in a browser on the same device.

## Change

- `ThrowableClass` — cached `toString` / `getCause` method ids.
- `DescribePendingException(jenv)` — grabs the throwable, clears it (JNI calls are illegal while an exception is pending), then walks up to 4 causes (`", caused by "`), guarding against a self-referencing cause.
- `BuildNetworkException(jenv, msg, url)` — used by all nine throw sites; falls back to the old message when nothing is pending.
- The connect site additionally reports the configured timeout, which a bare `SocketTimeoutException` does not attribute to the SDK setting.

Resulting message:

```
Unable to connect (connect/read timeout 10000 ms) (java.net.SocketTimeoutException: failed to connect to tiles.mapterhorn.com/151.101.1.1 (port 443) from /10.0.2.16 (port 41234) after 10000ms): https://tiles.mapterhorn.com/11/1056/736.webp
```

The iOS implementation already forwards the `NSError` description, so no change there.

## Verification

Compile-checked with the NDK toolchain:

```
$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=aarch64-linux-android24 \
  -fsyntax-only -std=c++17 -I all/native -I android/native -I libs-external/boost \
  -I libs-external/tinyformat android/native/network/HTTPClientAndroidImpl.cpp
```

Not yet run on a device — the next failing tile fetch will print the real cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)