### PR TITLE
fix(terrain): floor the shadow sun altitude for the shadow pass

### DIFF
--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1406,6 +1406,10 @@ namespace carto {
                     // at half the sharpness, while a tile with no stand-in at all shows a flat
                     // fill - a hole. An integer zoom step renames the whole cover at once, so the
                     // second class is exactly what has to be cleared fast.
+                    // Raising this to bake a whole renamed cover in one frame was measured on
+                    // device: worst frame 128 ms -> 300 ms, with no visible difference in the
+                    // stand-ins it was meant to remove. A bake is ~16 ms per tile at 1024, so the
+                    // budget IS the frame time here; keep it low and let the cover catch up.
                     static const int DRAPE_BAKE_BUDGET_BLANK = 8;
                     static const int DRAPE_BAKE_BUDGET_STANDIN = 3;
                     static const int DRAPE_BAKE_BUDGET_STALE = 1;
@@ -1444,7 +1448,12 @@ namespace carto {
                         }
                         std::size_t drapedIndex = drapedTiles.size(); // before the stand-in draws below extend the list
                         drapedTiles.push_back(draped);
-                        if (!hasContent) {
+                        // ONLY when no ancestor stand-in was found. The descendants are separate
+                        // surfaces at a finer tile zoom: their meshes coincide with this leaf's but
+                        // are not the same triangles, so drawn over it they read as tiles sitting
+                        // slightly off the terrain - while an ancestor sub-rect is the SAME mesh
+                        // with a blurrier texture, which merely looks soft. Prefer the soft one.
+                        if (!hasContent && draped.texture == 0) {
                             // Zooming OUT there is no baked ancestor - the cached tiles are the
                             // finer ones underneath. Draw those over the top: same meshes, same
                             // depth, so the ground shows real content instead of a flat fill.
@@ -1563,6 +1572,32 @@ namespace carto {
                         }
                     }
                     ResolvedLighting lighting = resolveLighting(_options->getLightOptions(), styleEnvironment);
+                    // The SHADOW sun, which is not always the lighting sun. A shadow is as long as
+                    // the caster is tall divided by tan(altitude): at 9 degrees a 700 m hill throws
+                    // 4.4 km and a 2 km massif 13 km. Two things break there, both measured. The
+                    // light box is stretched along the light by that same relief/tan(altitude), so
+                    // the whole cascade ladder goes coarse (31/53/62 m texels at z12.3 tilt 60,
+                    // against 11 m with the box bounded) - and shadows that long need casters from
+                    // far outside the drawn cover, so what does reach the screen is a flat grey
+                    // wash that appears and disappears as the cover changes with the zoom.
+                    // Flooring the altitude for the shadow pass ALONE caps the shadow length at
+                    // ~3.7x the relief and keeps the texels usable, while N.L lighting keeps the
+                    // true sun - so a low sun still reads as a low sun, without the wash.
+                    cglib::vec3<float> shadowSunDir = lighting.sunDir;
+                    {
+                        static const float MIN_SHADOW_SUN_SIN = 0.2588f; // sin(15 degrees)
+                        if (shadowSunDir(2) < MIN_SHADOW_SUN_SIN) {
+                            float horizontal = std::sqrt(shadowSunDir(0) * shadowSunDir(0) + shadowSunDir(1) * shadowSunDir(1));
+                            float scale = std::sqrt(std::max(0.0f, 1.0f - MIN_SHADOW_SUN_SIN * MIN_SHADOW_SUN_SIN));
+                            if (horizontal > 1.0e-6f) {
+                                // Keep the azimuth: only the altitude is raised, so the shadows
+                                // still fall in the direction the sun says, just shorter.
+                                shadowSunDir(0) *= scale / horizontal;
+                                shadowSunDir(1) *= scale / horizontal;
+                            }
+                            shadowSunDir(2) = MIN_SHADOW_SUN_SIN;
+                        }
+                    }
                     bool shadowsWanted = false;
                     {
                         shadowsWanted = lighting.terrainLightingEnabled && lighting.shadowStrength > 0.0f && !drapeTileIds.empty();
@@ -1635,7 +1670,7 @@ namespace carto {
                             std::array<std::vector<vt::TileId>, TerrainShadowMap::MAX_CASCADES> cascadeCasterTiles;
                             for (int cascade = 0; cascade < cascades; cascade++) {
                                 double depthRangeMeters = 1.0, texelMeters = 0;
-                                if (drapeLayers.front()->calculateShadowViewProj(drapeTileIds, casterTileIds, lighting.sunDir, tileHeights, minHeight, maxHeight, lighting.shadowDistance, _terrainShadowMap->getSize(), cascade, cascades, cascadeCasterTiles[cascade], depthRangeMeters, texelMeters, lightViewProjs[cascade])) {
+                                if (drapeLayers.front()->calculateShadowViewProj(drapeTileIds, casterTileIds, shadowSunDir, tileHeights, minHeight, maxHeight, lighting.shadowDistance, _terrainShadowMap->getSize(), cascade, cascades, cascadeCasterTiles[cascade], depthRangeMeters, texelMeters, lightViewProjs[cascade])) {
                                     // The bias is metric; the shader wants a fraction of the
                                     // normalised light depth, and each cascade's box spans its
                                     // own depth. Dividing per cascade is what keeps the shadow


### PR DESCRIPTION
## What

The shadow pass floors the sun altitude at 15° (azimuth untouched). N·L terrain lighting keeps the true sun, so only shadow *geometry* is affected.

Also: a drape tile standing in on a baked ancestor no longer additionally draws its finer baked descendants over itself.

## Why

A shadow is the caster's height over `tan(altitude)`. At the demo's 9° sun a 700 m hill throws 4.4 km and a 2 km massif 13 km, so half the valley is legitimately shadowed — but the shadow map cannot carry it: at that camera (z12.3, tilt 60, 1024 map, 3 cascades) the texels are 31/53/62 m, so it renders as a flat grey wash with a stair-stepped boundary, and it appears and disappears as the drawn cover changes with the zoom, because casters that far up-sun are not always in it.

Probes on device ruled out the usual suspects:

| probe | outcome |
|---|---|
| `shadowBias 20` | washes unchanged → not acne |
| `shadowMapSize 2048` | unchanged → not resolution |
| `shadowDistance 5000` (texels → 10.7 m) | unchanged → not texel size |
| `sunAltitude 30` | clean |
| `sunAzimuth 180` | pattern mirrors correctly → light matrices are right |
| shadows off | clean → it is the shadow map, not N·L |

Capping the length at ~3.7× the relief keeps the shadows inside what the map can represent and makes them consistent across zooms.

The descendant overdraw is a separate small thing: descendants are surfaces at a finer tile zoom, coincident with the leaf's mesh but not the same triangles, so drawn on top they read as tiles sitting slightly off the terrain. An ancestor sub-rect is the same mesh with a softer texture, so when one exists it is the better stand-in.

## Reviewer notes

- 15° = `sin = 0.2588`; the horizontal component is rescaled so the azimuth is preserved and the direction stays unit length.
- Only `calculateShadowViewProj` sees the floored direction; `setTerrainSunLighting` still gets the real one.
- Texel sizes do **not** change at this camera — the light box is bounded by the view (nearest visible ground ~10 km away spanning ~20 km across the cone), not by the `1/tan(sun)` term. What changed is shadow length.

## Verification

android-dev demo, real style bundle, hillshade + contour slots, 3D terrain, z12.3 tilt 60, sun 355°/9°: the wash over the Grenoble/Meylan valley is gone, shadows stay on the relief, the boundary no longer staircases. Checked z12.7 and the 11.5→14.5 zoom animation as well.

## Known, not addressed here

Drape bake cost: worst frame 128–350 ms in the field, ~16 ms per tile at `drapeResolution 1024`, and dropping to 512 did not clearly help (measurements were across different styles, so not conclusive). Tracked separately — it is what makes drape stand-ins linger on screen at a drape-zoom step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)