### PR TITLE
fix(terrain): stabilize 3D terrain labels and cut the label/tile churn behind them

### DIFF
--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -22,6 +22,7 @@
 #include "utils/Log.h"
 
 #include <vt/TileTransformer.h>
+#include <vt/RenderStats.h>
 
 namespace carto {
 
@@ -300,14 +301,23 @@ namespace carto {
         // Check if layer should be drawn
         if (!isVisible() || !getVisibleZoomRange().inRange(cullState->getViewState().getZoom()) || getOpacity() <= 0) {
             _calculatingTiles = false;
+            vt::RenderStats::tileLayersSkipped++;
 
-            refreshDrawData(cullState, true);
+            // Report the real change, not an unconditional one. This path runs on every cull
+            // pass for as long as the layer stays hidden, and a hardcoded 'changed' makes a
+            // VectorTileLayer request a redraw and a full label placement pass every time -
+            // and the redraw brings the cull worker straight back here. A hidden layer then
+            // burns a placement pass over every OTHER layer's labels, several times a second,
+            // on a completely still map. refreshTiles below still reports true once, on the
+            // pass that empties the tile set, which is the only change there is to report.
+            refreshDrawData(cullState, false);
             return;
         }
 
         // Check if tiles need to be recalculated
         bool recalculateTiles = (!_tileCullState || _frameNr != _lastFrameNr || cullState->getViewState().getModelviewProjectionMat() != _tileCullState->getViewState().getModelviewProjectionMat());
         if (recalculateTiles) {
+            vt::RenderStats::tileRecalculations++;
             // If the view has changed calculate new visible tiles, otherwise use the old ones
             calculateVisibleTiles(cullState);
 

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -301,7 +301,7 @@ namespace carto {
         // Check if layer should be drawn
         if (!isVisible() || !getVisibleZoomRange().inRange(cullState->getViewState().getZoom()) || getOpacity() <= 0) {
             _calculatingTiles = false;
-            vt::RenderStats::tileLayersSkipped++;
+            VT_STAT_INC(tileLayersSkipped);
 
             // Report the real change, not an unconditional one. This path runs on every cull
             // pass for as long as the layer stays hidden, and a hardcoded 'changed' makes a
@@ -317,7 +317,7 @@ namespace carto {
         // Check if tiles need to be recalculated
         bool recalculateTiles = (!_tileCullState || _frameNr != _lastFrameNr || cullState->getViewState().getModelviewProjectionMat() != _tileCullState->getViewState().getModelviewProjectionMat());
         if (recalculateTiles) {
-            vt::RenderStats::tileRecalculations++;
+            VT_STAT_INC(tileRecalculations);
             // If the view has changed calculate new visible tiles, otherwise use the old ones
             calculateVisibleTiles(cullState);
 

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -56,18 +56,19 @@
 
 namespace carto {
 
+#if CARTO_VT_RENDER_STATS
     namespace {
-        // Diagnostic dump of the vt label/tile churn counters. Set to false to silence.
-        // Everything except 'live' is a per-interval delta. Only called from the GL thread,
-        // so the previous values need no synchronization; the counters themselves are atomic
-        // because the placement worker and the tile threads also increment them.
-        constexpr bool LOG_RENDER_STATS = true;
+        // Diagnostic dump of the vt label/tile churn counters, compiled in together with the
+        // counters themselves (see vt/RenderStats.h - CARTO_VT_RENDER_STATS is the only
+        // switch). Everything except 'live' is a per-interval delta. Only called from the GL
+        // thread, so the previous values need no synchronization; the counters themselves are
+        // atomic because the placement worker and the tile threads also increment them.
         constexpr int RENDER_STATS_INTERVAL = 1000; // ms
 
         void logRenderStats() {
             using vt::RenderStats;
 
-            static const int COUNT = 16;
+            static const int COUNT = 17;
             static std::chrono::steady_clock::time_point lastTime = std::chrono::steady_clock::now();
             static long long lastValues[COUNT] = { 0 };
 
@@ -93,7 +94,8 @@ namespace carto {
                 RenderStats::labelsReused.load(),
                 RenderStats::cullWorkerUpdates.load(),
                 RenderStats::tileRecalculations.load(),
-                RenderStats::tileLayersSkipped.load()
+                RenderStats::tileLayersSkipped.load(),
+                RenderStats::placementSearches.load()
             };
             long long deltas[COUNT];
             for (int i = 0; i < COUNT; i++) {
@@ -108,13 +110,14 @@ namespace carto {
             lastPasses = passes;
             lastFlips = flips;
 
-            Log::Infof("RenderStats: cullUpd=%lld tileRecalc=%lld tileSkip=%lld tileSets=%lld labelMaps=%lld | labelsAlloc=%lld reused=%lld live=%lld elevReanchor=%lld | placeUpd=%lld reNull=%lld reHidden=%lld reVisible=%lld | snap=%lld snapMoved=%lld | cullPasses=%lld visFlips=%lld",
+            Log::Infof("RenderStats: cullUpd=%lld tileRecalc=%lld tileSkip=%lld tileSets=%lld labelMaps=%lld | labelsAlloc=%lld reused=%lld live=%lld elevReanchor=%lld | placeUpd=%lld reNull=%lld reHidden=%lld reVisible=%lld search=%lld | snap=%lld snapMoved=%lld | cullPasses=%lld visFlips=%lld",
                        deltas[13], deltas[14], deltas[15], deltas[0], deltas[11],
                        deltas[3], deltas[12], RenderStats::labelsLive.load(), deltas[4],
-                       deltas[5], deltas[6], deltas[7], deltas[8],
+                       deltas[5], deltas[6], deltas[7], deltas[8], deltas[16],
                        deltas[9], deltas[10], deltaPasses, deltaFlips);
         }
     }
+#endif
 
     MapRenderer::MapRenderer(const std::shared_ptr<Layers>& layers, const std::shared_ptr<Options>& options) :
         _lastFrameTime(),
@@ -800,9 +803,9 @@ namespace carto {
             _lastFrameTime.reset();
         }
 
-        if (LOG_RENDER_STATS) {
-            logRenderStats();
-        }
+#if CARTO_VT_RENDER_STATS
+        logRenderStats();
+#endif
 
         GLContext::CheckGLError("MapRenderer::onDrawFrame");
     }

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -43,6 +43,8 @@
 #include "utils/Log.h"
 #include "utils/ThreadUtils.h"
 
+#include <vt/RenderStats.h>
+
 #include <algorithm>
 #include <limits>
 #include <cstdio>
@@ -53,6 +55,66 @@
 #include <vector>
 
 namespace carto {
+
+    namespace {
+        // Diagnostic dump of the vt label/tile churn counters. Set to false to silence.
+        // Everything except 'live' is a per-interval delta. Only called from the GL thread,
+        // so the previous values need no synchronization; the counters themselves are atomic
+        // because the placement worker and the tile threads also increment them.
+        constexpr bool LOG_RENDER_STATS = true;
+        constexpr int RENDER_STATS_INTERVAL = 1000; // ms
+
+        void logRenderStats() {
+            using vt::RenderStats;
+
+            static const int COUNT = 16;
+            static std::chrono::steady_clock::time_point lastTime = std::chrono::steady_clock::now();
+            static long long lastValues[COUNT] = { 0 };
+
+            std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+            if (now - lastTime < std::chrono::milliseconds(RENDER_STATS_INTERVAL)) {
+                return;
+            }
+            lastTime = now;
+
+            const long long values[COUNT] = {
+                RenderStats::visibleTileSetChanges.load(),
+                RenderStats::tileSurfacesBuilt.load(),
+                RenderStats::tileSurfacesInvalidated.load(),
+                RenderStats::labelsAllocated.load(),
+                RenderStats::labelElevationReanchors.load(),
+                RenderStats::placementUpdates.load(),
+                RenderStats::placementReanchorsNull.load(),
+                RenderStats::placementReanchorsHidden.load(),
+                RenderStats::placementReanchorsVisible.load(),
+                RenderStats::snapPlacements.load(),
+                RenderStats::snapPlacementsMoved.load(),
+                RenderStats::labelMapRebuilds.load(),
+                RenderStats::labelsReused.load(),
+                RenderStats::cullWorkerUpdates.load(),
+                RenderStats::tileRecalculations.load(),
+                RenderStats::tileLayersSkipped.load()
+            };
+            long long deltas[COUNT];
+            for (int i = 0; i < COUNT; i++) {
+                deltas[i] = values[i] - lastValues[i];
+                lastValues[i] = values[i];
+            }
+            static long long lastPasses = 0, lastFlips = 0;
+            long long passes = RenderStats::cullerPasses.load();
+            long long flips = RenderStats::cullerVisibilityFlips.load();
+            long long deltaPasses = passes - lastPasses;
+            long long deltaFlips = flips - lastFlips;
+            lastPasses = passes;
+            lastFlips = flips;
+
+            Log::Infof("RenderStats: cullUpd=%lld tileRecalc=%lld tileSkip=%lld tileSets=%lld labelMaps=%lld | labelsAlloc=%lld reused=%lld live=%lld elevReanchor=%lld | placeUpd=%lld reNull=%lld reHidden=%lld reVisible=%lld | snap=%lld snapMoved=%lld | cullPasses=%lld visFlips=%lld",
+                       deltas[13], deltas[14], deltas[15], deltas[0], deltas[11],
+                       deltas[3], deltas[12], RenderStats::labelsLive.load(), deltas[4],
+                       deltas[5], deltas[6], deltas[7], deltas[8],
+                       deltas[9], deltas[10], deltaPasses, deltaFlips);
+        }
+    }
 
     MapRenderer::MapRenderer(const std::shared_ptr<Layers>& layers, const std::shared_ptr<Options>& options) :
         _lastFrameTime(),
@@ -738,9 +800,13 @@ namespace carto {
             _lastFrameTime.reset();
         }
 
+        if (LOG_RENDER_STATS) {
+            logRenderStats();
+        }
+
         GLContext::CheckGLError("MapRenderer::onDrawFrame");
     }
-    
+
     void MapRenderer::onSurfaceDestroyed() {
         // This method may never be called (e.x Android)
         _surfaceCreated = false;

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -399,10 +399,28 @@ namespace carto {
                         // hundreds of meters of depth tolerance at far distances (see-through ridges).
                         terrainDepthBias = terrainOptions->getDepthBias() * 0.1f;
                         activeTerrainOptions = terrainOptions;
-                        unsigned int elevationVersion = terrainOptions->getElevationManager()->getVersion();
+                        const std::shared_ptr<ElevationManager>& elevationManager = terrainOptions->getElevationManager();
+                        unsigned int elevationVersion = elevationManager->getVersion();
                         if (elevationVersion != _elevationVersion) {
                             auto now = std::chrono::steady_clock::now();
-                            if (!_lastSurfaceResetTime || now - *_lastSurfaceResetTime > std::chrono::milliseconds(SURFACE_RESET_DELAY)) {
+                            // The elevation version is global but a decoded elevation tile only
+                            // changes the surfaces over that tile. Rebuilding every visible
+                            // surface for it re-tesselates and re-uploads the whole screen -
+                            // repeatedly, while the initial elevation stream is running, with
+                            // nothing on most of it actually changing. Ask which tiles changed
+                            // and drop only those; the global reset stays as the fallback for
+                            // whole-data-set changes (data source change, exaggeration) and for
+                            // change-log overflow.
+                            std::vector<MapTile> changedTiles;
+                            if (_elevationVersion != 0 && elevationManager->getChangedTiles(_elevationVersion, changedTiles)) {
+                                _elevationVersion = elevationVersion;
+                                std::vector<vt::TileId> changedTileIds;
+                                changedTileIds.reserve(changedTiles.size());
+                                for (const MapTile& changedTile : changedTiles) {
+                                    changedTileIds.emplace_back(changedTile.getZoom(), changedTile.getX(), changedTile.getY());
+                                }
+                                tileRenderer->invalidateTileSurfaces(changedTileIds);
+                            } else if (!_lastSurfaceResetTime || now - *_lastSurfaceResetTime > std::chrono::milliseconds(SURFACE_RESET_DELAY)) {
                                 _elevationVersion = elevationVersion;
                                 _lastSurfaceResetTime = now;
                                 tileRenderer->resetTileSurfaces();

--- a/all/native/renderers/workers/CullWorker.cpp
+++ b/all/native/renderers/workers/CullWorker.cpp
@@ -258,7 +258,7 @@ namespace carto {
     }
     
     void CullWorker::updateLayers(const std::vector<std::shared_ptr<Layer> >& layers) {
-        vt::RenderStats::cullWorkerUpdates++;
+        VT_STAT_INC(cullWorkerUpdates);
         for (const std::shared_ptr<Layer>& layer : layers) {
             layer->update(std::make_shared<CullState>(_envelope, _viewState));
         }

--- a/all/native/renderers/workers/CullWorker.cpp
+++ b/all/native/renderers/workers/CullWorker.cpp
@@ -10,6 +10,8 @@
 #include "utils/Log.h"
 #include "utils/ThreadUtils.h"
 
+#include <vt/RenderStats.h>
+
 #include <optional>
 
 namespace carto {
@@ -256,6 +258,7 @@ namespace carto {
     }
     
     void CullWorker::updateLayers(const std::vector<std::shared_ptr<Layer> >& layers) {
+        vt::RenderStats::cullWorkerUpdates++;
         for (const std::shared_ptr<Layer>& layer : layers) {
             layer->update(std::make_shared<CullState>(_envelope, _viewState));
         }

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -70,7 +70,7 @@ namespace carto {
 
     void ElevationManager::setExaggeration(float exaggeration) {
         _exaggeration.store(std::max(0.0f, exaggeration));
-        _version++;
+        bumpGlobalVersion();
     }
 
     std::size_t ElevationManager::getCacheCapacity() const {
@@ -211,6 +211,17 @@ namespace carto {
                 }
                 float maxSeen = _maxSeenElevation.load();
                 while (grid->getMaxHeight() > maxSeen && !_maxSeenElevation.compare_exchange_weak(maxSeen, grid->getMaxHeight())) { }
+
+                // Record WHICH tile changed, not just that something did. Consumers with
+                // per-tile derived data can then rebuild only the affected tiles. Bump the
+                // version under the same lock as the cache insert, so a consumer that sees
+                // the new version also sees the grid and a matching log entry.
+                unsigned int version = _version.fetch_add(1) + 1;
+                _changeLog.emplace_back(version, grid->getTile());
+                while (_changeLog.size() > MAX_CHANGE_LOG_ENTRIES) {
+                    _changeLog.pop_front();
+                    _changeLogFirstVersion = _changeLog.front().first;
+                }
             } else {
                 _gridCache.put(tileId, std::shared_ptr<ElevationTileGrid>(), 1024);
                 _gridCache.invalidate(tileId, std::chrono::steady_clock::now() + std::chrono::milliseconds(FAILED_TILE_TTL_MILLISECONDS));
@@ -218,9 +229,6 @@ namespace carto {
             _pendingLoads.erase(tileId);
         }
         promise.set_value(grid);
-        if (grid) {
-            _version++;
-        }
         return grid;
     }
 
@@ -363,6 +371,20 @@ namespace carto {
         return _version.load();
     }
 
+    bool ElevationManager::getChangedTiles(unsigned int sinceVersion, std::vector<MapTile>& tiles) const {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (sinceVersion + 1 < _changeLogFirstVersion) {
+            return false;
+        }
+        for (const std::pair<unsigned int, MapTile>& entry : _changeLog) {
+            if (entry.first > sinceVersion) {
+                tiles.push_back(entry.second);
+            }
+        }
+        return true;
+    }
+
     std::shared_ptr<ElevationDecoder> ElevationManager::ResolveDecoder(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& preferredDecoder) {
         std::string encoding = dataSource ? dataSource->getEncoding() : std::string();
         if (encoding == "terrarium") {
@@ -385,7 +407,18 @@ namespace carto {
             std::lock_guard<std::mutex> lock(_mutex);
             _gridCache.clear();
         }
-        _version++;
+        bumpGlobalVersion();
+    }
+
+    void ElevationManager::bumpGlobalVersion() {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        // Everything derived from the elevation data is stale at once, which the per-tile
+        // change log can not express - drop it so that consumers take the full
+        // invalidation path until the next tile-level change.
+        unsigned int version = _version.fetch_add(1) + 1;
+        _changeLog.clear();
+        _changeLogFirstVersion = version + 1;
     }
 
     double ElevationManager::wrapInternalX(double internalX) const {

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -12,7 +12,9 @@
 #include "core/MapTile.h"
 
 #include <atomic>
+#include <deque>
 #include <future>
+#include <utility>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -117,6 +119,14 @@ namespace carto {
         virtual unsigned int getVersion() const override;
 
         /**
+         * Appends the elevation tiles whose data changed between 'sinceVersion' (exclusive) and
+         * the current version to 'tiles', in XYZ convention. Returns false if the change log no
+         * longer reaches back to 'sinceVersion' (log overflow, or the whole cache was dropped):
+         * the caller must then treat every tile as changed.
+         */
+        bool getChangedTiles(unsigned int sinceVersion, std::vector<MapTile>& tiles) const;
+
+        /**
          * Resolves the effective elevation decoder: the data source "encoding" setting takes precedence,
          * then the preferred decoder, then the MapBox decoder as the default.
          */
@@ -126,6 +136,7 @@ namespace carto {
         struct DataSourceListener;
 
         void tilesChanged();
+        void bumpGlobalVersion();
         double wrapInternalX(double internalX) const;
         MapTile clampTileZoom(const MapTile& mapTile) const;
         std::shared_ptr<ElevationTileGrid> getGridForInternalPos(double internalX, double internalY, LoadMode mode) const;
@@ -140,6 +151,13 @@ namespace carto {
         std::atomic<float> _exaggeration;
         mutable std::atomic<unsigned int> _version;
         mutable std::atomic<float> _maxSeenElevation;
+
+        // Which tiles changed at which version, so that consumers holding per-tile derived
+        // data (tile surfaces) can invalidate only what actually changed instead of
+        // everything on every decoded elevation tile.
+        static constexpr std::size_t MAX_CHANGE_LOG_ENTRIES = 256;
+        mutable std::deque<std::pair<unsigned int, MapTile> > _changeLog;
+        mutable unsigned int _changeLogFirstVersion = 1; // earliest version still covered by the log
 
         mutable cache::timed_lru_cache<long long, std::shared_ptr<ElevationTileGrid> > _gridCache;
         mutable std::map<long long, std::shared_future<std::shared_ptr<ElevationTileGrid> > > _pendingLoads; // single-flight de-duplication of concurrent loads


### PR DESCRIPTION
SDK side of farfromrefug/mobile-carto-libs#10, which carries the label anchor stability, label reuse and off-screen placement rejection work. This PR bumps the submodule and adds the terrain/layer changes found during the same investigation.

## Elevation invalidation (`49360901c`)

`ElevationManager` keeps a per-tile change log (256 entries) alongside its version counter, so consumers can rebuild only what changed. Version bumps for a decoded tile now happen under the same lock as the cache insert, so a consumer seeing the new version also sees the grid and a matching log entry. Whole-data-set changes (data source change, exaggeration) clear the log, putting consumers back on the full invalidation path.

`TileRenderer` uses that to invalidate only the tile surfaces over changed elevation tiles instead of resetting all of them whenever any elevation tile decodes.

**Caveat, stated plainly:** this path is inert in the GPU-draping / shared-grid configuration, where no per-tile surfaces are built at all. It measured zero surface rebuilds in the demo, so it is a correctness improvement with no measured win there.

## Hidden layer reporting an unconditional tile change (`49360901c`)

`TileLayer::update` returns early for a layer that is hidden, out of its visible zoom range, or at zero opacity, and passed `tilesChanged` as a literal `true`. For a `VectorTileLayer` that means calling `vtLabelsChanged` — a full placement pass over every vector layer's labels — plus `requestRedraw`, on every cull pass, with the redraw bringing the cull worker straight back. It now reports the real change; `refreshTiles` still returns true on the pass that empties the tile set, so becoming hidden still redraws once.

**This was investigated as the cause of an idle ~10 Hz re-cull loop in the demo, and it is not that cause** — the counter added for it shows the early-return path is never taken there. The loop is still unexplained; the change stands on its own. Remaining candidates are `TileRenderer::refreshTiles` comparing the tile map by `shared_ptr` identity, or `_horizontalLayerOffset` staying non-zero.

## Counters (`e5252cd2e`)

`CARTO_VT_RENDER_STATS` (in `vt/RenderStats.h`, default 0) is the single switch, gating the increments in `TileLayer` and `CullWorker` as well as `logRenderStats` itself. Off means absent, not unread: the counters have no storage, the macros never evaluate their arguments, and the printout is not compiled. Both configurations verified to compile.

## Measured effect

On the demo, per second, worst phases:

| | before | after |
|---|---|---|
| labels constructed | ~10–16k | ~0.6–1.5k (87–95% reused) |
| label visibility flips (zoom) | ~380 | ~110 |
| anchor moves per re-snap | ~50% | ~2% |
| placement attempts reaching a search | 100% | 1–4% |

## Merge order

farfromrefug/mobile-carto-libs#10 first — the submodule pointer here references its head commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
