### PR TITLE
fix(layers): match style attachments in composite group filters

### DIFF
--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -133,7 +133,8 @@ namespace carto {
         // overzoom independently - e.g. a ContourTileDataSource renders z13+ from z12 DEM data via
         // the child layer's MaxOverzoomLevel, without needing the DEM at the target zoom.
         auto childVectorLayer = std::make_shared<VectorTileLayer>(dataSource, getTileDecoder());
-        childVectorLayer->setRendererLayerFilter("^(" + name + ")$");
+        // Style names, not layer names: attachments included (see buildFilterString).
+        childVectorLayer->setRendererLayerFilter("^(" + name + ")(::.*)?$");
         childVectorLayer->setMaxOverzoomLevel(dataSource->getMaxOverzoomLevel());
         childVectorLayer->setLabelRenderOrder(getLabelRenderOrder());
         childVectorLayer->setBuildingRenderOrder(getBuildingRenderOrder());
@@ -214,10 +215,17 @@ namespace carto {
             // nothing ("[^\\s\\S]" requires one impossible char, so it matches no string, not even "").
             return includeBackground ? "^$" : "[^\\s\\S]";
         }
-        std::string pattern = "^(";
+        // The filter is matched against the name of every rendered vt tile layer, and that name is
+        // the STYLE name, not the map layer name: a layer with CartoCSS attachments produces one
+        // style per attachment, named "layer::attachment" (and nested, "layer::a::b"). Matching the
+        // bare layer name alone therefore keeps only the default attachment and silently drops the
+        // rest - all of "transportation::casing*", "poi::icon", "landcover::wood", "place::label".
+        // So accept the layer name followed by any attachment suffix.
+        std::string pattern = "^((";
         for (std::size_t i = 0; i < group.size(); i++) {
             pattern += (i ? "|" : "") + group[i];
         }
+        pattern += ")(::.*)?";
         if (includeBackground) {
             pattern += "|"; // empty alternative -> also matches the empty-named background layer
         }


### PR DESCRIPTION
## What

`CompositeVectorTileLayer` group filters (and the vector-source child filter) now accept a style layer name followed by any attachment suffix: `^((a|b|c)(::.*)?|)$` instead of `^(a|b|c)$`.

## Why

The layer splits the master style into groups around each external source slot and gives every group a `rendererLayerFilter` built from `decoder->getStyleLayerNames()` — mapnik **Layer** names. That filter is matched against the name of each rendered `vt::TileLayer`, and `mvt::TileReader` names those after the **style**, not the layer: a layer with CartoCSS attachments produces one style per attachment, named `layer::attachment` (nested too, `layer::a::b`).

So `^(housenumber|route|transportation|)$` kept only the default attachment and dropped every other style of those layers. With an attachment-using style that means:

| layer | styles kept | styles dropped |
|---|---|---|
| `transportation` | `transportation` | `::casing*`, `::bridge*`, `::transit`, `::aerial`, `::label` |
| `poi` | — | `::icon`, `::label` |
| `landcover` | `landcover` | `::wood`, `::sand` |
| `building` | `building` | `::3d`, `::line` |
| `place`, `housenumber` | — | `::label` |

Result: roads, poi, patterns, buildings and place labels looked like missing layers — but only once an external source occupied a slot (hillshade, raster, or a vector slot such as `ContourTileDataSource`). With no slot the filter is `""`, nothing is filtered, and the bug is invisible. Unrelated to the terrain/draping work; reproduced with draping off.

## Reviewer notes

- The background alternative stays outside the suffix group, so group 0 still matches the empty-named background layer and non-bottom groups still do not.
- Match is anchored and full, so `transportation` does not swallow `transportation_name` (the next char must be `::`).
- Names are still not regex-escaped — unchanged behaviour, layer names are identifiers in practice.

## Verification

android-dev demo, attachment-using style bundle, hillshade + contour slots, 3D terrain, z14.7/t45 and the default z11.5 view: roads, motorway shields, poi icons, wood patterns, buildings and place labels all render again; `--es contour false` (no slot, previously the only working config) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)