### PR TITLE
fix(terrain): stop landcover fills disappearing in non-draped terrain mode

### DIFF
--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -264,13 +264,19 @@ namespace carto {
             // wasted work - and the subdivided fill VBOs are uploaded on the render thread, which
             // stalls fast zooms. Draping fills therefore implies source-density (no fill
             // subdivision), exactly like the tangram source-density mode.
-            // ...but draping is decided PER TILE at render time (only native tiles are draped;
-            // overzoomed and proxy tiles fall through to the 3D geometry path), while
-            // source-density is decided GLOBALLY here at decode time. An un-subdivided fill that
-            // then does not get draped is a few large flat triangles chorded across the terrain:
-            // it sags below the depth-writing surface, fails the depth test and leaves the bare
-            // background colour - the documented "landcover holes". Since a tile cannot know at
-            // decode time whether it will be draped, always subdivide.
+            // ...but draping is decided PER TILE at render time, while source-density is decided
+            // GLOBALLY here at decode time. An un-subdivided fill that then does NOT get draped is
+            // a few large flat triangles chorded across the terrain: it sags below the surface,
+            // fails the depth test and leaves the bare background colour - the documented
+            // "landcover holes". Tiles fall through constantly, not just transiently: the drape
+            // cover is capped at the camera zoom and a hillshade contributes its DEM-limited zoom,
+            // so render tiles finer than the cover are normal - and they can not be suppressed
+            // instead (tried: the map becomes a stretched coarse drape). So: always subdivide.
+            // Measured on the emulator, meshResolution 128, drape on, scripted 3-level zoom:
+            // median 58-60 fps and the same worst-case bake spike either way, i.e. the
+            // subdivision is not what costs.
+            // This value MUST match what resetTileTransformer() passes, or a change to it silently
+            // keeps tiles decoded for the other mode.
             bool terrainSourceDensity = false;
             bool terrainSourceDensityLines = terrainOptions && terrainOptions->isDrapeLinesEnabled();
             if (_terrainOptions.lock() != terrainOptions || _terrainEnabled != terrainEnabled || _terrainExaggeration != terrainExaggeration || _terrainMeshResolution != terrainMeshResolution || _terrainMinZoom != terrainMinZoom || _terrainRegularGrid != terrainRegularGrid || _terrainSourceDensity != terrainSourceDensity || _terrainSourceDensityLines != terrainSourceDensityLines) {
@@ -885,7 +891,11 @@ namespace carto {
             }
             else if (auto terrainOptions = options->getTerrainOptions()) {
                 if (terrainOptions->isEnabled()) {
-                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled(), terrainOptions->isDrapeFillsEnabled(), terrainOptions->isDrapeLinesEnabled());
+                    // The source-density flags must match the ones calculateDrawData compares
+                    // against: they decide the tesselation the tiles in the cache were built with,
+                    // so a mismatch leaves tiles decoded for the other mode in place forever
+                    // (un-subdivided fills sagging through the terrain once draping is switched off).
+                    tileTransformer = std::make_shared<TerrainTileTransformer>(static_cast<float>(Const::WORLD_SIZE), terrainOptions->getElevationManager(), terrainOptions->getMeshResolution(), terrainOptions->getMinZoom(), terrainOptions->isRegularGridEnabled() || terrainOptions->isPainterOrderDepthEnabled(), false, terrainOptions->isDrapeLinesEnabled());
                 }
             }
         }


### PR DESCRIPTION
## Problem

In 3D terrain mode with RTT draping **off**, whole landcover/landuse polygons vanish and the terrain shows the bare background through them, while the same view with draping on paints fine. Repro in the android-dev demo: `pm clear`, launch (drape on by default), untick **drape (RTT)** — the fills on the slope disappear and stay gone.

## Cause

`TileLayer::resetTileTransformer` built the terrain transformer with

```
sourceDensity = terrainOptions->isDrapeFillsEnabled()
```

so with draping on, polygon fills were decoded at **source density** — no terrain subdivision at all. `calculateDrawData`, which decides when the tile caches must be rebuilt, compares against a hard-coded `false` for that same flag.

Two consequences:

1. Draping is decided **per tile at render time**, and tiles fall through to the 3D geometry path routinely — the drape cover is capped at `ceil(cameraZoom) + 1` and a hillshade contributes its DEM-limited zoom, so render tiles finer than the cover are the normal case. An un-subdivided fill drawn there is a few large flat triangles chorded across the terrain: it sags below the surface, fails the depth test, and leaves the bare background — the "landcover holes" the surrounding comment already documented.
2. Since the flag was not one of the tracked values, toggling `DrapeFillsEnabled` never rebuilt the tile caches, so tiles decoded for the other mode stayed forever. That is why the holes were permanent after switching draping off, and why launching straight into non-drape looked fine.

## Fix

Decode fills at full subdivision regardless of draping, and state at both sites that the two values must match.

## Alternative that did not work

Making the fall-through safe instead — treating a render tile finer than a drape leaf as draped, so no un-subdivided fill reaches the 3D pass — replaces the map with a stretched coarse drape (blurry ground, crisp labels), because finer render tiles are the normal case. Baking them into the leaf is already ruled out in `bakeDrapeTile` (minified sub-rect, no mipmap, aliasing noise). Recorded as a comment in farfromrefug/mobile-carto-libs#11.

## Perf

The skipped subdivision was a deliberate optimisation, so it was measured. Emulator, meshResolution 128, drape on, scripted 3-level zoom, cold start each run, fps from the renderer's own 60-frame log:

| build | fps median | fps min | drape bake avg | worst spike |
|---|---|---|---|---|
| source density (before) | 58.0 | 2.8 | 3.7 ms | 106 ms |
| always subdivide (this PR) | 58.8 / 59.8 | 3.2 / 3.4 | 2.6 / 2.3 ms | 170 / 105 ms |

Two repeats of the same build differ more than the two builds do — the bake bursts dominate, not the fill tesselation. Emulator only; device numbers may differ.

## Testing

Emulator, cold start each time:

- before: launch → untick drape → holes, stable at 60 s; 1598 tiles logged as decoded without subdivision (temporary instrumentation, removed).
- after: same sequence → no holes, 0 unsubdivided tiles.
- non-drape zoom sweep z11.5 / 13.2 / 14.6 / 15.4 / 16.2 → clean.
- drape on → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)