### PR TITLE
fix(hillshade): match MapLibre's hillshade rendering + composite zoom level bias

### DIFF
--- a/all/modules/components/TerrainOptions.i
+++ b/all/modules/components/TerrainOptions.i
@@ -24,8 +24,11 @@
 
 %attribute(carto::TerrainOptions, bool, Enabled, isEnabled, setEnabled)
 %attribute(carto::TerrainOptions, float, Exaggeration, getExaggeration, setExaggeration)
+%attribute(carto::TerrainOptions, bool, SeamlessTileEdgesEnabled, isSeamlessTileEdgesEnabled, setSeamlessTileEdgesEnabled)
+%attribute(carto::TerrainOptions, bool, ElevationPrefetchEnabled, isElevationPrefetchEnabled, setElevationPrefetchEnabled)
 %attribute(carto::TerrainOptions, int, MeshResolution, getMeshResolution, setMeshResolution)
 %attribute(carto::TerrainOptions, bool, RegularGridEnabled, isRegularGridEnabled, setRegularGridEnabled)
+%attribute(carto::TerrainOptions, bool, TileEdgeStitchingEnabled, isTileEdgeStitchingEnabled, setTileEdgeStitchingEnabled)
 %attribute(carto::TerrainOptions, bool, PainterOrderDepthEnabled, isPainterOrderDepthEnabled, setPainterOrderDepthEnabled)
 %attribute(carto::TerrainOptions, bool, DrapeFillsEnabled, isDrapeFillsEnabled, setDrapeFillsEnabled)
 %attribute(carto::TerrainOptions, bool, DrapeLinesEnabled, isDrapeLinesEnabled, setDrapeLinesEnabled)

--- a/all/modules/layers/CompositeVectorTileLayer.i
+++ b/all/modules/layers/CompositeVectorTileLayer.i
@@ -29,6 +29,11 @@
 %std_exceptions(carto::CompositeVectorTileLayer::CompositeVectorTileLayer)
 %std_exceptions(carto::CompositeVectorTileLayer::addExternalDataSource)
 %std_exceptions(carto::CompositeVectorTileLayer::addVectorDataSource)
+%std_exceptions(carto::CompositeVectorTileLayer::setExternalDataSourceZoomLevelBias)
+%std_exceptions(carto::CompositeVectorTileLayer::getExternalDataSourceZoomLevelBias)
+%std_exceptions(carto::CompositeVectorTileLayer::clearExternalDataSourceZoomLevelBias)
+%std_exceptions(carto::CompositeVectorTileLayer::setExternalDataSourceMaxOverzoomLevel)
+%std_exceptions(carto::CompositeVectorTileLayer::getExternalDataSourceMaxOverzoomLevel)
 
 %include "layers/CompositeVectorTileLayer.h"
 

--- a/all/modules/layers/HillshadeRasterTileLayer.i
+++ b/all/modules/layers/HillshadeRasterTileLayer.i
@@ -29,6 +29,7 @@
 %attribute(carto::HillshadeRasterTileLayer, carto::MapVec, IlluminationDirection, getIlluminationDirection, setIlluminationDirection)
 %attribute(carto::HillshadeRasterTileLayer, bool, IlluminationMapRotationEnabled, getIlluminationMapRotationEnabled, setIlluminationMapRotationEnabled)
 %attribute(carto::HillshadeRasterTileLayer, bool, ExagerateHeightScaleEnabled, getExagerateHeightScaleEnabled, setExagerateHeightScaleEnabled)
+%attribute(carto::HillshadeRasterTileLayer, bool, LegacyHeightScaleEnabled, isLegacyHeightScaleEnabled, setLegacyHeightScaleEnabled)
 %attribute(carto::HillshadeRasterTileLayer, carto::HillshadeMethod::HillshadeMethod, HillshadeMethod, getHillshadeMethod, setHillshadeMethod)
 %attributeval(carto::HillshadeRasterTileLayer, carto::Color, ShadowColor, getShadowColor, setShadowColor)
 %attributeval(carto::HillshadeRasterTileLayer, carto::Color, HighlightColor, getHighlightColor, setHighlightColor)

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -18,7 +18,8 @@ namespace carto {
         _enabled(true),
         _meshResolution(32),
         _regularGridEnabled(false),
-        _painterOrderDepthEnabled(false),
+        _tileEdgeStitchingEnabled(true),
+        _painterOrderDepthEnabled(true),
         _drapeFillsEnabled(true),
         _drapeLinesEnabled(true),
         _drapeResolution(512),
@@ -76,6 +77,28 @@ namespace carto {
         }
     }
 
+    bool TerrainOptions::isSeamlessTileEdgesEnabled() const {
+        return _elevationManager->isSeamlessTileEdgesEnabled();
+    }
+
+    void TerrainOptions::setSeamlessTileEdgesEnabled(bool enabled) {
+        if (_elevationManager->isSeamlessTileEdgesEnabled() != enabled) {
+            _elevationManager->setSeamlessTileEdgesEnabled(enabled);
+            notifyOptionChanged("SeamlessTileEdgesEnabled");
+        }
+    }
+
+    bool TerrainOptions::isElevationPrefetchEnabled() const {
+        return _elevationManager->isNeighbourPrefetchEnabled();
+    }
+
+    void TerrainOptions::setElevationPrefetchEnabled(bool enabled) {
+        if (_elevationManager->isNeighbourPrefetchEnabled() != enabled) {
+            _elevationManager->setNeighbourPrefetchEnabled(enabled);
+            notifyOptionChanged("ElevationPrefetchEnabled");
+        }
+    }
+
     int TerrainOptions::getMeshResolution() const {
         return _meshResolution.load();
     }
@@ -94,6 +117,16 @@ namespace carto {
     void TerrainOptions::setRegularGridEnabled(bool regularGridEnabled) {
         if (_regularGridEnabled.exchange(regularGridEnabled) != regularGridEnabled) {
             notifyOptionChanged("RegularGridEnabled");
+        }
+    }
+
+    bool TerrainOptions::isTileEdgeStitchingEnabled() const {
+        return _tileEdgeStitchingEnabled.load();
+    }
+
+    void TerrainOptions::setTileEdgeStitchingEnabled(bool enabled) {
+        if (_tileEdgeStitchingEnabled.exchange(enabled) != enabled) {
+            notifyOptionChanged("TileEdgeStitchingEnabled");
         }
     }
 

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -94,6 +94,41 @@ namespace carto {
         void setExaggeration(float exaggeration);
 
         /**
+         * Returns whether seamless tile edge handling is enabled.
+         * @return True if elevation textures take their border texels from neighbouring DEM tiles at any level. The default is true.
+         */
+        bool isSeamlessTileEdgesEnabled() const;
+        /**
+         * Enables or disables seamless tile edge handling. When enabled, the 1-texel border of
+         * every elevation texture is taken from the neighbouring elevation tiles - same-level
+         * neighbours texel-exactly, coarser (ancestor) neighbours by sampling their height field.
+         * Adjacent terrain tiles then agree on the height along their shared edge instead of
+         * showing a ridge of up to one DEM texel of relief. Costs no IO, only a small amount of
+         * CPU when an elevation texture is built. Disable if the elevation tiles already match
+         * exactly across tile borders.
+         * @param enabled True to fill elevation texture borders from neighbouring tiles.
+         */
+        void setSeamlessTileEdgesEnabled(bool enabled);
+
+        /**
+         * Returns whether elevation tile prefetching is enabled.
+         * @return True if visible tiles and their neighbours are requested from the elevation data source. The default is true.
+         */
+        bool isElevationPrefetchEnabled() const;
+        /**
+         * Enables or disables elevation tile prefetching. When enabled, every visible terrain tile
+         * asynchronously requests its own elevation tile and the 8 surrounding ones, so neighbouring
+         * terrain tiles are displaced by the same DEM level and border texels have real neighbour
+         * data. When disabled, elevation tiles are only loaded as a side effect of map tile fetches,
+         * which leaves cached map tiles (and the tiles around the viewport) on coarser ancestor
+         * elevation data. This is the costly option: it adds elevation tile requests, decoding and
+         * cache pressure. Disable to keep elevation traffic at a minimum, or if the elevation
+         * tileset is fully local.
+         * @param enabled True to prefetch elevation tiles for visible tiles and their neighbours.
+         */
+        void setElevationPrefetchEnabled(bool enabled);
+
+        /**
          * Returns the terrain mesh resolution.
          * @return The maximum number of grid cells per tile edge used for terrain geometry. The default is 32.
          */
@@ -124,8 +159,25 @@ namespace carto {
         void setRegularGridEnabled(bool regularGridEnabled);
 
         /**
+         * Returns whether cross-LOD tile edge stitching is enabled.
+         * @return True if grid surface edges follow a coarser neighbour's lattice. The default is true.
+         */
+        bool isTileEdgeStitchingEnabled() const;
+        /**
+         * Enables or disables cross-LOD tile edge stitching. Neighbouring terrain tiles at
+         * different zoom levels interpolate the elevation between differently spaced grid
+         * vertices along their shared edge, which opens a thin crack. When enabled, the finer
+         * tile chords across the coarser neighbour's grid nodes on that edge, so both tiles
+         * describe the same edge. Only takes effect together with the regular grid surface mode
+         * (adaptive tesselation matches its borders to the neighbours already) and needs an even
+         * MeshResolution. Costs one uniform per tile - no extra geometry.
+         * @param enabled True to snap grid surface edges to a coarser neighbour's grid.
+         */
+        void setTileEdgeStitchingEnabled(bool enabled);
+
+        /**
          * Returns whether the painter-order terrain depth model is used.
-         * @return True if painter-order depth is used, false for the surface-occluder model. The default is false.
+         * @return True if painter-order depth is used, false for the surface-occluder model. The default is true.
          */
         bool isPainterOrderDepthEnabled() const;
         /**
@@ -134,7 +186,6 @@ namespace carto {
          * per-layer clip-space delta instead of being depth-tested against a surface pre-pass occluder,
          * which removes the distance-growing depth slack (no see-through band). Implies (and forces)
          * RegularGridEnabled. Only takes effect in GPU draping mode (vertex texture fetch, planar).
-         * Experimental.
          * @param painterOrderDepthEnabled True to use painter-order depth, false for the occluder model.
          */
         void setPainterOrderDepthEnabled(bool painterOrderDepthEnabled);
@@ -437,6 +488,7 @@ namespace carto {
         std::atomic<bool> _enabled;
         std::atomic<int> _meshResolution;
         std::atomic<bool> _regularGridEnabled;
+        std::atomic<bool> _tileEdgeStitchingEnabled;
         std::atomic<bool> _painterOrderDepthEnabled;
         std::atomic<bool> _drapeFillsEnabled;
         std::atomic<bool> _drapeLinesEnabled;

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -113,8 +113,17 @@ namespace carto {
 
         {
             std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+            ExternalSource source { name, type, dataSource, childLayer };
+            if (const ExternalSource* previous = findExternalSource(name)) {
+                // Replacing a source keeps whatever per-source tile properties were set on it.
+                source.zoomLevelBiasSet = previous->zoomLevelBiasSet;
+                source.zoomLevelBias = previous->zoomLevelBias;
+                source.maxOverzoomLevelSet = previous->maxOverzoomLevelSet;
+                source.maxOverzoomLevel = previous->maxOverzoomLevel;
+            }
             removeExternalDataSource(name); // replace if it exists
-            _externalSources.push_back({ name, type, dataSource, childLayer });
+            _externalSources.push_back(source);
+            applyChildTileProperties(_externalSources.back());
             if (_componentsSet) {
                 wireChild(childLayer);
             }
@@ -142,8 +151,16 @@ namespace carto {
 
         {
             std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+            ExternalSource source { name, CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR, dataSource, childLayer };
+            if (const ExternalSource* previous = findExternalSource(name)) {
+                source.zoomLevelBiasSet = previous->zoomLevelBiasSet;
+                source.zoomLevelBias = previous->zoomLevelBias;
+                source.maxOverzoomLevelSet = previous->maxOverzoomLevelSet;
+                source.maxOverzoomLevel = previous->maxOverzoomLevel;
+            }
             removeExternalDataSource(name);
-            _externalSources.push_back({ name, CompositeSourceType::COMPOSITE_SOURCE_TYPE_VECTOR, dataSource, childLayer });
+            _externalSources.push_back(source);
+            applyChildTileProperties(_externalSources.back());
             if (_componentsSet) {
                 wireChild(childLayer);
             }
@@ -182,6 +199,86 @@ namespace carto {
             names.push_back(s.name);
         }
         return names;
+    }
+
+    void CompositeVectorTileLayer::setZoomLevelBias(float bias) {
+        VectorTileLayer::setZoomLevelBias(bias);
+
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        for (const ExternalSource& s : _externalSources) {
+            applyChildTileProperties(s);
+        }
+        for (const DrawItem& item : _drawItems) {
+            if (auto groupLayer = std::dynamic_pointer_cast<TileLayer>(item.groupLayer)) {
+                groupLayer->setZoomLevelBias(bias);
+            }
+        }
+    }
+
+    void CompositeVectorTileLayer::setPreloading(bool preloading) {
+        VectorTileLayer::setPreloading(preloading);
+
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        for (const ExternalSource& s : _externalSources) {
+            applyChildTileProperties(s);
+        }
+        for (const DrawItem& item : _drawItems) {
+            if (auto groupLayer = std::dynamic_pointer_cast<TileLayer>(item.groupLayer)) {
+                groupLayer->setPreloading(preloading);
+            }
+        }
+    }
+
+    void CompositeVectorTileLayer::setExternalDataSourceZoomLevelBias(const std::string& name, float bias) {
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        ExternalSource& source = getExternalSource(name);
+        source.zoomLevelBiasSet = true;
+        source.zoomLevelBias = bias;
+        applyChildTileProperties(source);
+    }
+
+    float CompositeVectorTileLayer::getExternalDataSourceZoomLevelBias(const std::string& name) const {
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        const ExternalSource& source = getExternalSource(name);
+        return source.zoomLevelBiasSet ? source.zoomLevelBias : getZoomLevelBias();
+    }
+
+    void CompositeVectorTileLayer::clearExternalDataSourceZoomLevelBias(const std::string& name) {
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        ExternalSource& source = getExternalSource(name);
+        source.zoomLevelBiasSet = false;
+        source.zoomLevelBias = 0.0f;
+        applyChildTileProperties(source);
+    }
+
+    void CompositeVectorTileLayer::setExternalDataSourceMaxOverzoomLevel(const std::string& name, int level) {
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        ExternalSource& source = getExternalSource(name);
+        source.maxOverzoomLevelSet = true;
+        source.maxOverzoomLevel = level;
+        applyChildTileProperties(source);
+    }
+
+    int CompositeVectorTileLayer::getExternalDataSourceMaxOverzoomLevel(const std::string& name) const {
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        const ExternalSource& source = getExternalSource(name);
+        if (source.maxOverzoomLevelSet) {
+            return source.maxOverzoomLevel;
+        }
+        auto childLayer = std::dynamic_pointer_cast<TileLayer>(source.childLayer);
+        return childLayer ? childLayer->getMaxOverzoomLevel() : getMaxOverzoomLevel();
+    }
+
+    void CompositeVectorTileLayer::applyChildTileProperties(const ExternalSource& source) {
+        auto childLayer = std::dynamic_pointer_cast<TileLayer>(source.childLayer);
+        if (!childLayer) {
+            return;
+        }
+        childLayer->setPreloading(isPreloading());
+        childLayer->setZoomLevelBias(source.zoomLevelBiasSet ? source.zoomLevelBias : getZoomLevelBias());
+        if (source.maxOverzoomLevelSet) {
+            childLayer->setMaxOverzoomLevel(source.maxOverzoomLevel);
+        }
     }
 
     bool CompositeVectorTileLayer::isSinglePassRenderingEnabled() const {
@@ -255,6 +352,9 @@ namespace carto {
         groupLayer->setRendererLayerFilter(filter);
         groupLayer->setLabelRenderOrder(getLabelRenderOrder());
         groupLayer->setBuildingRenderOrder(getBuildingRenderOrder());
+        // The groups render the same source as this layer, so they must select the same tiles.
+        groupLayer->setZoomLevelBias(getZoomLevelBias());
+        groupLayer->setPreloading(isPreloading());
         std::shared_ptr<Layer> child = groupLayer;
         if (_componentsSet) {
             wireChild(child);
@@ -451,6 +551,25 @@ namespace carto {
         return it != _externalSources.end() ? &(*it) : nullptr;
     }
 
+    CompositeVectorTileLayer::ExternalSource* CompositeVectorTileLayer::findExternalSource(const std::string& name) {
+        auto it = std::find_if(_externalSources.begin(), _externalSources.end(), [&](const ExternalSource& s) { return s.name == name; });
+        return it != _externalSources.end() ? &(*it) : nullptr;
+    }
+
+    CompositeVectorTileLayer::ExternalSource& CompositeVectorTileLayer::getExternalSource(const std::string& name) {
+        if (ExternalSource* source = findExternalSource(name)) {
+            return *source;
+        }
+        throw InvalidArgumentException("No external data source named " + name);
+    }
+
+    const CompositeVectorTileLayer::ExternalSource& CompositeVectorTileLayer::getExternalSource(const std::string& name) const {
+        if (const ExternalSource* source = findExternalSource(name)) {
+            return *source;
+        }
+        throw InvalidArgumentException("No external data source named " + name);
+    }
+
     bool CompositeVectorTileLayer::isDrawnSlot(const std::string& name) const {
         // Caller holds _sourceMutex. A source with no draw item is not in the style's 'layers'.
         for (const DrawItem& item : _drawItems) {
@@ -492,6 +611,23 @@ namespace carto {
             applied[key] = value;
             return true;
         };
+
+        // Tile selection, common to every source type. A style value takes precedence over
+        // setExternalDataSourceZoomLevelBias / setExternalDataSourceMaxOverzoomLevel while it is
+        // present, the same way the other per-source config values win over programmatic setters.
+        const mvt::Value* biasValue = getValue("zoom-level-bias");
+        const mvt::Value* overzoomValue = getValue("max-overzoom-level");
+        if (biasValue || overzoomValue) {
+            auto childTileLayer = std::dynamic_pointer_cast<TileLayer>(source.childLayer);
+            if (childTileLayer && biasValue) {
+                float bias = valueToFloat(*biasValue, 0.0f);
+                if (changed("zoom-level-bias", bias)) { childTileLayer->setZoomLevelBias(bias); }
+            }
+            if (childTileLayer && overzoomValue) {
+                int level = static_cast<int>(valueToFloat(*overzoomValue, 0.0f));
+                if (changed("max-overzoom-level", level)) { childTileLayer->setMaxOverzoomLevel(level); }
+            }
+        }
 
         if (source.type == CompositeSourceType::COMPOSITE_SOURCE_TYPE_RASTER) {
             auto raster = std::static_pointer_cast<RasterTileLayer>(source.childLayer);

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -113,6 +113,60 @@ namespace carto {
          */
         void setSinglePassRenderingEnabled(bool enabled);
 
+        /**
+         * Sets the zoom level bias for this layer and for every child layer it owns (external
+         * raster/hillshade/vector sources and the internal style-group layers). Sources with a
+         * per-source bias set via setExternalDataSourceZoomLevelBias keep their own value.
+         * @param bias The new bias value, both positive and negative fractional values are supported.
+         */
+        virtual void setZoomLevelBias(float bias);
+        /**
+         * Sets the preloading state for this layer and for every child layer it owns.
+         * @param preloading The new preloading state of the layer.
+         */
+        virtual void setPreloading(bool preloading);
+
+        /**
+         * Sets the zoom level bias of a single external data source, overriding the layer-wide value.
+         * Use this to fetch a source at a different resolution from the base map - e.g. a bias of 1.0
+         * on a high-resolution DEM source makes the hillshade use one zoom level more detail.
+         * Note that if the style defines a 'zoom-level-bias' value for this source, the style value
+         * wins - the same precedence the other per-source config values have.
+         * @param name The source name.
+         * @param bias The new bias value, both positive and negative fractional values are supported.
+         * @throws std::invalid_argument If the source does not exist.
+         */
+        void setExternalDataSourceZoomLevelBias(const std::string& name, float bias);
+        /**
+         * Returns the effective zoom level bias of the given external data source.
+         * @param name The source name.
+         * @return The zoom level bias of the source.
+         * @throws std::invalid_argument If the source does not exist.
+         */
+        float getExternalDataSourceZoomLevelBias(const std::string& name) const;
+        /**
+         * Clears the per-source zoom level bias, so the source follows the layer-wide value again.
+         * @param name The source name.
+         * @throws std::invalid_argument If the source does not exist.
+         */
+        void clearExternalDataSourceZoomLevelBias(const std::string& name);
+        /**
+         * Sets the maximum overzoom level of a single external data source. Overzooming reuses a
+         * coarser parent tile when the source has no tile at the target zoom level, which is how a
+         * low-resolution DEM keeps covering the map above its own max zoom.
+         * @param name The source name.
+         * @param level The new maximum overzoom level.
+         * @throws std::invalid_argument If the source does not exist.
+         */
+        void setExternalDataSourceMaxOverzoomLevel(const std::string& name, int level);
+        /**
+         * Returns the maximum overzoom level of the given external data source.
+         * @param name The source name.
+         * @return The maximum overzoom level of the source.
+         * @throws std::invalid_argument If the source does not exist.
+         */
+        int getExternalDataSourceMaxOverzoomLevel(const std::string& name) const;
+
     protected:
         virtual void setComponents(const std::shared_ptr<CancelableThreadPool>& envelopeThreadPool,
                                    const std::shared_ptr<CancelableThreadPool>& tileThreadPool,
@@ -136,6 +190,11 @@ namespace carto {
             CompositeSourceType::CompositeSourceType type;
             std::shared_ptr<TileDataSource> dataSource;
             std::shared_ptr<Layer> childLayer; // raster/hillshade child; null for merged vector
+            // Per-source overrides. When unset the child follows the composite layer's own value.
+            bool zoomLevelBiasSet = false;
+            float zoomLevelBias = 0.0f;
+            bool maxOverzoomLevelSet = false;
+            int maxOverzoomLevel = 0;
         };
 
         // One ordered draw step after the layer's own group-0 render: either an external
@@ -161,7 +220,15 @@ namespace carto {
         std::shared_ptr<Layer> makeGroupLayer(const std::string& filter);
         void rebuildDrawItems();
         void applyExternalChildZoomRange(const ExternalSource& source);
+        // Pushes the tile-selection properties (zoom level bias, max overzoom level, preloading)
+        // down to a child layer, honouring the source's per-source overrides. Caller holds _sourceMutex.
+        void applyChildTileProperties(const ExternalSource& source);
         const ExternalSource* findExternalSource(const std::string& name) const;
+        // Non-const variant, for the per-source property setters. Caller holds _sourceMutex.
+        ExternalSource* findExternalSource(const std::string& name);
+        // Same, but throws if the source is unknown. Caller holds _sourceMutex.
+        ExternalSource& getExternalSource(const std::string& name);
+        const ExternalSource& getExternalSource(const std::string& name) const;
         // Whether the style's 'layers' gives this source a slot, i.e. whether anything would ever
         // draw it. A source without one is not loaded and not draped.
         bool isDrawnSlot(const std::string& name) const;

--- a/all/native/layers/HillshadeRasterTileLayer.cpp
+++ b/all/native/layers/HillshadeRasterTileLayer.cpp
@@ -32,9 +32,10 @@ namespace carto
     HillshadeRasterTileLayer::HillshadeRasterTileLayer(const std::shared_ptr<TileDataSource> &dataSource, const std::shared_ptr<ElevationDecoder> &elevationDecoder) : CustomRasterTileLayer(dataSource),
         _elevationDecoder(elevationDecoder),
         _contrast(0.5f),
-        _heightScale(0.09f),
+        _heightScale(1.0f),
         _exaggeration(1.0f),
         _exagerateHeightScaleEnabled(true),
+        _legacyHeightScaleEnabled(false),
         _normalMapLightingShader(),
         _accentColor(Color(0, 0, 0, 255)),
         _shadowColor(Color(0, 0, 0, 255)),
@@ -56,6 +57,7 @@ namespace carto
         _heightScale(1.0f),
         _exaggeration(1.0f),
         _exagerateHeightScaleEnabled(true),
+        _legacyHeightScaleEnabled(false),
         _normalMapLightingShader(),
         _accentColor(Color(0, 0, 0, 255)),
         _shadowColor(Color(0, 0, 0, 255)),
@@ -171,6 +173,15 @@ namespace carto
         _exagerateHeightScaleEnabled.store(enabled);
         updateTiles(false);
     }
+    bool HillshadeRasterTileLayer::isLegacyHeightScaleEnabled() const
+    {
+        return _legacyHeightScaleEnabled.load();
+    }
+    void HillshadeRasterTileLayer::setLegacyHeightScaleEnabled(bool enabled)
+    {
+        _legacyHeightScaleEnabled.store(enabled);
+        updateTiles(false);
+    }
 
     HillshadeMethod::HillshadeMethod HillshadeRasterTileLayer::getHillshadeMethod() const {
         return _hillshadeMethod.load();
@@ -274,7 +285,10 @@ namespace carto
                     break;
             }
             _tileRenderer->setHillshadeMethod(hillshadeMethod);
-            _tileRenderer->setHillshadeExaggeration(getContrast() * getExaggeration());
+            // Two separate jobs: exaggeration scales the slope, contrast is MapLibre's
+            // 'hillshade-exaggeration' (the slope response curve and the overall strength).
+            _tileRenderer->setHillshadeExaggeration(getExaggeration());
+            _tileRenderer->setHillshadeIntensity(getContrast());
             bool refresh = _tileRenderer->onDrawFrame(deltaSeconds, viewState);
 
             if (opacity < 1.0f)
@@ -317,11 +331,24 @@ namespace carto
             elevationCoeffs = { { static_cast<float>(rawCoeffs[0]), static_cast<float>(rawCoeffs[1]), static_cast<float>(rawCoeffs[2]), static_cast<float>(rawCoeffs[3]) } };
             alpha = static_cast<std::uint8_t>(getContrast() * 255.0f);
             float heightScale = decoder->getMinimumHeightScale();
-            float scale = heightScale * static_cast<float>(bitmap->getHeight() * std::pow(2.0, tile.getZoom()) / 40075016.6855785);
-            if (_exagerateHeightScaleEnabled) {
-                 float exaggeration = tile.getZoom() < 2 ? 0.2f : tile.getZoom() < 5 ? 0.3f : 0.35f;
-                 scale = heightScale * 160 * getHeightScale() * static_cast<float>(bitmap->getHeight() * std::pow(2.0, tile.getZoom() * (1 - exaggeration)) / 40075016.6855785);
-
+            double zoom = tile.getZoom();
+            // Heights are converted into tile-pixel units so the Sobel gradient in NormalMapBuilder
+            // comes out as a true slope: bitmapHeight * 2^zoom / earthCircumference = pixels/metre.
+            float scale = heightScale * getHeightScale() * static_cast<float>(bitmap->getHeight() * std::pow(2.0, zoom) / 40075016.6855785);
+            if (_legacyHeightScaleEnabled) {
+                // Pre-MapLibre-parity formula, kept for styles tuned against it. Relief is damped by
+                // the ABSOLUTE zoom, so it washes out as you zoom in. Needs heightScale 0.09 to
+                // reproduce the old default appearance.
+                float exaggeration = zoom < 2 ? 0.2f : zoom < 5 ? 0.3f : 0.35f;
+                scale = heightScale * 160 * getHeightScale() * static_cast<float>(bitmap->getHeight() * std::pow(2.0, zoom * (1 - exaggeration)) / 40075016.6855785);
+            } else if (_exagerateHeightScaleEnabled && zoom < 15.0) {
+                // MapLibre hillshade_prepare.fragment.glsl, verbatim: relief is the true slope from
+                // zoom 15 up (15 being the max zoom of Mapbox terrain-RGB, where this constant comes
+                // from) and boosted below it, because otherwise it is barely noticeable at low zoom.
+                // Unlike the legacy formula it does not flatten as the camera zooms in, which is what
+                // keeps the detail on a high-resolution (z15+) DEM.
+                float exaggerationFactor = zoom < 2.0 ? 0.4f : zoom < 4.5 ? 0.35f : 0.3f;
+                scale *= static_cast<float>(std::pow(2.0, (15.0 - zoom) * exaggerationFactor));
             }
             std::transform(scales.begin(), scales.end(), scales.begin(), [&scale](float &c) { return c * scale; });
         }

--- a/all/native/layers/HillshadeRasterTileLayer.h
+++ b/all/native/layers/HillshadeRasterTileLayer.h
@@ -35,7 +35,8 @@ namespace carto {
             */
             IGOR,
             /**
-            * Multi-directional hillshade with multiple light sources.
+            * Multi-directional hillshade based on GDAL: four light sources at 225, 270, 315 and 360
+            * degrees weighted by the aspect. Ignores the illumination azimuth, uses only its altitude.
             */
             MULTIDIRECTIONAL,
             /**
@@ -61,12 +62,15 @@ namespace carto {
         virtual ~HillshadeRasterTileLayer();
 
         /**
-         * Returns the contrast of the hillshade overlay.
+         * Returns the contrast of the hillshade overlay. This is the equivalent of MapLibre's
+         * 'hillshade-exaggeration' paint property: it controls the slope response curve and the
+         * overall strength of the shading, not the relief itself.
          * @return The contrast value (between 0..1). Default is 0.5.
          */
         float getContrast() const;
         /**
-         * Sets the contrast of the hillshade overlay.
+         * Sets the contrast of the hillshade overlay. Equivalent to MapLibre's
+         * 'hillshade-exaggeration'; 0.5 is the neutral value.
          * @param contrast The contrast value (between 0..1).
          */
         void setContrast(float contrast);
@@ -77,19 +81,21 @@ namespace carto {
          */
         float getHeightScale() const;
         /**
-         * Sets the height scale of the hillshade overlay.
+         * Sets the height scale of the hillshade overlay. Baked into the normal map at decode time,
+         * so changing it reloads the tiles. See setLegacyHeightScaleEnabled for the old default.
          * @param heightScale The relative height scale. Actual height is multiplied by this values.
          */
         void setHeightScale(float heightScale);
 
         /**
-         * Returns the per-frame relief exaggeration factor. Unlike height scale this is a shader
-         * uniform applied at render time (no tile re-decode), so it can be animated smoothly.
+         * Returns the per-frame relief exaggeration factor, i.e. the vertical exaggeration of the
+         * slope. Unlike height scale this is a shader uniform applied at render time (no tile
+         * re-decode), so it can be animated smoothly.
          * @return The exaggeration factor. Default is 1.0.
          */
         float getExaggeration() const;
         /**
-         * Sets the per-frame relief exaggeration factor. Scales the hillshade slope/intensity in the
+         * Sets the per-frame relief exaggeration factor. Multiplies the hillshade slope in the
          * shader without re-decoding tiles, so it can change smoothly (e.g. with zoom). 1.0 leaves the
          * appearance unchanged.
          * @param exaggeration The exaggeration factor.
@@ -143,8 +149,14 @@ namespace carto {
         MapVec getIlluminationDirection() const;
         /**
          * Sets the illumination direction.
+         * The horizontal part is read as a compass bearing (x = sin(azimuth), y = cos(azimuth), with
+         * azimuth 0 = north, increasing clockwise) pointing towards the light, and z points down
+         * towards the ground: -sin(altitude). MapLibre's default 'hillshade-illumination-direction'
+         * of 335 degrees at a 45 degree altitude is therefore (-0.4226, 0.9063, -0.7071), which is
+         * the default here too.
          * @param The new direction vector for the illumination light. (0,0,-1) means straight down, (-0.707,0,-0.707) means
          *        from east with a 45 degree angle. The direction vector will be normalized.
+         *        Note that the MULTIDIRECTIONAL method ignores the azimuth and uses only the altitude.
          */
         void setIlluminationDirection(MapVec direction);
         /**
@@ -168,6 +180,22 @@ namespace carto {
          * @param enabled whether to enable or not.
          */
         void setExagerateHeightScaleEnabled(bool enabled);
+
+        /**
+         * Returns whether the legacy (pre-MapLibre-parity) height scale formula is used.
+         * @return True if the legacy formula is used. Default is false.
+         */
+        bool isLegacyHeightScaleEnabled() const;
+
+        /**
+         * Sets whether to use the legacy (pre-MapLibre-parity) height scale formula, in which the
+         * relief is damped by the absolute zoom level and therefore flattens as the camera zooms in.
+         * The default formula instead follows MapLibre: the true slope from zoom 15 up, boosted
+         * below it. Styles tuned against the legacy formula should enable this and also call
+         * setHeightScale(0.09f), which was the old default height scale.
+         * @param enabled Whether to use the legacy formula.
+         */
+        void setLegacyHeightScaleEnabled(bool enabled);
 
         /**
          * Returns the hillshade rendering method.
@@ -255,6 +283,7 @@ namespace carto {
    
         std::atomic<float> _contrast;
         std::atomic<bool> _exagerateHeightScaleEnabled;
+        std::atomic<bool> _legacyHeightScaleEnabled;
         std::atomic<float> _heightScale;
 
         std::atomic<float> _exaggeration;

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -107,8 +107,8 @@ namespace carto {
          * will considerably increase network traffic if used with online maps. The default is false.
          * @param preloading The new preloading state of the layer.
          */
-        void setPreloading(bool preloading);
-        
+        virtual void setPreloading(bool preloading);
+
         /**
          * Returns the state of the synchronized refresh flag.
          * @return The state of the synchronized refresh flag.
@@ -144,7 +144,7 @@ namespace carto {
          * The default bias is 0.
          * @param bias The new bias value, both positive and negative fractional values are supported.
          */
-        void setZoomLevelBias(float bias);
+        virtual void setZoomLevelBias(float bias);
         
         /**
          * Gets the current maximum overzoom level for this layer.

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1351,7 +1351,17 @@ namespace carto {
                                 if (it->second == 0) {
                                     continue; // reported for the cover, but nothing drapeable in it
                                 }
-                                if (it->first == tileId || covers(it->first, tileId) || covers(tileId, it->first)) {
+                                // Only contributors the bake will actually draw: its own tile, or a
+                                // COARSER one covering it. GLTileRenderer::bakeDrapeTile skips
+                                // render tiles FINER than the terrain tile on purpose (they are the
+                                // generation being replaced, and minifying them into a sub-rect
+                                // turns the drape into aliasing noise), so counting them here made
+                                // the leaf permanently incomplete: its own bake could never satisfy
+                                // a layer whose only contribution was a finer tile. The stand-in
+                                // path then kept drawing that layer's PREVIOUS, finer textures over
+                                // the leaf for as long as they stayed cached - which is the patch of
+                                // stale z11 map (satellite, roads) that survives a zoom out to z10.
+                                if (it->first == tileId || covers(it->first, tileId)) {
                                     layerMask |= static_cast<std::size_t>(1) << i;
                                     break;
                                 }

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -445,6 +445,12 @@ namespace carto {
             }
             if (_maxVertexTextureUnits > 0) {
                 std::shared_ptr<ElevationManager> elevationManager = activeTerrainOptions->getElevationManager();
+                if (elevationManager) {
+                    // Cap elevation levels at what the mesh can express - for every elevation
+                    // consumer, not just the drawn surface (billboard occlusion ray marching and
+                    // element placement query the same manager and must see the same heights).
+                    elevationManager->setSurfaceResolution(activeTerrainOptions->getMeshResolution());
+                }
                 if (_elevationTextureCache && _elevationTextureCache->getElevationManager() != elevationManager) {
                     _elevationTextureCache.reset();
                 }
@@ -454,6 +460,7 @@ namespace carto {
                     }
                 }
                 if (_elevationTextureCache) {
+                    _elevationTextureCache->beginFrame();
                     std::shared_ptr<ElevationTextureCache> elevationTextureCache = _elevationTextureCache;
                     terrainTextureProvider = [elevationTextureCache](const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture) {
                         return elevationTextureCache->getTexture(tileId, terrainTexture);
@@ -503,6 +510,7 @@ namespace carto {
         bool regularGrid = painterOrder || drapeFills || (terrainMode && activeTerrainOptions && activeTerrainOptions->isRegularGridEnabled() && (bool) terrainTextureProvider);
         tileRenderer->setTerrainRegularGrid(regularGrid, activeTerrainOptions ? activeTerrainOptions->getMeshResolution() : 0);
         tileRenderer->setTerrainPainterOrder(painterOrder);
+        tileRenderer->setTerrainEdgeStitching(regularGrid && activeTerrainOptions && activeTerrainOptions->isTileEdgeStitchingEnabled());
         // Draped content is baked FLAT (orthographic, no displacement), so lines need no terrain
         // subdivision either - draping them is strictly cheaper as well as artifact-free.
         tileRenderer->setTerrainDrapeFills(drapeFills, drapeFills);

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -63,7 +63,8 @@ namespace carto {
         _normalIlluminationDirection(0,0,0),
         _mapRotation(0),
         _hillshadeMethod(HillshadeMethod::STANDARD),
-        _hillshadeExaggeration(0.5f),
+        _hillshadeExaggeration(1.0f),
+        _hillshadeIntensity(0.5f),
         _tiles(),
         _mutex()
     {
@@ -190,6 +191,11 @@ namespace carto {
     void TileRenderer::setHillshadeExaggeration(float exaggeration) {
         std::lock_guard<std::mutex> lock(_mutex);
         _hillshadeExaggeration = exaggeration;
+    }
+
+    void TileRenderer::setHillshadeIntensity(float intensity) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _hillshadeIntensity = intensity;
     }
 
     void TileRenderer::setRendererLayerFilter(const std::optional<std::regex>& filter) {
@@ -580,9 +586,14 @@ namespace carto {
             if (_normalIlluminationMapRotationEnabled) {
                 double y = normalIlluminationDir.getY();
                 double x = normalIlluminationDir.getX();
-                double azimuthal = ((x > 0) ? acos(y) : -acos(y)) * Const::RAD_TO_DEG - _mapRotation;
-                double sin = std::sin(azimuthal * Const::DEG_TO_RAD);
-                double cos = std::cos(azimuthal * Const::DEG_TO_RAD);
+                // Compass azimuth (0 = north, clockwise) of the horizontal part, counter-rotated by
+                // the map rotation so the light stays anchored to the viewport. The horizontal
+                // length is preserved - the previous acos(y) form assumed a unit xy and silently
+                // rewrote the horizontal/vertical balance of any other direction.
+                double xyLength = std::sqrt(x * x + y * y);
+                double azimuthal = std::atan2(x, y) * Const::RAD_TO_DEG - _mapRotation;
+                double sin = std::sin(azimuthal * Const::DEG_TO_RAD) * xyLength;
+                double cos = std::cos(azimuthal * Const::DEG_TO_RAD) * xyLength;
                 normalIlluminationDir = MapVec(sin, cos, normalIlluminationDir.getZ());
             }
 
@@ -964,18 +975,22 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
             tileRenderer->setLightingShader3D(lightingShader3D);
 
             vt::GLTileRenderer::LightingShader lightingShaderNormalMap(false, _normalMapLightingShader, [this](GLuint shaderProgram, const vt::ViewState& viewState) {
-                    // Pass colors without premultiplying RGB by alpha, matching MapLibre's approach
+                    // Straight (non-premultiplied) colors - the shader premultiplies them before
+                    // mixing, which is the form MapLibre's hillshade fragment shader works in.
                     glUniform4f(glGetUniformLocation(shaderProgram, "u_shadowColor"), _normalMapShadowColor.getR() / 255.0f, _normalMapShadowColor.getG() / 255.0f, _normalMapShadowColor.getB() / 255.0f, _normalMapShadowColor.getA() / 255.0f);
                     glUniform4f(glGetUniformLocation(shaderProgram, "u_accentColor"), _normalMapAccentColor.getR() / 255.0f, _normalMapAccentColor.getG() / 255.0f, _normalMapAccentColor.getB() / 255.0f, _normalMapAccentColor.getA() / 255.0f);
                     glUniform4f(glGetUniformLocation(shaderProgram, "u_highlightColor"), _normalMapHighlightColor.getR() / 255.0f, _normalMapHighlightColor.getG() / 255.0f, _normalMapHighlightColor.getB() / 255.0f, _normalMapHighlightColor.getA() / 255.0f);
                     glUniform3fv(glGetUniformLocation(shaderProgram, "u_lightDir"), 1, _normalLightDir.data() );
                     glUniform1i(glGetUniformLocation(shaderProgram, "u_method"), (_hillshadeMethod));
                     glUniform1f(glGetUniformLocation(shaderProgram, "u_exaggeration"), _hillshadeExaggeration);
+                    // MapLibre's 'hillshade-exaggeration' (the slope response curve), fed from the
+                    // layer's contrast. Kept separate from u_exaggeration, which scales the slope.
+                    glUniform1f(glGetUniformLocation(shaderProgram, "u_intensity"), _hillshadeIntensity);
                     // Elevation-encoded normal map + contour lines (opt-in). These uniforms have no
                     // effect unless the normal map was built with elevation encoding (see HillshadeRasterTileLayer).
                     glUniform1f(glGetUniformLocation(shaderProgram, "u_elevationEncoded"), _normalMapElevationEncoded ? 1.0f : 0.0f);
                     glUniform2f(glGetUniformLocation(shaderProgram, "u_elevationDecode"), vt::NormalMapBuilder::ELEVATION_SCALE, vt::NormalMapBuilder::ELEVATION_OFFSET);
-                    glUniform1f(glGetUniformLocation(shaderProgram, "u_contrast"), _hillshadeExaggeration);
+                    glUniform1f(glGetUniformLocation(shaderProgram, "u_contrast"), _hillshadeIntensity);
                     glUniform4f(glGetUniformLocation(shaderProgram, "u_contourColor"), _normalMapContourColor.getR() / 255.0f, _normalMapContourColor.getG() / 255.0f, _normalMapContourColor.getB() / 255.0f, _normalMapContourColor.getA() / 255.0f);
                     glUniform1f(glGetUniformLocation(shaderProgram, "u_contourInterval"), _normalMapContourInterval);
                     glUniform1f(glGetUniformLocation(shaderProgram, "u_contourWidth"), _normalMapContourWidth);
@@ -1030,7 +1045,11 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
         uniform vec4 u_accentColor;
         uniform vec3 u_lightDir;
         uniform int u_method;
+        // Vertical relief multiplier applied to the slope (HillshadeRasterTileLayer exaggeration).
         uniform float u_exaggeration;
+        // MapLibre's 'hillshade-exaggeration': the slope response curve and the overall strength
+        // (HillshadeRasterTileLayer contrast). Default 0.5, matching the MapLibre style spec.
+        uniform float u_intensity;
 
         #define PI 3.141592653589793
         #define STANDARD 0
@@ -1039,58 +1058,70 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
         #define MULTIDIRECTIONAL 3
         #define BASIC 4
 
+        // All algorithms below composite in premultiplied alpha (the renderer blends normal map
+        // tiles with GL_ONE, GL_ONE_MINUS_SRC_ALPHA), so the straight colors coming in from the
+        // uniforms are premultiplied first - as MapLibre does before its shader ever runs.
+        vec4 premul(vec4 color) {
+            return vec4(color.rgb * color.a, color.a);
+        }
+
         float get_aspect(vec2 deriv) {
             return deriv.x != 0.0 ? atan(deriv.y, -deriv.x) : PI / 2.0 * (deriv.y > 0.0 ? 1.0 : -1.0);
         }
 
+        // The GDAL-derived algorithms below scale the slope by the intensity, as MapLibre does
+        // (deriv * u_exaggeration * 2.0 in its hillshade.fragment.glsl). standard_hillshade does
+        // not - it feeds the intensity into its slope response curve instead.
+        vec2 scale_deriv(vec2 deriv) {
+            return deriv * u_intensity * 2.0;
+        }
+
         // Based on GDALHillshadeIgorAlg()
-        vec4 igor_hillshade(vec2 deriv, vec3 lightDir) {
+        vec4 igor_hillshade(vec2 deriv_in, float azimuth) {
+            vec2 deriv = scale_deriv(deriv_in);
             float aspect = get_aspect(deriv);
-            // Convert light direction to azimuth
-            float azimuth = atan(lightDir.y, lightDir.x) + PI;
             float slope_strength = atan(length(deriv)) * 2.0/PI;
             float aspect_strength = 1.0 - abs(mod((aspect + azimuth) / PI + 0.5, 2.0) - 1.0);
             float shadow_strength = slope_strength * aspect_strength;
             float highlight_strength = slope_strength * (1.0-aspect_strength);
-            vec4 result = u_shadowColor * shadow_strength + u_highlightColor * highlight_strength;
-            // Premultiply RGB by alpha to handle transparency correctly
-            return vec4(result.rgb * result.a, result.a);
+            return premul(u_shadowColor) * shadow_strength + premul(u_highlightColor) * highlight_strength;
         }
 
-        // MapLibre's legacy hillshade algorithm
-        vec4 standard_hillshade(vec2 deriv, vec3 lightDir) {
-            // Convert light direction to azimuth
-            float azimuth = atan(lightDir.y, lightDir.x) + PI;
-
-            // We multiply the slope by an arbitrary z-factor of 0.625
+        // Port of MapLibre's hillshade.fragment.glsl. Kept line-for-line comparable so the two
+        // renderers can be diffed against each other; the only deliberate difference is that the
+        // Mercator scale correction (MapLibre's 'scaleFactor') is baked into the normal map by
+        // NormalMapBuilder instead of being recomputed per fragment from a latitude range.
+        vec4 standard_hillshade(vec2 deriv, float azimuth) {
+            // We also multiply the slope by an arbitrary z-factor of 0.625
             float slope = atan(0.625 * length(deriv));
             float aspect = get_aspect(deriv);
 
-            float intensity = u_exaggeration;
+            float intensity = u_intensity;
 
-            // Scale the slope exponentially based on intensity
+            // We scale the slope exponentially based on intensity, using the position of the
+            // maximum return value of the shade function as the exponent
             float base = 1.875 - intensity * 1.75;
             float maxValue = 0.5 * PI;
             float scaledSlope = intensity != 0.5 ? ((pow(base, slope) - 1.0) / (pow(base, maxValue) - 1.0)) * maxValue : slope;
 
-            // The accent color is calculated with the cosine of the slope
+            // The accent color is calculated with the cosine of the slope while the shade color is
+            // calculated with the sine, so that the accent color's rate of change eases in while
+            // the shade color's eases out.
             float accent = cos(scaledSlope);
-            vec4 accent_color = (1.0 - accent) * u_accentColor * clamp(intensity * 2.0, 0.0, 1.0);
-            
-            // Shade color based on aspect and azimuth
+            // Both the accent and shade color are multiplied by a clamped intensity value so that
+            // intensities >= 0.5 do not additionally affect the color values, while intensity
+            // values < 0.5 make the overall color more transparent.
+            vec4 accent_color = (1.0 - accent) * premul(u_accentColor) * clamp(intensity * 2.0, 0.0, 1.0);
+
             float shade = abs(mod((aspect + azimuth) / PI + 0.5, 2.0) - 1.0);
-            vec4 shade_color = mix(u_shadowColor, u_highlightColor, shade) * sin(scaledSlope) * clamp(intensity * 2.0, 0.0, 1.0);
-            
-            vec4 result = accent_color * (1.0 - shade_color.a) + shade_color;
-            // Premultiply RGB by alpha to handle transparency correctly
-            return vec4(result.rgb * result.a, result.a);
+            vec4 shade_color = mix(premul(u_shadowColor), premul(u_highlightColor), shade) * sin(scaledSlope) * clamp(intensity * 2.0, 0.0, 1.0);
+
+            return accent_color * (1.0 - shade_color.a) + shade_color;
         }
 
-        // Based on GDALHillshadeAlg()
-        vec4 basic_hillshade(vec2 deriv, vec3 lightDir) {
-            float azimuth = atan(lightDir.y, lightDir.x) + PI;
-            float altitude = asin(clamp(lightDir.z, -1.0, 1.0));
-            
+        // Based on GDALHillshadeAlg(). 'altitude' is the light's elevation above the horizon.
+        vec4 basic_hillshade(vec2 deriv_in, float azimuth, float altitude) {
+            vec2 deriv = scale_deriv(deriv_in);
             float cos_az = cos(azimuth);
             float sin_az = sin(azimuth);
             float cos_alt = cos(altitude);
@@ -1099,28 +1130,55 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
             float cang = (sin_alt - (deriv.y*cos_az*cos_alt - deriv.x*sin_az*cos_alt)) / sqrt(1.0 + dot(deriv, deriv));
 
             float shade = clamp(cang, 0.0, 1.0);
-            vec4 result;
             if(shade > 0.5) {
-                result = u_highlightColor * (2.0*shade - 1.0);
-            } else {
-                result = u_shadowColor * (1.0 - 2.0*shade);
+                return premul(u_highlightColor) * (2.0*shade - 1.0);
             }
-            // Premultiply RGB by alpha to handle transparency correctly
-            return vec4(result.rgb * result.a, result.a);
+            return premul(u_shadowColor) * (1.0 - 2.0*shade);
         }
 
-        // Multidirectional hillshade (simplified to single light for now)
-        vec4 multidirectional_hillshade(vec2 deriv, vec3 lightDir) {
-            // For now, just use basic hillshade with the main light
-            // In the future, this could be extended to support multiple lights
-            return basic_hillshade(deriv, lightDir);
+        // Based on GDALHillshadeMultiDirectionalAlg(): four lights at 225/270/315/360 degrees,
+        // weighted by the aspect. The user azimuth is unused by design - only the altitude matters.
+        // Note MapLibre instead averages basic_hillshade over its illumination-source arrays, which
+        // degenerates to plain BASIC for the single light source this layer exposes; GDAL's version
+        // is used here so the mode is actually multidirectional.
+        vec4 multidirectional_hillshade(vec2 deriv_in, float altitude) {
+            vec2 deriv = scale_deriv(deriv_in);
+            float cos_alt = cos(altitude);
+            float sin_alt = sin(altitude);
+            float xx_plus_yy = dot(deriv, deriv);
+
+            float shade;
+            if (xx_plus_yy == 0.0) {
+                shade = clamp(sin_alt, 0.0, 1.0);
+            } else {
+                float x = deriv.x;
+                float y = deriv.y;
+                // cos(225 deg) * cos(altitude), shared by the 225 and 315 degree lights
+                float c225 = -0.70710678 * cos_alt;
+                float val225 = sin_alt + (x - y) * c225;
+                float val270 = sin_alt - x * cos_alt;
+                float val315 = sin_alt + (x + y) * c225;
+                float val360 = sin_alt - y * cos_alt;
+
+                float weight225 = 0.5 * xx_plus_yy - x * y;
+                float weight270 = x * x;
+                float weight315 = xx_plus_yy - weight225;
+                float weight360 = y * y;
+
+                float cang = (max(0.0, val225) * weight225 + max(0.0, val270) * weight270 +
+                              max(0.0, val315) * weight315 + max(0.0, val360) * weight360) / (xx_plus_yy * 2.0);
+                shade = clamp(cang / sqrt(1.0 + xx_plus_yy), 0.0, 1.0);
+            }
+
+            if(shade > 0.5) {
+                return premul(u_highlightColor) * (2.0*shade - 1.0);
+            }
+            return premul(u_shadowColor) * (1.0 - 2.0*shade);
         }
 
         // Based on GDALHillshadeCombinedAlg()
-        vec4 combined_hillshade(vec2 deriv, vec3 lightDir) {
-            float azimuth = atan(lightDir.y, lightDir.x) + PI;
-            float altitude = asin(clamp(lightDir.z, -1.0, 1.0));
-            
+        vec4 combined_hillshade(vec2 deriv_in, float azimuth, float altitude) {
+            vec2 deriv = scale_deriv(deriv_in);
             float cos_az = cos(azimuth);
             float sin_az = sin(azimuth);
             float cos_alt = cos(altitude);
@@ -1133,40 +1191,39 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
             float shade = cang * atan(length(deriv)) * 4.0/PI/PI;
             float highlight = (PI/2.0-cang) * atan(length(deriv)) * 4.0/PI/PI;
 
-            vec4 result = u_shadowColor*shade + u_highlightColor*highlight;
-            // Premultiply RGB by alpha to handle transparency correctly
-            return vec4(result.rgb * result.a, result.a);
+            return premul(u_shadowColor)*shade + premul(u_highlightColor)*highlight;
         }
 
         vec4 applyLighting(lowp vec4 color, mediump vec3 normal, mediump vec3 surfaceNormal, mediump float intensity) {
-            // Extract derivatives from normal vector
-            // The normal is already in tangent space where z points up
-            // For a flat surface, normal would be (0, 0, 1)
-            // The derivatives represent the slope in x and y directions
-            vec2 deriv = vec2(-normal.x / max(normal.z, 0.001), -normal.y / max(normal.z, 0.001));
-            
-            // Apply exaggeration to derivatives
-            deriv *= u_exaggeration * 2.0;
-            
-            vec4 hillshadeColor;
+            // Recover the height gradient from the perturbed normal. On a planar surface the
+            // tangent frame flips x and y, so -normal.xy/normal.z gives (dh/dEast, dh/dNorth).
+            // The y component is negated on top of that to match MapLibre, whose DEM texture has
+            // north at v = 0 and therefore works with (dh/dEast, -dh/dNorth). Without it the
+            // aspect is mirrored about the east-west axis and the light rotates the wrong way.
+            vec2 deriv = vec2(-normal.x, normal.y) / max(normal.z, 0.001);
+
+            // Extra vertical exaggeration, a CARTO addition with no MapLibre equivalent. At the
+            // default of 1.0 the slope is left exactly as the normal map encoded it.
+            deriv *= u_exaggeration;
+
+            // u_lightDir is (sin(compassAzimuth), cos(compassAzimuth), -sin(altitude)): the
+            // horizontal part points towards the light, z points down towards the ground.
+            // MapLibre adds PI to the compass azimuth for every method, because 0 degrees is north
+            // and the original shader was written to accept (-illuminationDirection - 90).
+            float azimuth = atan(u_lightDir.x, u_lightDir.y) + PI;
+            float altitude = asin(clamp(-u_lightDir.z, -1.0, 1.0));
+
             if (u_method == BASIC) {
-                hillshadeColor = basic_hillshade(deriv, u_lightDir);
+                return basic_hillshade(deriv, azimuth, altitude);
             } else if (u_method == COMBINED) {
-                hillshadeColor = combined_hillshade(deriv, u_lightDir);
+                return combined_hillshade(deriv, azimuth, altitude);
             } else if (u_method == IGOR) {
-                hillshadeColor = igor_hillshade(deriv, u_lightDir);
+                return igor_hillshade(deriv, azimuth);
             } else if (u_method == MULTIDIRECTIONAL) {
-                hillshadeColor = multidirectional_hillshade(deriv, u_lightDir);
-            } else {
-                // STANDARD (default)
-                hillshadeColor = standard_hillshade(deriv, u_lightDir);
+                return multidirectional_hillshade(deriv, altitude);
             }
-            
-            // The VT library multiplies our result by 'intensity', but hillshading should have
-            // constant strength regardless of slope. Divide by intensity to cancel this out.
-            // Use max() to avoid division by zero for flat areas.
-            float intensityFactor = max(intensity, 0.01);
-            return vec4(hillshadeColor.rgb / intensityFactor, hillshadeColor.a);
+            // STANDARD (default)
+            return standard_hillshade(deriv, azimuth);
         }
     )GLSL";
 

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -72,6 +72,7 @@ namespace carto {
         void setNormalIlluminationDirection(MapVec direction);
         void setHillshadeMethod(int method);
         void setHillshadeExaggeration(float exaggeration);
+        void setHillshadeIntensity(float intensity);
         void setRendererLayerFilter(const std::optional<std::regex>& filter);
         void setClickHandlerLayerFilter(const std::optional<std::regex>& filter);
 
@@ -177,6 +178,7 @@ namespace carto {
         double _mapRotation;
         int _hillshadeMethod;
         float _hillshadeExaggeration;
+        float _hillshadeIntensity;
         bool _terrainDepthWriteMode = false;
         bool prepareFrameUnsafe(float deltaSeconds, const ViewState& viewState); // caller holds _mutex
 

--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -21,20 +21,69 @@ namespace carto {
     }
 
     bool ElevationTextureCache::getTexture(const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture) {
+        int tileMask = (1 << tileId.zoom) - 1;
+        MapTile mapTile(tileId.x & tileMask, std::min(std::max(tileId.y, 0), tileMask), tileId.zoom, 0);
+        long long mapTileId = mapTile.getTileId();
+
+        // The provider is called once per tile per render pass; resolve the tile at most
+        // once per frame and reuse the resolution for the remaining passes.
+        long long gridTileId = -1;
+        auto frameIt = _frameResolved.find(mapTileId);
+        if (frameIt != _frameResolved.end()) {
+            gridTileId = frameIt->second;
+        } else {
+            if (!resolveEntry(tileId, gridTileId)) {
+                gridTileId = -1;
+            }
+            _frameResolved[mapTileId] = gridTileId;
+        }
+        if (gridTileId < 0) {
+            return false;
+        }
+
+        auto it = _cache.find(gridTileId);
+        if (it == _cache.end() || !it->second.texture || it->second.texture->getTexId() == 0) {
+            return false;
+        }
+        it->second.lastUsed = ++_accessCounter;
+        fillTexture(it->second, static_cast<float>(_elevationManager->getExaggeration() * Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE), terrainTexture);
+        return true;
+    }
+
+    bool ElevationTextureCache::resolveEntry(const vt::TileId& tileId, long long& gridTileId) {
         // Resolve the best already-decoded elevation grid for the tile. This mirrors the
         // CPU displacement path (TerrainTileTransformer), so the GPU-sampled heights stay
         // consistent with element placement, hit testing and label anchors.
         int tileMask = (1 << tileId.zoom) - 1;
         MapTile mapTile(tileId.x & tileMask, std::min(std::max(tileId.y, 0), tileMask), tileId.zoom, 0);
-        std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getTileGrid(mapTile, ElevationManager::LoadMode::CACHED_ONLY);
+
+        // The tile that carries this tile's elevation data: its own level, capped by the data
+        // source maximum zoom and by the resolution the surface mesh can express (see
+        // ElevationManager::setSurfaceResolution). The cap lives in the manager so that the
+        // displaced surface and every CPU-side elevation query use the same height field.
+        MapTile dataTile = _elevationManager->getDataTile(mapTile);
+
+        std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getTileGrid(dataTile, ElevationManager::LoadMode::CACHED_ONLY);
+        if (!grid || !(grid->getTile() == dataTile)) {
+            // Missing or resolved through a coarser ancestor: request the real thing, ahead of
+            // any neighbour request. Until it arrives this tile is displaced by an ancestor grid
+            // - which is a 2x2 average of its children, i.e. a different height field than the
+            // neighbouring tiles that already have their own level - and the surface tears along
+            // the shared edge. Loading the right level fast is what closes it.
+            // No-op when elevation prefetching is disabled or the tile is already queued.
+            _elevationManager->prefetchTileGrid(dataTile, 2);
+        }
         if (!grid || grid->getWidth() < 1 || grid->getHeight() < 1) {
             return false;
         }
 
-        // Fetch the same-level neighbour grids: the texture gets a 1-texel border copied
-        // from them, so adjacent tiles bilinearly interpolate across tile borders from
-        // identical texel pairs - same-level DEM tile borders become seam-free. Only exact
-        // same-level neighbours are used (ancestor fallbacks would not be symmetric).
+        // Fetch the neighbour grids: the texture gets a 1-texel border taken from them, so
+        // adjacent tiles bilinearly interpolate across tile borders from identical texel
+        // pairs - same-level DEM tile borders become seam-free. With seamless tile edges
+        // enabled, coarser ancestor grids are accepted as well and sampled geographically
+        // (ElevationTileGrid::encodeTextureWithBorders): not perfectly symmetric across a
+        // level change, but real DEM data instead of a duplicated edge texel.
+        bool seamless = _elevationManager->isSeamlessTileEdgesEnabled();
         const MapTile& gridTile = grid->getTile();
         int gridMask = (1 << gridTile.getZoom()) - 1;
         auto neighbourGrid = [&, this](int dx, int dy) -> std::shared_ptr<ElevationTileGrid> {
@@ -44,8 +93,18 @@ namespace carto {
             }
             MapTile neighbourTile((gridTile.getX() + dx) & gridMask, ny, gridTile.getZoom(), 0);
             std::shared_ptr<ElevationTileGrid> neighbour = _elevationManager->getTileGrid(neighbourTile, ElevationManager::LoadMode::CACHED_ONLY);
-            if (neighbour && !(neighbour->getTile() == neighbourTile)) {
-                neighbour.reset();
+            if (!neighbour || !(neighbour->getTile() == neighbourTile)) {
+                // Border texels want the real neighbour tile, but after every tile's own level:
+                // a missing neighbour costs one texel of border accuracy, a missing own level
+                // displaces the whole tile. Diagonal neighbours only fill the corner texel where
+                // four tiles meet, so they come last.
+                _elevationManager->prefetchTileGrid(neighbourTile, dx == 0 || dy == 0 ? 1 : 0);
+            }
+            if (neighbour && !(neighbour->getTile() == neighbourTile) && !seamless) {
+                neighbour.reset(); // strict mode: only exact same-level neighbours
+            }
+            if (neighbour && neighbour->getTile() == gridTile) {
+                neighbour.reset(); // our own grid covers the neighbour: the texture is already continuous there
             }
             return neighbour;
         };
@@ -55,7 +114,7 @@ namespace carto {
             neighbourGrid(-1, 1), neighbourGrid(1, 1), neighbourGrid(-1, -1), neighbourGrid(1, -1)
         } };
 
-        long long gridTileId = gridTile.getTileId();
+        gridTileId = gridTile.getTileId();
         auto it = _cache.find(gridTileId);
         if (it == _cache.end() || it->second.grid != grid || it->second.neighbours != neighbours) {
             if (_cache.size() >= MAX_CACHED_TEXTURES && it == _cache.end()) {
@@ -63,9 +122,22 @@ namespace carto {
                 // re-encodes+re-uploads every texture whenever the working set exceeds the cap,
                 // which stalls the render thread on fast multi-level zooms (the working set of
                 // visible + neighbour DEM tiles briefly exceeds the cap). LRU keeps the warm set.
-                auto lru = std::min_element(_cache.begin(), _cache.end(), [](const std::pair<const long long, CacheEntry>& a, const std::pair<const long long, CacheEntry>& b) {
-                    return a.second.lastUsed < b.second.lastUsed;
-                });
+                // Entries already used in this frame are kept if possible: dropping one would
+                // make the tile fall back to flat in its remaining render passes.
+                auto lru = _cache.end();
+                for (auto entryIt = _cache.begin(); entryIt != _cache.end(); entryIt++) {
+                    if (entryIt->second.lastUsed > _frameStartCounter) {
+                        continue;
+                    }
+                    if (lru == _cache.end() || entryIt->second.lastUsed < lru->second.lastUsed) {
+                        lru = entryIt;
+                    }
+                }
+                if (lru == _cache.end()) {
+                    lru = std::min_element(_cache.begin(), _cache.end(), [](const std::pair<const long long, CacheEntry>& a, const std::pair<const long long, CacheEntry>& b) {
+                        return a.second.lastUsed < b.second.lastUsed;
+                    });
+                }
                 if (lru != _cache.end()) {
                     _cache.erase(lru);
                 }
@@ -84,11 +156,10 @@ namespace carto {
             it = _cache.insert_or_assign(gridTileId, std::move(entry)).first;
         }
         it->second.lastUsed = ++_accessCounter;
-        const CacheEntry& entry = it->second;
-        if (!entry.texture || entry.texture->getTexId() == 0) {
-            return false;
-        }
+        return it->second.texture && it->second.texture->getTexId() != 0;
+    }
 
+    void ElevationTextureCache::fillTexture(const CacheEntry& entry, float metersToInternal, vt::GLTileRenderer::TerrainTexture& terrainTexture) {
         // The texture covers the grid bounds extended by the 1-texel border
         const MapBounds& bounds = entry.grid->getInternalBounds();
         double texelX = (bounds.getMax().getX() - bounds.getMin().getX()) / entry.grid->getWidth();
@@ -98,12 +169,17 @@ namespace carto {
         terrainTexture.internalOrigin = cglib::vec2<double>(bounds.getMin().getX() - texelX, bounds.getMin().getY() - texelY);
         terrainTexture.internalSize = cglib::vec2<double>(bounds.getMax().getX() - bounds.getMin().getX() + 2 * texelX, bounds.getMax().getY() - bounds.getMin().getY() + 2 * texelY);
         terrainTexture.decode = cglib::vec4<float>(entry.decode[0], entry.decode[1], entry.decode[2], entry.decode[3]);
-        terrainTexture.metersToInternal = static_cast<float>(_elevationManager->getExaggeration() * Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE);
+        terrainTexture.metersToInternal = metersToInternal;
         terrainTexture.mercatorYScale = static_cast<float>(2.0 * Const::PI / Const::WORLD_SIZE);
-        return true;
+    }
+
+    void ElevationTextureCache::beginFrame() {
+        _frameResolved.clear();
+        _frameStartCounter = _accessCounter;
     }
 
     void ElevationTextureCache::clear() {
         _cache.clear();
+        _frameResolved.clear();
     }
 }

--- a/all/native/renderers/utils/ElevationTextureCache.h
+++ b/all/native/renderers/utils/ElevationTextureCache.h
@@ -42,6 +42,13 @@ namespace carto {
          */
         bool getTexture(const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture);
 
+        /**
+         * Starts a new frame: drops the per-frame tile resolution memo. The provider is called
+         * once per tile per render pass, so without the memo every pass would redo the grid and
+         * neighbour lookups (9 locked cache lookups per tile) for the same result.
+         */
+        void beginFrame();
+
         void clear();
 
     private:
@@ -55,10 +62,15 @@ namespace carto {
 
         static constexpr std::size_t MAX_CACHED_TEXTURES = 96; // ~24MB of RGBA 256x256 textures
 
+        bool resolveEntry(const vt::TileId& tileId, long long& gridTileId);
+        static void fillTexture(const CacheEntry& entry, float metersToInternal, vt::GLTileRenderer::TerrainTexture& terrainTexture);
+
         const std::shared_ptr<ElevationManager> _elevationManager;
         const std::shared_ptr<GLResourceManager> _glResourceManager;
         std::map<long long, CacheEntry> _cache; // keyed by the grid tile id
+        std::map<long long, long long> _frameResolved; // render tile id -> grid tile id (-1: no data), reset every frame
         std::uint64_t _accessCounter = 0; // monotonic LRU clock
+        std::uint64_t _frameStartCounter = 0; // LRU clock at the start of the current frame
     };
 }
 

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -20,6 +20,8 @@ namespace carto {
     static const std::size_t DEFAULT_CACHE_CAPACITY = 64 * 1024 * 1024;
     static const int FAILED_TILE_TTL_MILLISECONDS = 30 * 1000;
     static const int MAX_ANCESTOR_SEARCH_DEPTH = 8;
+    static const std::size_t MAX_PREFETCH_QUEUE_SIZE = 64;
+    static const int PREFETCH_THREADS = 3; // elevation tiles are network+decode bound; one worker converges too slowly
     static constexpr double NO_DATA_ELEVATION = -1000000.0;
     static constexpr double DEFAULT_MIN_ELEVATION = -500.0;
     static constexpr double DEFAULT_MAX_ELEVATION = 9000.0;
@@ -43,16 +45,34 @@ namespace carto {
         _projection(dataSource->getProjection()),
         _dataSourceListener(),
         _exaggeration(1.0f),
+        _seamlessTileEdges(true),
+        _surfaceResolution(32),
+        _gridSizeHint(256),
+        _neighbourPrefetch(true),
         _version(1),
         _maxSeenElevation(0.0f),
         _gridCache(DEFAULT_CACHE_CAPACITY),
-        _mutex()
+        _mutex(),
+        _prefetchStopped(false)
     {
         _dataSourceListener = std::make_shared<DataSourceListener>(*this);
         _dataSource->registerOnChangeListener(_dataSourceListener);
     }
 
     ElevationManager::~ElevationManager() {
+        {
+            std::lock_guard<std::mutex> lock(_prefetchMutex);
+            _prefetchStopped = true;
+            _prefetchQueue.clear();
+            _prefetchQueueHigh.clear();
+            _prefetchTileIds.clear();
+        }
+        _prefetchCondition.notify_all();
+        for (std::thread& thread : _prefetchThreads) {
+            if (thread.joinable()) {
+                thread.join();
+            }
+        }
         _dataSource->unregisterOnChangeListener(_dataSourceListener);
     }
 
@@ -71,6 +91,31 @@ namespace carto {
     void ElevationManager::setExaggeration(float exaggeration) {
         _exaggeration.store(std::max(0.0f, exaggeration));
         _version++;
+    }
+
+    bool ElevationManager::isSeamlessTileEdgesEnabled() const {
+        return _seamlessTileEdges.load();
+    }
+
+    void ElevationManager::setSeamlessTileEdgesEnabled(bool enabled) {
+        if (_seamlessTileEdges.exchange(enabled) != enabled) {
+            _version++; // elevation texture borders change, force a rebuild
+        }
+    }
+
+    void ElevationManager::setSurfaceResolution(int resolution) {
+        int value = std::max(1, resolution);
+        if (_surfaceResolution.exchange(value) != value) {
+            _version++; // the elevation level cap changes with it
+        }
+    }
+
+    bool ElevationManager::isNeighbourPrefetchEnabled() const {
+        return _neighbourPrefetch.load();
+    }
+
+    void ElevationManager::setNeighbourPrefetchEnabled(bool enabled) {
+        _neighbourPrefetch.store(enabled);
     }
 
     std::size_t ElevationManager::getCacheCapacity() const {
@@ -150,7 +195,21 @@ namespace carto {
 
         // Look for the tile or any of its cached ancestors
         bool tileFailed = false;
-        {
+        if (mode == LoadMode::LOAD_EXACT) {
+            // The caller wants THIS level, not a stand-in: a cached ancestor must not short
+            // circuit the load, or a tile that once fell back to its parent would stay on it
+            // forever - and neighbouring tiles displaced by different elevation levels tear the
+            // surface open along their shared edge. A grid cached under this tile id that covers
+            // an ancestor is the data source saying the level does not exist here, so it stands.
+            std::lock_guard<std::mutex> lock(_mutex);
+            std::shared_ptr<ElevationTileGrid> grid;
+            if (_gridCache.read(tile.getTileId(), grid)) {
+                if (grid) {
+                    return grid;
+                }
+                tileFailed = true; // recently failed to load, do not retry until the failure marker expires
+            }
+        } else {
             std::lock_guard<std::mutex> lock(_mutex);
             MapTile searchTile = tile;
             for (int depth = 0; depth <= MAX_ANCESTOR_SEARCH_DEPTH; depth++) {
@@ -222,6 +281,84 @@ namespace carto {
             _version++;
         }
         return grid;
+    }
+
+    MapTile ElevationManager::getDataTile(const MapTile& mapTile) const {
+        return clampTileZoom(mapTile);
+    }
+
+    void ElevationManager::prefetchTileGrid(const MapTile& mapTile, int priority) const {
+        if (!_neighbourPrefetch.load()) {
+            return;
+        }
+        MapTile tile = clampTileZoom(mapTile);
+        if (tile.getZoom() < _dataSource->getMinZoom()) {
+            return;
+        }
+
+        long long tileId = tile.getTileId();
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            std::shared_ptr<ElevationTileGrid> grid;
+            if (_gridCache.read(tileId, grid)) {
+                return; // already loaded, resolved via an ancestor, or recently failed
+            }
+            if (_pendingLoads.find(tileId) != _pendingLoads.end()) {
+                return; // already being loaded by another thread
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(_prefetchMutex);
+            if (_prefetchStopped) {
+                return;
+            }
+            if (!_prefetchTileIds.insert(tileId).second) {
+                return; // already queued
+            }
+            std::deque<MapTile>& queue = (priority >= 2 ? _prefetchQueueHigh : _prefetchQueue);
+            // The queues are drained newest first, so the lowest priority requests (diagonal
+            // neighbours) go to the far end instead of the near one.
+            if (priority <= 0) {
+                queue.push_front(tile);
+            } else {
+                queue.push_back(tile);
+            }
+            while (queue.size() > MAX_PREFETCH_QUEUE_SIZE) {
+                _prefetchTileIds.erase(queue.front().getTileId());
+                queue.pop_front();
+            }
+            while (static_cast<int>(_prefetchThreads.size()) < PREFETCH_THREADS) {
+                _prefetchThreads.emplace_back([this]() { runPrefetchWorker(); });
+            }
+        }
+        _prefetchCondition.notify_one();
+    }
+
+    void ElevationManager::runPrefetchWorker() const {
+        while (true) {
+            MapTile tile(0, 0, 0, 0);
+            {
+                std::unique_lock<std::mutex> lock(_prefetchMutex);
+                _prefetchCondition.wait(lock, [this]() { return _prefetchStopped || !_prefetchQueue.empty() || !_prefetchQueueHigh.empty(); });
+                if (_prefetchStopped) {
+                    return;
+                }
+                // High priority (a tile's own elevation level) before border neighbours, and
+                // newest request first: it belongs to the current viewport, while the oldest
+                // entries may already have scrolled out of view.
+                std::deque<MapTile>& queue = (_prefetchQueueHigh.empty() ? _prefetchQueue : _prefetchQueueHigh);
+                tile = queue.back();
+                queue.pop_back();
+                _prefetchTileIds.erase(tile.getTileId());
+            }
+            try {
+                getTileGrid(tile, LoadMode::LOAD_EXACT);
+            }
+            catch (const std::exception& ex) {
+                Log::Warnf("ElevationManager::runPrefetchWorker: Failed to prefetch elevation tile: %s", ex.what());
+            }
+        }
     }
 
     double ElevationManager::getDisplayScale(double internalY) const {
@@ -395,6 +532,14 @@ namespace carto {
 
     MapTile ElevationManager::clampTileZoom(const MapTile& mapTile) const {
         MapTile tile = mapTile;
+        // Cap by the resolution the terrain mesh can express: an elevation tile is 256-512 texels
+        // while the surface has _surfaceResolution cells, so taking the tile zoom literally would
+        // give every tile its own elevation tile - and its own decoded grid and GL texture - for
+        // detail that cannot be rendered. One texel per half surface cell is the useful limit.
+        int surfaceResolution = _surfaceResolution.load();
+        for (int size = _gridSizeHint.load(); size > 2 * surfaceResolution && tile.getZoom() > 0; size /= 2) {
+            tile = tile.getParent();
+        }
         int maxZoom = _dataSource->getMaxZoom();
         while (tile.getZoom() > maxZoom) {
             tile = tile.getParent();
@@ -434,6 +579,10 @@ namespace carto {
                                  MapPos(std::max(internalMin.getX(), internalMax.getX()), std::max(internalMin.getY(), internalMax.getY())));
 
         std::array<double, 4> coeffs = _elevationDecoder->getColorComponentCoefficients();
-        return ElevationTileGrid::DecodeBitmap(mapTile, internalBounds, tileBitmap, coeffs);
+        std::shared_ptr<ElevationTileGrid> grid = ElevationTileGrid::DecodeBitmap(mapTile, internalBounds, tileBitmap, coeffs);
+        if (grid && grid->getWidth() > 0) {
+            _gridSizeHint.store(grid->getWidth()); // drives the elevation level cap in clampTileZoom
+        }
+        return grid;
     }
 }

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -12,10 +12,14 @@
 #include "core/MapTile.h"
 
 #include <atomic>
+#include <condition_variable>
+#include <deque>
 #include <future>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
+#include <thread>
 #include <vector>
 
 #include <stdext/timed_lru_cache.h>
@@ -44,7 +48,13 @@ namespace carto {
             /**
              * The elevation tile may be synchronously loaded from the data source. May block on IO/network.
              */
-            ALLOW_LOAD
+            ALLOW_LOAD,
+            /**
+             * Like ALLOW_LOAD, but a cached ancestor is not accepted as a stand-in: the tile itself
+             * is loaded unless the data source has already answered that this level does not exist.
+             * May block on IO/network.
+             */
+            LOAD_EXACT
         };
 
         ElevationManager(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& elevationDecoder);
@@ -55,6 +65,22 @@ namespace carto {
 
         float getExaggeration() const;
         void setExaggeration(float exaggeration);
+
+        bool isSeamlessTileEdgesEnabled() const;
+        void setSeamlessTileEdgesEnabled(bool enabled);
+
+        bool isNeighbourPrefetchEnabled() const;
+        void setNeighbourPrefetchEnabled(bool enabled);
+
+        /**
+         * Sets the terrain surface resolution (mesh cells per tile edge). Elevation levels are
+         * capped so that one elevation texel covers at most half a surface cell: finer data cannot
+         * be expressed by the mesh, but every level costs four times the tiles, decoded grids and
+         * GL textures. The cap applies to EVERY elevation query, so the displaced surface, the
+         * elevation lookups, the ray intersection used for billboard occlusion and the CPU-side
+         * element placement all agree on one height field.
+         */
+        void setSurfaceResolution(int resolution);
 
         std::size_t getCacheCapacity() const;
         void setCacheCapacity(std::size_t capacityInBytes);
@@ -89,6 +115,22 @@ namespace carto {
          * The tile must be in XYZ convention (y=0 north, same as vt::TileId and TileDataSource::loadTile).
          */
         std::shared_ptr<ElevationTileGrid> getTileGrid(const MapTile& mapTile, LoadMode mode) const;
+
+        /**
+         * Returns the tile that actually carries the elevation data for the given tile: the same
+         * tile, or its ancestor at the data source maximum zoom level.
+         */
+        MapTile getDataTile(const MapTile& mapTile) const;
+
+        /**
+         * Requests an asynchronous load of the given elevation tile. Never blocks and never
+         * performs IO on the calling thread. A no-op if the grid is already cached, already
+         * queued or currently being loaded, or if neighbour prefetching is disabled.
+         * Priority 2 (the tile's own elevation level) is served before 1 (edge neighbours),
+         * which is served before 0 (diagonal neighbours, which only fill a corner texel).
+         * The tile must be in XYZ convention (y=0 north, same as getTileGrid).
+         */
+        void prefetchTileGrid(const MapTile& mapTile, int priority) const;
 
         /**
          * Returns the meters-to-internal-display-units scale at the given internal y coordinate
@@ -131,6 +173,7 @@ namespace carto {
         std::shared_ptr<ElevationTileGrid> getGridForInternalPos(double internalX, double internalY, LoadMode mode) const;
         std::shared_ptr<ElevationTileGrid> loadTileGrid(const MapTile& mapTile) const;
         void getMinMaxDisplayHeight(const MapTile& tile, double& minZ, double& maxZ, bool exact) const;
+        void runPrefetchWorker() const;
 
         const std::shared_ptr<TileDataSource> _dataSource;
         const std::shared_ptr<ElevationDecoder> _elevationDecoder;
@@ -138,12 +181,27 @@ namespace carto {
         std::shared_ptr<DataSourceListener> _dataSourceListener;
 
         std::atomic<float> _exaggeration;
+        std::atomic<bool> _seamlessTileEdges;
+        std::atomic<int> _surfaceResolution;      // terrain mesh cells per tile edge
+        mutable std::atomic<int> _gridSizeHint;   // texels per elevation tile edge, from the last decoded grid
+        std::atomic<bool> _neighbourPrefetch;
         mutable std::atomic<unsigned int> _version;
         mutable std::atomic<float> _maxSeenElevation;
 
         mutable cache::timed_lru_cache<long long, std::shared_ptr<ElevationTileGrid> > _gridCache;
         mutable std::map<long long, std::shared_future<std::shared_ptr<ElevationTileGrid> > > _pendingLoads; // single-flight de-duplication of concurrent loads
         mutable std::mutex _mutex;
+
+        // Background prefetch worker: loads elevation tiles requested by the render thread
+        // (visible tiles + their neighbours) without ever blocking it. The thread is started
+        // on the first request and joined in the destructor.
+        mutable std::deque<MapTile> _prefetchQueue;      // low priority (neighbour borders)
+        mutable std::deque<MapTile> _prefetchQueueHigh;  // high priority (the tile's own level)
+        mutable std::set<long long> _prefetchTileIds;
+        mutable std::vector<std::thread> _prefetchThreads;
+        mutable std::condition_variable _prefetchCondition;
+        mutable bool _prefetchStopped;
+        mutable std::mutex _prefetchMutex;
     };
 }
 

--- a/all/native/terrain/ElevationTileGrid.cpp
+++ b/all/native/terrain/ElevationTileGrid.cpp
@@ -105,6 +105,71 @@ namespace carto {
             double py = _internalBounds.getMin().getY() + (gy + 0.5) * texelY;
             return EncodeHeight(grid->sampleHeight(px, py));
         };
+        // EDGE BOX FILTER. A coarser neighbour's height field is the 2^k x 2^k average of this
+        // level's (mapterhorn and every other overview pyramid downsamples that way), so along a
+        // shared edge it only ever interpolates those averages while this tile interpolates its
+        // own full-detail texels. Border backfill alone does not close that: this side meets the
+        // border at (own texel + neighbour average) / 2 while the neighbour meets it at
+        // (neighbour average + own average) / 2, and the difference - half the local high-frequency
+        // detail - is the dotted speckle line along LOD-ring borders.
+        // Averaging THIS tile's outermost texel row/column over the neighbour's texel footprint
+        // removes that term: both sides then meet the border on the same average. What is left is
+        // an eighth of the difference between the neighbour's texel and this tile's average over
+        // it - the border texel is itself an interpolation of the coarse field, not one of its
+        // texels - so the seam is reduced rather than eliminated. Only the outermost row/column is
+        // touched, and only towards a coarser neighbour: everything else keeps full DEM detail.
+        // Groups are found geographically rather than assumed to be a power of two, so an unaligned
+        // or non-quadtree neighbour degrades to a no-op instead of a shift.
+        // In the steady state this rarely fires: the elevation level cap usually gives two render
+        // tiles of different zoom the SAME DEM level (see ElevationManager::clampTileZoom), and the
+        // lattice mismatch that remains at a LOD ring is what TileEdgeStitchingEnabled handles.
+        // It does fire while tiles stream in, when a tile is still standing on an ancestor grid.
+        // alongY: the edge runs north-south (west/east edge), so texel ROWS are grouped and
+        // fixedIndex is the column; otherwise columns are grouped and fixedIndex is the row.
+        auto edgeFilter = [&, this](const std::shared_ptr<ElevationTileGrid>& neighbour, bool alongY, int fixedIndex) -> std::vector<std::uint16_t> {
+            std::vector<std::uint16_t> result;
+            if (!neighbour || sameLevel(neighbour) || neighbour->_width < 1 || neighbour->_height < 1) {
+                return result;
+            }
+            double ourTexel = alongY ? texelY : texelX;
+            double neighbourTexel = alongY
+                ? (neighbour->_internalBounds.getMax().getY() - neighbour->_internalBounds.getMin().getY()) / neighbour->_height
+                : (neighbour->_internalBounds.getMax().getX() - neighbour->_internalBounds.getMin().getX()) / neighbour->_width;
+            if (!(neighbourTexel > ourTexel * 1.5)) {
+                return result; // same resolution or finer: this tile is already the smooth side
+            }
+            double neighbourOrigin = alongY ? neighbour->_internalBounds.getMin().getY() : neighbour->_internalBounds.getMin().getX();
+            double ourOrigin = alongY ? _internalBounds.getMin().getY() : _internalBounds.getMin().getX();
+            auto groupOf = [&](int i) {
+                return static_cast<long long>(std::floor((ourOrigin + (i + 0.5) * ourTexel - neighbourOrigin) / neighbourTexel));
+            };
+            int count = alongY ? _height : _width;
+            result.resize(count);
+            for (int i = 0; i < count; ) {
+                long long group = groupOf(i);
+                int last = i;
+                double sum = 0;
+                while (last < count && groupOf(last) == group) {
+                    // The stored value is a linear encoding of the height, so averaging encoded
+                    // values is averaging heights (up to half a quantum).
+                    sum += alongY
+                        ? _heights[static_cast<std::size_t>(last) * _width + fixedIndex]
+                        : _heights[static_cast<std::size_t>(fixedIndex) * _width + last];
+                    last++;
+                }
+                std::uint16_t average = static_cast<std::uint16_t>(sum / (last - i) + 0.5);
+                for (int j = i; j < last; j++) {
+                    result[j] = average;
+                }
+                i = last;
+            }
+            return result;
+        };
+        std::vector<std::uint16_t> westEdge = edgeFilter(neighbours[0], true, 0);
+        std::vector<std::uint16_t> eastEdge = edgeFilter(neighbours[1], true, _width - 1);
+        std::vector<std::uint16_t> southEdge = edgeFilter(neighbours[2], false, 0);
+        std::vector<std::uint16_t> northEdge = edgeFilter(neighbours[3], false, _height - 1);
+
         // texel value at padded coordinates (gx, gy in [-1, width/height]); border texels
         // come from the neighbour that actually covers them, falling back to edge clamping
         auto rawValue = [&, this](int gx, int gy) -> std::uint16_t {
@@ -133,6 +198,30 @@ namespace carto {
             // no neighbour data: duplicate our own edge texel
             int cx = std::min(std::max(gx, 0), _width - 1);
             int cy = std::min(std::max(gy, 0), _height - 1);
+            // Own texel, but on an edge shared with a coarser neighbour: the box-filtered value.
+            // A corner texel lies on two such edges and takes the mean of both, which is what the
+            // two neighbours (and the diagonal one between them) average to as well.
+            double filtered = 0;
+            int filterCount = 0;
+            if (!westEdge.empty() && cx == 0) {
+                filtered += westEdge[cy];
+                filterCount++;
+            }
+            if (!eastEdge.empty() && cx == _width - 1) {
+                filtered += eastEdge[cy];
+                filterCount++;
+            }
+            if (!southEdge.empty() && cy == 0) {
+                filtered += southEdge[cx];
+                filterCount++;
+            }
+            if (!northEdge.empty() && cy == _height - 1) {
+                filtered += northEdge[cx];
+                filterCount++;
+            }
+            if (filterCount > 0) {
+                return static_cast<std::uint16_t>(filtered / filterCount + 0.5);
+            }
             return _heights[static_cast<std::size_t>(cy) * _width + cx];
         };
 

--- a/all/native/terrain/ElevationTileGrid.cpp
+++ b/all/native/terrain/ElevationTileGrid.cpp
@@ -87,33 +87,53 @@ namespace carto {
         int paddedHeight = _height + 2;
         rgbaData.resize(static_cast<std::size_t>(paddedWidth) * paddedHeight * 4);
 
-        auto compatible = [this](const std::shared_ptr<ElevationTileGrid>& grid) {
-            return grid && grid->_width == _width && grid->_height == _height;
+        // Same DEM level and grid size: the border texel is one of the neighbour's own
+        // texels, so it can be copied bit-exactly by index.
+        auto sameLevel = [this](const std::shared_ptr<ElevationTileGrid>& grid) {
+            // The same grid standing in for a neighbour (both tiles resolved to one ancestor)
+            // must NOT be index-copied - that would wrap around to its opposite edge.
+            return grid && grid->_width == _width && grid->_height == _height && grid->_tile.getZoom() == _tile.getZoom() && !(grid->_tile == _tile);
+        };
+        // Different level (a coarser ancestor grid stands in for the neighbour): sample the
+        // neighbour's height field at the geographic position of the border texel center.
+        // Real DEM data at the tile edge beats duplicating our own edge texel, which leaves
+        // a full-texel height step (tens of meters on a slope) at the tile border.
+        double texelX = (_internalBounds.getMax().getX() - _internalBounds.getMin().getX()) / _width;
+        double texelY = (_internalBounds.getMax().getY() - _internalBounds.getMin().getY()) / _height;
+        auto sampleValue = [&, this](const ElevationTileGrid* grid, int gx, int gy) -> std::uint16_t {
+            double px = _internalBounds.getMin().getX() + (gx + 0.5) * texelX;
+            double py = _internalBounds.getMin().getY() + (gy + 0.5) * texelY;
+            return EncodeHeight(grid->sampleHeight(px, py));
         };
         // texel value at padded coordinates (gx, gy in [-1, width/height]); border texels
         // come from the neighbour that actually covers them, falling back to edge clamping
         auto rawValue = [&, this](int gx, int gy) -> std::uint16_t {
-            const ElevationTileGrid* grid = this;
-            if (gx < 0 && gy >= 0 && gy < _height && compatible(neighbours[0])) {
-                grid = neighbours[0].get(); gx += _width;
-            } else if (gx >= _width && gy >= 0 && gy < _height && compatible(neighbours[1])) {
-                grid = neighbours[1].get(); gx -= _width;
-            } else if (gy < 0 && gx >= 0 && gx < _width && compatible(neighbours[2])) {
-                grid = neighbours[2].get(); gy += _height;
-            } else if (gy >= _height && gx >= 0 && gx < _width && compatible(neighbours[3])) {
-                grid = neighbours[3].get(); gy -= _height;
-            } else if (gx < 0 && gy < 0 && compatible(neighbours[4])) {
-                grid = neighbours[4].get(); gx += _width; gy += _height;
-            } else if (gx >= _width && gy < 0 && compatible(neighbours[5])) {
-                grid = neighbours[5].get(); gx -= _width; gy += _height;
-            } else if (gx < 0 && gy >= _height && compatible(neighbours[6])) {
-                grid = neighbours[6].get(); gx += _width; gy -= _height;
-            } else if (gx >= _width && gy >= _height && compatible(neighbours[7])) {
-                grid = neighbours[7].get(); gx -= _width; gy -= _height;
+            static const std::array<std::pair<int, int>, 8> DIRS = { {
+                { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 }, { -1, -1 }, { 1, -1 }, { -1, 1 }, { 1, 1 }
+            } };
+            int dx = (gx < 0 ? -1 : (gx >= _width ? 1 : 0));
+            int dy = (gy < 0 ? -1 : (gy >= _height ? 1 : 0));
+            if (dx != 0 || dy != 0) {
+                for (std::size_t i = 0; i < DIRS.size(); i++) {
+                    if (DIRS[i].first != dx || DIRS[i].second != dy) {
+                        continue;
+                    }
+                    const std::shared_ptr<ElevationTileGrid>& neighbour = neighbours[i];
+                    if (sameLevel(neighbour)) {
+                        int nx = gx - dx * _width;
+                        int ny = gy - dy * _height;
+                        return neighbour->_heights[static_cast<std::size_t>(ny) * neighbour->_width + nx];
+                    }
+                    if (neighbour) {
+                        return sampleValue(neighbour.get(), gx, gy);
+                    }
+                    break;
+                }
             }
-            gx = std::min(std::max(gx, 0), grid->_width - 1);
-            gy = std::min(std::max(gy, 0), grid->_height - 1);
-            return grid->_heights[static_cast<std::size_t>(gy) * grid->_width + gx];
+            // no neighbour data: duplicate our own edge texel
+            int cx = std::min(std::max(gx, 0), _width - 1);
+            int cy = std::min(std::max(gy, 0), _height - 1);
+            return _heights[static_cast<std::size_t>(cy) * _width + cx];
         };
 
         std::size_t i = 0;

--- a/all/native/terrain/ElevationTileGrid.h
+++ b/all/native/terrain/ElevationTileGrid.h
@@ -59,8 +59,10 @@ namespace carto {
 
         /**
          * Like encodeTexture, but pads the texture with a 1-texel border taken from the
-         * neighbouring grids (same DEM level, order: W, E, S, N, SW, SE, NW, NE; null or
-         * differently-sized neighbours fall back to duplicating this grid's edge texels).
+         * neighbouring grids (order: W, E, S, N, SW, SE, NW, NE). Same-level neighbours are
+         * copied texel-exactly; coarser (ancestor) neighbour grids are sampled at the border
+         * texel centers, which still gives real DEM data across the tile border. Only missing
+         * neighbours fall back to duplicating this grid's edge texels.
          * Adjacent tiles then interpolate across the border from IDENTICAL texel pairs,
          * making same-level tile borders seam-free. The padded texture covers the grid
          * bounds extended by one texel on each side.


### PR DESCRIPTION
Hillshade in this fork renders visibly worse than MapLibre + Mapterhorn DEM at z16: relief detail collapses on one mountain face, and which face collapses flips with `illumination-direction`. The `STANDARD` method is a port of MapLibre's `hillshade.fragment.glsl` that had drifted; this brings it back to parity against the current MapLibre sources, and adds the missing `zoomLevelBias` control on `CompositeVectorTileLayer` so a high-resolution DEM child can actually be fetched at more detail than the base map.

## Hillshade parity

- **Aspect was mirrored north-south.** `Bitmap::loadPNG` stores rows bottom-up, so `NormalMapBuilder`'s `y` increases northward and the shader's `deriv` came out as `(dh/dEast, +dh/dNorth)` where MapLibre - whose DEM texture has north at `v = 0` - uses `(dh/dEast, -dh/dNorth)`. On top of that the azimuth was read as `atan(y, x)` although the illumination `MapVec` is `(sin(compass), cos(compass))`, a further 90 degree error. Combined, a light configured as 335 degrees arrived from roughly ENE and rotating it turned the shading the wrong way.
- **`applyLighting` divided the result by the slope-derived `intensity`**, cancelling a multiplication the vt library has not done for a long time. On the lit side that reduces to a constant for every slope from flat to vertical, so the sunlit face lost its gradient and washed out while the shaded face kept its own - the reported "less detail on one face, and it flips with the illumination direction".
- **Premultiplication order.** Colors were mixed straight and premultiplied afterwards, which is not the composite MapLibre performs on premultiplied inputs. They are premultiplied up front now and the result returned as-is.
- **`contrast` and `exaggeration` were collapsed into one uniform** used both as MapLibre's slope response curve and as a slope multiplier. `contrast` is now MapLibre's `hillshade-exaggeration` (`u_intensity`, and the deriv multiplier the GDAL-derived methods apply), `exaggeration` is a plain vertical relief multiplier. The defaults 0.5 / 1.0 land exactly on MapLibre's defaults.
- **The height scale damped relief by the ABSOLUTE zoom**, so it washed out as the camera zoomed in - the opposite of what a z15+ DEM needs. It now follows `hillshade_prepare.fragment.glsl`: true slope from zoom 15 up, boosted below it with MapLibre's 0.4/0.35/0.3 ladder.
- `BASIC` and `COMBINED` were dead - `altitude = asin(lightDir.z)` is negative for the documented downward-pointing direction, pinning the result to a flat shadow wash. They now take the altitude from `-lightDir.z`. `MULTIDIRECTIONAL` was an alias for `BASIC` and is now GDAL's four-light version.
- The map-rotation branch rebuilt the light's horizontal part from `acos(y)` and so silently renormalised any direction whose xy was not unit length. Now `atan2(x, y)` with the horizontal length preserved.

Submodule (farfromrefug/mobile-carto-libs, branch `feat/hillshade-maplibre-parity`): the Mercator correction baked into the normal used `tanh(y1)` where Web Mercator needs `tanh(2 * y1)` (0.910 instead of 0.707 at 45 degrees, ~4.6x off at extreme latitudes), and normal components were truncated rather than rounded when packed to 8 bits.

## Composite zoom level bias

`CompositeVectorTileLayer` owns its children (external raster/hillshade/vector sources plus the internal style-group layers) but forwarded no `TileLayer` property to them. `setZoomLevelBias` and `setPreloading` are now `virtual` on `TileLayer` and overridden to apply to every child, and each external source can override the bias (and the max overzoom level) on its own:

```java
composite.setExternalDataSourceZoomLevelBias("hillshade", 1.0f);
composite.setExternalDataSourceMaxOverzoomLevel("hillshade", 2);
```

Per-source values survive a source being replaced under the same name, and `zoom-level-bias` / `max-overzoom-level` can also come from the style config for any source type, with the same style-wins precedence the other per-source config values already have.

## Breaking changes for reviewers

- **Hillshade appearance changes at every zoom.** That is the point of the PR, but styles tuned against the old curve will need re-tuning. `setLegacyHeightScaleEnabled(true)` plus `setHeightScale(0.09f)` restores the previous formula and default per layer.
- The `HeightScale` default of the two-argument (elevation decoder) constructor changes from `0.09f` to `1.0f`, matching the one-argument constructor and the header documentation.
- `HillshadeMethod.MULTIDIRECTIONAL` now renders differently (it used to be `BASIC`). Note MapLibre's own multidirectional averages `basic_hillshade` over its illumination-source arrays, which degenerates to plain `BASIC` for the single light source this layer exposes; GDAL's version is used here so the mode is actually multidirectional.

## Verification

- `clang++ -fsyntax-only` on every touched translation unit; `glslangValidator` on the extracted fragment shader.
- SWIG proxies regenerated with `swigpp-java.py`; `./gradlew :app:assembleDebug` green, native `.so` relinked for all four ABIs.
- Installed and run on the emulator against the demo's Mapterhorn DEM source: no shader errors in logcat, and the ridge lighting reads NW-bright / SE-dark, i.e. the 335 degree light now lands where it should.
- Not yet compared side by side against MapLibre at matching centre/zoom/illumination - that is the remaining check before merge.

Note this PR depends on the submodule branch above being merged (or the pointer retargeted) first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
