### PR TITLE
3D terrain: matching DEM heights across tile edges

### DIFF
--- a/all/modules/components/TerrainOptions.i
+++ b/all/modules/components/TerrainOptions.i
@@ -28,6 +28,7 @@
 %attribute(carto::TerrainOptions, bool, ElevationPrefetchEnabled, isElevationPrefetchEnabled, setElevationPrefetchEnabled)
 %attribute(carto::TerrainOptions, int, MeshResolution, getMeshResolution, setMeshResolution)
 %attribute(carto::TerrainOptions, bool, RegularGridEnabled, isRegularGridEnabled, setRegularGridEnabled)
+%attribute(carto::TerrainOptions, bool, TileEdgeStitchingEnabled, isTileEdgeStitchingEnabled, setTileEdgeStitchingEnabled)
 %attribute(carto::TerrainOptions, bool, PainterOrderDepthEnabled, isPainterOrderDepthEnabled, setPainterOrderDepthEnabled)
 %attribute(carto::TerrainOptions, bool, DrapeFillsEnabled, isDrapeFillsEnabled, setDrapeFillsEnabled)
 %attribute(carto::TerrainOptions, bool, DrapeLinesEnabled, isDrapeLinesEnabled, setDrapeLinesEnabled)

--- a/all/modules/components/TerrainOptions.i
+++ b/all/modules/components/TerrainOptions.i
@@ -24,6 +24,8 @@
 
 %attribute(carto::TerrainOptions, bool, Enabled, isEnabled, setEnabled)
 %attribute(carto::TerrainOptions, float, Exaggeration, getExaggeration, setExaggeration)
+%attribute(carto::TerrainOptions, bool, SeamlessTileEdgesEnabled, isSeamlessTileEdgesEnabled, setSeamlessTileEdgesEnabled)
+%attribute(carto::TerrainOptions, bool, ElevationPrefetchEnabled, isElevationPrefetchEnabled, setElevationPrefetchEnabled)
 %attribute(carto::TerrainOptions, int, MeshResolution, getMeshResolution, setMeshResolution)
 %attribute(carto::TerrainOptions, bool, RegularGridEnabled, isRegularGridEnabled, setRegularGridEnabled)
 %attribute(carto::TerrainOptions, bool, PainterOrderDepthEnabled, isPainterOrderDepthEnabled, setPainterOrderDepthEnabled)

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -19,7 +19,7 @@ namespace carto {
         _meshResolution(32),
         _regularGridEnabled(false),
         _tileEdgeStitchingEnabled(false),
-        _painterOrderDepthEnabled(false),
+        _painterOrderDepthEnabled(true),
         _drapeFillsEnabled(true),
         _drapeLinesEnabled(true),
         _drapeResolution(512),

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -18,7 +18,7 @@ namespace carto {
         _enabled(true),
         _meshResolution(32),
         _regularGridEnabled(false),
-        _tileEdgeStitchingEnabled(false),
+        _tileEdgeStitchingEnabled(true),
         _painterOrderDepthEnabled(true),
         _drapeFillsEnabled(true),
         _drapeLinesEnabled(true),

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -76,6 +76,28 @@ namespace carto {
         }
     }
 
+    bool TerrainOptions::isSeamlessTileEdgesEnabled() const {
+        return _elevationManager->isSeamlessTileEdgesEnabled();
+    }
+
+    void TerrainOptions::setSeamlessTileEdgesEnabled(bool enabled) {
+        if (_elevationManager->isSeamlessTileEdgesEnabled() != enabled) {
+            _elevationManager->setSeamlessTileEdgesEnabled(enabled);
+            notifyOptionChanged("SeamlessTileEdgesEnabled");
+        }
+    }
+
+    bool TerrainOptions::isElevationPrefetchEnabled() const {
+        return _elevationManager->isNeighbourPrefetchEnabled();
+    }
+
+    void TerrainOptions::setElevationPrefetchEnabled(bool enabled) {
+        if (_elevationManager->isNeighbourPrefetchEnabled() != enabled) {
+            _elevationManager->setNeighbourPrefetchEnabled(enabled);
+            notifyOptionChanged("ElevationPrefetchEnabled");
+        }
+    }
+
     int TerrainOptions::getMeshResolution() const {
         return _meshResolution.load();
     }

--- a/all/native/components/TerrainOptions.cpp
+++ b/all/native/components/TerrainOptions.cpp
@@ -18,6 +18,7 @@ namespace carto {
         _enabled(true),
         _meshResolution(32),
         _regularGridEnabled(false),
+        _tileEdgeStitchingEnabled(false),
         _painterOrderDepthEnabled(false),
         _drapeFillsEnabled(true),
         _drapeLinesEnabled(true),
@@ -116,6 +117,16 @@ namespace carto {
     void TerrainOptions::setRegularGridEnabled(bool regularGridEnabled) {
         if (_regularGridEnabled.exchange(regularGridEnabled) != regularGridEnabled) {
             notifyOptionChanged("RegularGridEnabled");
+        }
+    }
+
+    bool TerrainOptions::isTileEdgeStitchingEnabled() const {
+        return _tileEdgeStitchingEnabled.load();
+    }
+
+    void TerrainOptions::setTileEdgeStitchingEnabled(bool enabled) {
+        if (_tileEdgeStitchingEnabled.exchange(enabled) != enabled) {
+            notifyOptionChanged("TileEdgeStitchingEnabled");
         }
     }
 

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -94,6 +94,41 @@ namespace carto {
         void setExaggeration(float exaggeration);
 
         /**
+         * Returns whether seamless tile edge handling is enabled.
+         * @return True if elevation textures take their border texels from neighbouring DEM tiles at any level. The default is true.
+         */
+        bool isSeamlessTileEdgesEnabled() const;
+        /**
+         * Enables or disables seamless tile edge handling. When enabled, the 1-texel border of
+         * every elevation texture is taken from the neighbouring elevation tiles - same-level
+         * neighbours texel-exactly, coarser (ancestor) neighbours by sampling their height field.
+         * Adjacent terrain tiles then agree on the height along their shared edge instead of
+         * showing a ridge of up to one DEM texel of relief. Costs no IO, only a small amount of
+         * CPU when an elevation texture is built. Disable if the elevation tiles already match
+         * exactly across tile borders.
+         * @param enabled True to fill elevation texture borders from neighbouring tiles.
+         */
+        void setSeamlessTileEdgesEnabled(bool enabled);
+
+        /**
+         * Returns whether elevation tile prefetching is enabled.
+         * @return True if visible tiles and their neighbours are requested from the elevation data source. The default is true.
+         */
+        bool isElevationPrefetchEnabled() const;
+        /**
+         * Enables or disables elevation tile prefetching. When enabled, every visible terrain tile
+         * asynchronously requests its own elevation tile and the 8 surrounding ones, so neighbouring
+         * terrain tiles are displaced by the same DEM level and border texels have real neighbour
+         * data. When disabled, elevation tiles are only loaded as a side effect of map tile fetches,
+         * which leaves cached map tiles (and the tiles around the viewport) on coarser ancestor
+         * elevation data. This is the costly option: it adds elevation tile requests, decoding and
+         * cache pressure. Disable to keep elevation traffic at a minimum, or if the elevation
+         * tileset is fully local.
+         * @param enabled True to prefetch elevation tiles for visible tiles and their neighbours.
+         */
+        void setElevationPrefetchEnabled(bool enabled);
+
+        /**
          * Returns the terrain mesh resolution.
          * @return The maximum number of grid cells per tile edge used for terrain geometry. The default is 32.
          */

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -160,7 +160,7 @@ namespace carto {
 
         /**
          * Returns whether cross-LOD tile edge stitching is enabled.
-         * @return True if grid surface edges follow a coarser neighbour's lattice. The default is false.
+         * @return True if grid surface edges follow a coarser neighbour's lattice. The default is true.
          */
         bool isTileEdgeStitchingEnabled() const;
         /**

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -159,6 +159,23 @@ namespace carto {
         void setRegularGridEnabled(bool regularGridEnabled);
 
         /**
+         * Returns whether cross-LOD tile edge stitching is enabled.
+         * @return True if grid surface edges follow a coarser neighbour's lattice. The default is false.
+         */
+        bool isTileEdgeStitchingEnabled() const;
+        /**
+         * Enables or disables cross-LOD tile edge stitching. Neighbouring terrain tiles at
+         * different zoom levels interpolate the elevation between differently spaced grid
+         * vertices along their shared edge, which opens a thin crack. When enabled, the finer
+         * tile chords across the coarser neighbour's grid nodes on that edge, so both tiles
+         * describe the same edge. Only takes effect together with the regular grid surface mode
+         * (adaptive tesselation matches its borders to the neighbours already) and needs an even
+         * MeshResolution. Costs one uniform per tile - no extra geometry.
+         * @param enabled True to snap grid surface edges to a coarser neighbour's grid.
+         */
+        void setTileEdgeStitchingEnabled(bool enabled);
+
+        /**
          * Returns whether the painter-order terrain depth model is used.
          * @return True if painter-order depth is used, false for the surface-occluder model. The default is false.
          */
@@ -472,6 +489,7 @@ namespace carto {
         std::atomic<bool> _enabled;
         std::atomic<int> _meshResolution;
         std::atomic<bool> _regularGridEnabled;
+        std::atomic<bool> _tileEdgeStitchingEnabled;
         std::atomic<bool> _painterOrderDepthEnabled;
         std::atomic<bool> _drapeFillsEnabled;
         std::atomic<bool> _drapeLinesEnabled;

--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -177,7 +177,7 @@ namespace carto {
 
         /**
          * Returns whether the painter-order terrain depth model is used.
-         * @return True if painter-order depth is used, false for the surface-occluder model. The default is false.
+         * @return True if painter-order depth is used, false for the surface-occluder model. The default is true.
          */
         bool isPainterOrderDepthEnabled() const;
         /**
@@ -186,7 +186,6 @@ namespace carto {
          * per-layer clip-space delta instead of being depth-tested against a surface pre-pass occluder,
          * which removes the distance-growing depth slack (no see-through band). Implies (and forces)
          * RegularGridEnabled. Only takes effect in GPU draping mode (vertex texture fetch, planar).
-         * Experimental.
          * @param painterOrderDepthEnabled True to use painter-order depth, false for the occluder model.
          */
         void setPainterOrderDepthEnabled(bool painterOrderDepthEnabled);

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -454,6 +454,7 @@ namespace carto {
                     }
                 }
                 if (_elevationTextureCache) {
+                    _elevationTextureCache->beginFrame();
                     std::shared_ptr<ElevationTextureCache> elevationTextureCache = _elevationTextureCache;
                     terrainTextureProvider = [elevationTextureCache](const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture) {
                         return elevationTextureCache->getTexture(tileId, terrainTexture);

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -445,6 +445,12 @@ namespace carto {
             }
             if (_maxVertexTextureUnits > 0) {
                 std::shared_ptr<ElevationManager> elevationManager = activeTerrainOptions->getElevationManager();
+                if (elevationManager) {
+                    // Cap elevation levels at what the mesh can express - for every elevation
+                    // consumer, not just the drawn surface (billboard occlusion ray marching and
+                    // element placement query the same manager and must see the same heights).
+                    elevationManager->setSurfaceResolution(activeTerrainOptions->getMeshResolution());
+                }
                 if (_elevationTextureCache && _elevationTextureCache->getElevationManager() != elevationManager) {
                     _elevationTextureCache.reset();
                 }
@@ -454,7 +460,6 @@ namespace carto {
                     }
                 }
                 if (_elevationTextureCache) {
-                    _elevationTextureCache->setSurfaceResolution(activeTerrainOptions->getMeshResolution());
                     _elevationTextureCache->beginFrame();
                     std::shared_ptr<ElevationTextureCache> elevationTextureCache = _elevationTextureCache;
                     terrainTextureProvider = [elevationTextureCache](const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture) {

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -454,6 +454,7 @@ namespace carto {
                     }
                 }
                 if (_elevationTextureCache) {
+                    _elevationTextureCache->setSurfaceResolution(activeTerrainOptions->getMeshResolution());
                     _elevationTextureCache->beginFrame();
                     std::shared_ptr<ElevationTextureCache> elevationTextureCache = _elevationTextureCache;
                     terrainTextureProvider = [elevationTextureCache](const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture) {

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -504,6 +504,7 @@ namespace carto {
         bool regularGrid = painterOrder || drapeFills || (terrainMode && activeTerrainOptions && activeTerrainOptions->isRegularGridEnabled() && (bool) terrainTextureProvider);
         tileRenderer->setTerrainRegularGrid(regularGrid, activeTerrainOptions ? activeTerrainOptions->getMeshResolution() : 0);
         tileRenderer->setTerrainPainterOrder(painterOrder);
+        tileRenderer->setTerrainEdgeStitching(regularGrid && activeTerrainOptions && activeTerrainOptions->isTileEdgeStitchingEnabled());
         // Draped content is baked FLAT (orthographic, no displacement), so lines need no terrain
         // subdivision either - draping them is strictly cheaper as well as artifact-free.
         tileRenderer->setTerrainDrapeFills(drapeFills, drapeFills);

--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -57,23 +57,13 @@ namespace carto {
         int tileMask = (1 << tileId.zoom) - 1;
         MapTile mapTile(tileId.x & tileMask, std::min(std::max(tileId.y, 0), tileMask), tileId.zoom, 0);
 
-        // The tile that should carry this tile's elevation data: the tile's own level, capped by
-        // the data source maximum zoom AND by the resolution the surface mesh can express. An
-        // elevation tile is typically 256-512 texels while the mesh has MeshResolution cells, so
-        // taking the level literally would give every render tile its own elevation texture for
-        // detail that cannot be rendered - four times the decoded grids, texture uploads and tile
-        // requests per level. One texel per half surface cell is the useful limit; the coarser
-        // level also means neighbouring tiles share one texture, which is seamless by construction.
-        MapTile levelTile = mapTile;
-        for (int size = _gridSizeHint; size > 2 * _surfaceResolution && levelTile.getZoom() > 0; size /= 2) {
-            levelTile = levelTile.getParent();
-        }
-        MapTile dataTile = _elevationManager->getDataTile(levelTile);
+        // The tile that carries this tile's elevation data: its own level, capped by the data
+        // source maximum zoom and by the resolution the surface mesh can express (see
+        // ElevationManager::setSurfaceResolution). The cap lives in the manager so that the
+        // displaced surface and every CPU-side elevation query use the same height field.
+        MapTile dataTile = _elevationManager->getDataTile(mapTile);
 
         std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getTileGrid(dataTile, ElevationManager::LoadMode::CACHED_ONLY);
-        if (grid && grid->getWidth() > 0) {
-            _gridSizeHint = grid->getWidth();
-        }
         if (!grid || !(grid->getTile() == dataTile)) {
             // Missing or resolved through a coarser ancestor: request the real thing, ahead of
             // any neighbour request. Until it arrives this tile is displaced by an ancestor grid
@@ -186,14 +176,6 @@ namespace carto {
     void ElevationTextureCache::beginFrame() {
         _frameResolved.clear();
         _frameStartCounter = _accessCounter;
-    }
-
-    void ElevationTextureCache::setSurfaceResolution(int resolution) {
-        int value = std::max(1, resolution);
-        if (_surfaceResolution != value) {
-            _surfaceResolution = value;
-            clear(); // the elevation level cap changes with it
-        }
     }
 
     void ElevationTextureCache::clear() {

--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -62,40 +62,14 @@ namespace carto {
         MapTile dataTile = _elevationManager->getDataTile(mapTile);
 
         std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getTileGrid(mapTile, ElevationManager::LoadMode::CACHED_ONLY);
-
-        // Level consistency: report what this tile could resolve on its own, then fall back to
-        // the coarsest level its render-zoom siblings could resolve. Without this, one tile
-        // displaced by a z14 grid next to a tile displaced by its z12 ancestor tears the surface
-        // open along the shared edge - the ancestor is an average of its children, so the two
-        // height fields simply differ. The reported level stays uncapped, so the cap lifts by
-        // itself once the missing elevation tiles arrive.
-        if (grid && _elevationManager->isSeamlessTileEdgesEnabled()) {
-            int ownLevel = grid->getTile().getZoom();
-            auto capIt = _levelCapNext.find(tileId.zoom);
-            if (capIt == _levelCapNext.end()) {
-                _levelCapNext[tileId.zoom] = ownLevel;
-            } else if (ownLevel < capIt->second) {
-                capIt->second = ownLevel;
-            }
-            auto levelIt = _levelCap.find(tileId.zoom);
-            if (levelIt != _levelCap.end() && levelIt->second < ownLevel) {
-                MapTile cappedTile = mapTile;
-                while (cappedTile.getZoom() > levelIt->second) {
-                    cappedTile = cappedTile.getParent();
-                }
-                if (std::shared_ptr<ElevationTileGrid> cappedGrid = _elevationManager->getTileGrid(cappedTile, ElevationManager::LoadMode::CACHED_ONLY)) {
-                    grid = cappedGrid;
-                }
-            }
-        }
-
         if (!grid || !(grid->getTile() == dataTile)) {
-            // Missing or resolved through a coarser ancestor: request the real thing. Without
-            // this, elevation tiles are only loaded as a side effect of map tile fetches - map
-            // tiles served from the cache never trigger one, so neighbouring surface tiles can
-            // stay displaced by different DEM levels, which is a hard step at the tile border.
+            // Missing or resolved through a coarser ancestor: request the real thing, ahead of
+            // any neighbour request. Until it arrives this tile is displaced by an ancestor grid
+            // - which is a 2x2 average of its children, i.e. a different height field than the
+            // neighbouring tiles that already have their own level - and the surface tears along
+            // the shared edge. Loading the right level fast is what closes it.
             // No-op when elevation prefetching is disabled or the tile is already queued.
-            _elevationManager->prefetchTileGrid(dataTile);
+            _elevationManager->prefetchTileGrid(dataTile, 2);
         }
         if (!grid || grid->getWidth() < 1 || grid->getHeight() < 1) {
             return false;
@@ -118,7 +92,11 @@ namespace carto {
             MapTile neighbourTile((gridTile.getX() + dx) & gridMask, ny, gridTile.getZoom(), 0);
             std::shared_ptr<ElevationTileGrid> neighbour = _elevationManager->getTileGrid(neighbourTile, ElevationManager::LoadMode::CACHED_ONLY);
             if (!neighbour || !(neighbour->getTile() == neighbourTile)) {
-                _elevationManager->prefetchTileGrid(neighbourTile); // border texels want the real neighbour tile
+                // Border texels want the real neighbour tile, but after every tile's own level:
+                // a missing neighbour costs one texel of border accuracy, a missing own level
+                // displaces the whole tile. Diagonal neighbours only fill the corner texel where
+                // four tiles meet, so they come last.
+                _elevationManager->prefetchTileGrid(neighbourTile, dx == 0 || dy == 0 ? 1 : 0);
             }
             if (neighbour && !(neighbour->getTile() == neighbourTile) && !seamless) {
                 neighbour.reset(); // strict mode: only exact same-level neighbours
@@ -195,15 +173,11 @@ namespace carto {
 
     void ElevationTextureCache::beginFrame() {
         _frameResolved.clear();
-        _levelCap = _levelCapNext;
-        _levelCapNext.clear();
         _frameStartCounter = _accessCounter;
     }
 
     void ElevationTextureCache::clear() {
         _cache.clear();
         _frameResolved.clear();
-        _levelCap.clear();
-        _levelCapNext.clear();
     }
 }

--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -57,11 +57,23 @@ namespace carto {
         int tileMask = (1 << tileId.zoom) - 1;
         MapTile mapTile(tileId.x & tileMask, std::min(std::max(tileId.y, 0), tileMask), tileId.zoom, 0);
 
-        // The tile that should carry this tile's elevation data (own level, or the data source
-        // maximum zoom level for overzoomed tiles).
-        MapTile dataTile = _elevationManager->getDataTile(mapTile);
+        // The tile that should carry this tile's elevation data: the tile's own level, capped by
+        // the data source maximum zoom AND by the resolution the surface mesh can express. An
+        // elevation tile is typically 256-512 texels while the mesh has MeshResolution cells, so
+        // taking the level literally would give every render tile its own elevation texture for
+        // detail that cannot be rendered - four times the decoded grids, texture uploads and tile
+        // requests per level. One texel per half surface cell is the useful limit; the coarser
+        // level also means neighbouring tiles share one texture, which is seamless by construction.
+        MapTile levelTile = mapTile;
+        for (int size = _gridSizeHint; size > 2 * _surfaceResolution && levelTile.getZoom() > 0; size /= 2) {
+            levelTile = levelTile.getParent();
+        }
+        MapTile dataTile = _elevationManager->getDataTile(levelTile);
 
-        std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getTileGrid(mapTile, ElevationManager::LoadMode::CACHED_ONLY);
+        std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getTileGrid(dataTile, ElevationManager::LoadMode::CACHED_ONLY);
+        if (grid && grid->getWidth() > 0) {
+            _gridSizeHint = grid->getWidth();
+        }
         if (!grid || !(grid->getTile() == dataTile)) {
             // Missing or resolved through a coarser ancestor: request the real thing, ahead of
             // any neighbour request. Until it arrives this tile is displaced by an ancestor grid
@@ -174,6 +186,14 @@ namespace carto {
     void ElevationTextureCache::beginFrame() {
         _frameResolved.clear();
         _frameStartCounter = _accessCounter;
+    }
+
+    void ElevationTextureCache::setSurfaceResolution(int resolution) {
+        int value = std::max(1, resolution);
+        if (_surfaceResolution != value) {
+            _surfaceResolution = value;
+            clear(); // the elevation level cap changes with it
+        }
     }
 
     void ElevationTextureCache::clear() {

--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -62,6 +62,33 @@ namespace carto {
         MapTile dataTile = _elevationManager->getDataTile(mapTile);
 
         std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getTileGrid(mapTile, ElevationManager::LoadMode::CACHED_ONLY);
+
+        // Level consistency: report what this tile could resolve on its own, then fall back to
+        // the coarsest level its render-zoom siblings could resolve. Without this, one tile
+        // displaced by a z14 grid next to a tile displaced by its z12 ancestor tears the surface
+        // open along the shared edge - the ancestor is an average of its children, so the two
+        // height fields simply differ. The reported level stays uncapped, so the cap lifts by
+        // itself once the missing elevation tiles arrive.
+        if (grid && _elevationManager->isSeamlessTileEdgesEnabled()) {
+            int ownLevel = grid->getTile().getZoom();
+            auto capIt = _levelCapNext.find(tileId.zoom);
+            if (capIt == _levelCapNext.end()) {
+                _levelCapNext[tileId.zoom] = ownLevel;
+            } else if (ownLevel < capIt->second) {
+                capIt->second = ownLevel;
+            }
+            auto levelIt = _levelCap.find(tileId.zoom);
+            if (levelIt != _levelCap.end() && levelIt->second < ownLevel) {
+                MapTile cappedTile = mapTile;
+                while (cappedTile.getZoom() > levelIt->second) {
+                    cappedTile = cappedTile.getParent();
+                }
+                if (std::shared_ptr<ElevationTileGrid> cappedGrid = _elevationManager->getTileGrid(cappedTile, ElevationManager::LoadMode::CACHED_ONLY)) {
+                    grid = cappedGrid;
+                }
+            }
+        }
+
         if (!grid || !(grid->getTile() == dataTile)) {
             // Missing or resolved through a coarser ancestor: request the real thing. Without
             // this, elevation tiles are only loaded as a side effect of map tile fetches - map
@@ -168,11 +195,15 @@ namespace carto {
 
     void ElevationTextureCache::beginFrame() {
         _frameResolved.clear();
+        _levelCap = _levelCapNext;
+        _levelCapNext.clear();
         _frameStartCounter = _accessCounter;
     }
 
     void ElevationTextureCache::clear() {
         _cache.clear();
         _frameResolved.clear();
+        _levelCap.clear();
+        _levelCapNext.clear();
     }
 }

--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -21,20 +21,66 @@ namespace carto {
     }
 
     bool ElevationTextureCache::getTexture(const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture) {
+        int tileMask = (1 << tileId.zoom) - 1;
+        MapTile mapTile(tileId.x & tileMask, std::min(std::max(tileId.y, 0), tileMask), tileId.zoom, 0);
+        long long mapTileId = mapTile.getTileId();
+
+        // The provider is called once per tile per render pass; resolve the tile at most
+        // once per frame and reuse the resolution for the remaining passes.
+        long long gridTileId = -1;
+        auto frameIt = _frameResolved.find(mapTileId);
+        if (frameIt != _frameResolved.end()) {
+            gridTileId = frameIt->second;
+        } else {
+            if (!resolveEntry(tileId, gridTileId)) {
+                gridTileId = -1;
+            }
+            _frameResolved[mapTileId] = gridTileId;
+        }
+        if (gridTileId < 0) {
+            return false;
+        }
+
+        auto it = _cache.find(gridTileId);
+        if (it == _cache.end() || !it->second.texture || it->second.texture->getTexId() == 0) {
+            return false;
+        }
+        it->second.lastUsed = ++_accessCounter;
+        fillTexture(it->second, static_cast<float>(_elevationManager->getExaggeration() * Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE), terrainTexture);
+        return true;
+    }
+
+    bool ElevationTextureCache::resolveEntry(const vt::TileId& tileId, long long& gridTileId) {
         // Resolve the best already-decoded elevation grid for the tile. This mirrors the
         // CPU displacement path (TerrainTileTransformer), so the GPU-sampled heights stay
         // consistent with element placement, hit testing and label anchors.
         int tileMask = (1 << tileId.zoom) - 1;
         MapTile mapTile(tileId.x & tileMask, std::min(std::max(tileId.y, 0), tileMask), tileId.zoom, 0);
+
+        // The tile that should carry this tile's elevation data (own level, or the data source
+        // maximum zoom level for overzoomed tiles).
+        MapTile dataTile = _elevationManager->getDataTile(mapTile);
+
         std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getTileGrid(mapTile, ElevationManager::LoadMode::CACHED_ONLY);
+        if (!grid || !(grid->getTile() == dataTile)) {
+            // Missing or resolved through a coarser ancestor: request the real thing. Without
+            // this, elevation tiles are only loaded as a side effect of map tile fetches - map
+            // tiles served from the cache never trigger one, so neighbouring surface tiles can
+            // stay displaced by different DEM levels, which is a hard step at the tile border.
+            // No-op when elevation prefetching is disabled or the tile is already queued.
+            _elevationManager->prefetchTileGrid(dataTile);
+        }
         if (!grid || grid->getWidth() < 1 || grid->getHeight() < 1) {
             return false;
         }
 
-        // Fetch the same-level neighbour grids: the texture gets a 1-texel border copied
-        // from them, so adjacent tiles bilinearly interpolate across tile borders from
-        // identical texel pairs - same-level DEM tile borders become seam-free. Only exact
-        // same-level neighbours are used (ancestor fallbacks would not be symmetric).
+        // Fetch the neighbour grids: the texture gets a 1-texel border taken from them, so
+        // adjacent tiles bilinearly interpolate across tile borders from identical texel
+        // pairs - same-level DEM tile borders become seam-free. With seamless tile edges
+        // enabled, coarser ancestor grids are accepted as well and sampled geographically
+        // (ElevationTileGrid::encodeTextureWithBorders): not perfectly symmetric across a
+        // level change, but real DEM data instead of a duplicated edge texel.
+        bool seamless = _elevationManager->isSeamlessTileEdgesEnabled();
         const MapTile& gridTile = grid->getTile();
         int gridMask = (1 << gridTile.getZoom()) - 1;
         auto neighbourGrid = [&, this](int dx, int dy) -> std::shared_ptr<ElevationTileGrid> {
@@ -44,8 +90,14 @@ namespace carto {
             }
             MapTile neighbourTile((gridTile.getX() + dx) & gridMask, ny, gridTile.getZoom(), 0);
             std::shared_ptr<ElevationTileGrid> neighbour = _elevationManager->getTileGrid(neighbourTile, ElevationManager::LoadMode::CACHED_ONLY);
-            if (neighbour && !(neighbour->getTile() == neighbourTile)) {
-                neighbour.reset();
+            if (!neighbour || !(neighbour->getTile() == neighbourTile)) {
+                _elevationManager->prefetchTileGrid(neighbourTile); // border texels want the real neighbour tile
+            }
+            if (neighbour && !(neighbour->getTile() == neighbourTile) && !seamless) {
+                neighbour.reset(); // strict mode: only exact same-level neighbours
+            }
+            if (neighbour && neighbour->getTile() == gridTile) {
+                neighbour.reset(); // our own grid covers the neighbour: the texture is already continuous there
             }
             return neighbour;
         };
@@ -55,7 +107,7 @@ namespace carto {
             neighbourGrid(-1, 1), neighbourGrid(1, 1), neighbourGrid(-1, -1), neighbourGrid(1, -1)
         } };
 
-        long long gridTileId = gridTile.getTileId();
+        gridTileId = gridTile.getTileId();
         auto it = _cache.find(gridTileId);
         if (it == _cache.end() || it->second.grid != grid || it->second.neighbours != neighbours) {
             if (_cache.size() >= MAX_CACHED_TEXTURES && it == _cache.end()) {
@@ -63,9 +115,22 @@ namespace carto {
                 // re-encodes+re-uploads every texture whenever the working set exceeds the cap,
                 // which stalls the render thread on fast multi-level zooms (the working set of
                 // visible + neighbour DEM tiles briefly exceeds the cap). LRU keeps the warm set.
-                auto lru = std::min_element(_cache.begin(), _cache.end(), [](const std::pair<const long long, CacheEntry>& a, const std::pair<const long long, CacheEntry>& b) {
-                    return a.second.lastUsed < b.second.lastUsed;
-                });
+                // Entries already used in this frame are kept if possible: dropping one would
+                // make the tile fall back to flat in its remaining render passes.
+                auto lru = _cache.end();
+                for (auto entryIt = _cache.begin(); entryIt != _cache.end(); entryIt++) {
+                    if (entryIt->second.lastUsed > _frameStartCounter) {
+                        continue;
+                    }
+                    if (lru == _cache.end() || entryIt->second.lastUsed < lru->second.lastUsed) {
+                        lru = entryIt;
+                    }
+                }
+                if (lru == _cache.end()) {
+                    lru = std::min_element(_cache.begin(), _cache.end(), [](const std::pair<const long long, CacheEntry>& a, const std::pair<const long long, CacheEntry>& b) {
+                        return a.second.lastUsed < b.second.lastUsed;
+                    });
+                }
                 if (lru != _cache.end()) {
                     _cache.erase(lru);
                 }
@@ -84,11 +149,10 @@ namespace carto {
             it = _cache.insert_or_assign(gridTileId, std::move(entry)).first;
         }
         it->second.lastUsed = ++_accessCounter;
-        const CacheEntry& entry = it->second;
-        if (!entry.texture || entry.texture->getTexId() == 0) {
-            return false;
-        }
+        return it->second.texture && it->second.texture->getTexId() != 0;
+    }
 
+    void ElevationTextureCache::fillTexture(const CacheEntry& entry, float metersToInternal, vt::GLTileRenderer::TerrainTexture& terrainTexture) {
         // The texture covers the grid bounds extended by the 1-texel border
         const MapBounds& bounds = entry.grid->getInternalBounds();
         double texelX = (bounds.getMax().getX() - bounds.getMin().getX()) / entry.grid->getWidth();
@@ -98,12 +162,17 @@ namespace carto {
         terrainTexture.internalOrigin = cglib::vec2<double>(bounds.getMin().getX() - texelX, bounds.getMin().getY() - texelY);
         terrainTexture.internalSize = cglib::vec2<double>(bounds.getMax().getX() - bounds.getMin().getX() + 2 * texelX, bounds.getMax().getY() - bounds.getMin().getY() + 2 * texelY);
         terrainTexture.decode = cglib::vec4<float>(entry.decode[0], entry.decode[1], entry.decode[2], entry.decode[3]);
-        terrainTexture.metersToInternal = static_cast<float>(_elevationManager->getExaggeration() * Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE);
+        terrainTexture.metersToInternal = metersToInternal;
         terrainTexture.mercatorYScale = static_cast<float>(2.0 * Const::PI / Const::WORLD_SIZE);
-        return true;
+    }
+
+    void ElevationTextureCache::beginFrame() {
+        _frameResolved.clear();
+        _frameStartCounter = _accessCounter;
     }
 
     void ElevationTextureCache::clear() {
         _cache.clear();
+        _frameResolved.clear();
     }
 }

--- a/all/native/renderers/utils/ElevationTextureCache.h
+++ b/all/native/renderers/utils/ElevationTextureCache.h
@@ -69,15 +69,6 @@ namespace carto {
         const std::shared_ptr<GLResourceManager> _glResourceManager;
         std::map<long long, CacheEntry> _cache; // keyed by the grid tile id
         std::map<long long, long long> _frameResolved; // render tile id -> grid tile id (-1: no data), reset every frame
-        // Coarsest elevation level actually available among the tiles of one render zoom level.
-        // Neighbouring tiles displaced by DIFFERENT elevation levels disagree along their shared
-        // edge (a parent grid is an average of its children, not the same height field), which
-        // tears the surface open. Tiles of the same render zoom therefore all fall back to the
-        // coarsest level any of them can resolve; the cap lifts again as the missing tiles load.
-        // Collected while resolving a frame, applied to the next one (one frame of lag, no extra
-        // pass). Only the coarsest LEVEL is shared, the tiles keep their own elevation textures.
-        std::map<int, int> _levelCap;      // render zoom -> elevation level cap (from the previous frame)
-        std::map<int, int> _levelCapNext;  // render zoom -> coarsest level seen in this frame
         std::uint64_t _accessCounter = 0; // monotonic LRU clock
         std::uint64_t _frameStartCounter = 0; // LRU clock at the start of the current frame
     };

--- a/all/native/renderers/utils/ElevationTextureCache.h
+++ b/all/native/renderers/utils/ElevationTextureCache.h
@@ -49,6 +49,15 @@ namespace carto {
          */
         void beginFrame();
 
+        /**
+         * Sets the terrain surface resolution (grid cells per tile edge). The elevation level is
+         * capped so that one elevation texel covers at most half a surface cell: finer elevation
+         * data cannot be expressed by the mesh, but it would multiply the number of distinct
+         * elevation textures by four per level - and with it the decoded grid working set, the
+         * texture uploads and the tile requests.
+         */
+        void setSurfaceResolution(int resolution);
+
         void clear();
 
     private:
@@ -69,6 +78,8 @@ namespace carto {
         const std::shared_ptr<GLResourceManager> _glResourceManager;
         std::map<long long, CacheEntry> _cache; // keyed by the grid tile id
         std::map<long long, long long> _frameResolved; // render tile id -> grid tile id (-1: no data), reset every frame
+        int _surfaceResolution = 32;   // terrain mesh cells per tile edge
+        int _gridSizeHint = 256;       // texels per elevation tile edge, from the last resolved grid
         std::uint64_t _accessCounter = 0; // monotonic LRU clock
         std::uint64_t _frameStartCounter = 0; // LRU clock at the start of the current frame
     };

--- a/all/native/renderers/utils/ElevationTextureCache.h
+++ b/all/native/renderers/utils/ElevationTextureCache.h
@@ -69,6 +69,15 @@ namespace carto {
         const std::shared_ptr<GLResourceManager> _glResourceManager;
         std::map<long long, CacheEntry> _cache; // keyed by the grid tile id
         std::map<long long, long long> _frameResolved; // render tile id -> grid tile id (-1: no data), reset every frame
+        // Coarsest elevation level actually available among the tiles of one render zoom level.
+        // Neighbouring tiles displaced by DIFFERENT elevation levels disagree along their shared
+        // edge (a parent grid is an average of its children, not the same height field), which
+        // tears the surface open. Tiles of the same render zoom therefore all fall back to the
+        // coarsest level any of them can resolve; the cap lifts again as the missing tiles load.
+        // Collected while resolving a frame, applied to the next one (one frame of lag, no extra
+        // pass). Only the coarsest LEVEL is shared, the tiles keep their own elevation textures.
+        std::map<int, int> _levelCap;      // render zoom -> elevation level cap (from the previous frame)
+        std::map<int, int> _levelCapNext;  // render zoom -> coarsest level seen in this frame
         std::uint64_t _accessCounter = 0; // monotonic LRU clock
         std::uint64_t _frameStartCounter = 0; // LRU clock at the start of the current frame
     };

--- a/all/native/renderers/utils/ElevationTextureCache.h
+++ b/all/native/renderers/utils/ElevationTextureCache.h
@@ -49,15 +49,6 @@ namespace carto {
          */
         void beginFrame();
 
-        /**
-         * Sets the terrain surface resolution (grid cells per tile edge). The elevation level is
-         * capped so that one elevation texel covers at most half a surface cell: finer elevation
-         * data cannot be expressed by the mesh, but it would multiply the number of distinct
-         * elevation textures by four per level - and with it the decoded grid working set, the
-         * texture uploads and the tile requests.
-         */
-        void setSurfaceResolution(int resolution);
-
         void clear();
 
     private:
@@ -78,8 +69,6 @@ namespace carto {
         const std::shared_ptr<GLResourceManager> _glResourceManager;
         std::map<long long, CacheEntry> _cache; // keyed by the grid tile id
         std::map<long long, long long> _frameResolved; // render tile id -> grid tile id (-1: no data), reset every frame
-        int _surfaceResolution = 32;   // terrain mesh cells per tile edge
-        int _gridSizeHint = 256;       // texels per elevation tile edge, from the last resolved grid
         std::uint64_t _accessCounter = 0; // monotonic LRU clock
         std::uint64_t _frameStartCounter = 0; // LRU clock at the start of the current frame
     };

--- a/all/native/renderers/utils/ElevationTextureCache.h
+++ b/all/native/renderers/utils/ElevationTextureCache.h
@@ -42,6 +42,13 @@ namespace carto {
          */
         bool getTexture(const vt::TileId& tileId, vt::GLTileRenderer::TerrainTexture& terrainTexture);
 
+        /**
+         * Starts a new frame: drops the per-frame tile resolution memo. The provider is called
+         * once per tile per render pass, so without the memo every pass would redo the grid and
+         * neighbour lookups (9 locked cache lookups per tile) for the same result.
+         */
+        void beginFrame();
+
         void clear();
 
     private:
@@ -55,10 +62,15 @@ namespace carto {
 
         static constexpr std::size_t MAX_CACHED_TEXTURES = 96; // ~24MB of RGBA 256x256 textures
 
+        bool resolveEntry(const vt::TileId& tileId, long long& gridTileId);
+        static void fillTexture(const CacheEntry& entry, float metersToInternal, vt::GLTileRenderer::TerrainTexture& terrainTexture);
+
         const std::shared_ptr<ElevationManager> _elevationManager;
         const std::shared_ptr<GLResourceManager> _glResourceManager;
         std::map<long long, CacheEntry> _cache; // keyed by the grid tile id
+        std::map<long long, long long> _frameResolved; // render tile id -> grid tile id (-1: no data), reset every frame
         std::uint64_t _accessCounter = 0; // monotonic LRU clock
+        std::uint64_t _frameStartCounter = 0; // LRU clock at the start of the current frame
     };
 }
 

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -21,6 +21,7 @@ namespace carto {
     static const int FAILED_TILE_TTL_MILLISECONDS = 30 * 1000;
     static const int MAX_ANCESTOR_SEARCH_DEPTH = 8;
     static const std::size_t MAX_PREFETCH_QUEUE_SIZE = 64;
+    static const int PREFETCH_THREADS = 3; // elevation tiles are network+decode bound; one worker converges too slowly
     static constexpr double NO_DATA_ELEVATION = -1000000.0;
     static constexpr double DEFAULT_MIN_ELEVATION = -500.0;
     static constexpr double DEFAULT_MAX_ELEVATION = 9000.0;
@@ -61,11 +62,14 @@ namespace carto {
             std::lock_guard<std::mutex> lock(_prefetchMutex);
             _prefetchStopped = true;
             _prefetchQueue.clear();
+            _prefetchQueueHigh.clear();
             _prefetchTileIds.clear();
         }
         _prefetchCondition.notify_all();
-        if (_prefetchThread.joinable()) {
-            _prefetchThread.join();
+        for (std::thread& thread : _prefetchThreads) {
+            if (thread.joinable()) {
+                thread.join();
+            }
         }
         _dataSource->unregisterOnChangeListener(_dataSourceListener);
     }
@@ -182,7 +186,21 @@ namespace carto {
 
         // Look for the tile or any of its cached ancestors
         bool tileFailed = false;
-        {
+        if (mode == LoadMode::LOAD_EXACT) {
+            // The caller wants THIS level, not a stand-in: a cached ancestor must not short
+            // circuit the load, or a tile that once fell back to its parent would stay on it
+            // forever - and neighbouring tiles displaced by different elevation levels tear the
+            // surface open along their shared edge. A grid cached under this tile id that covers
+            // an ancestor is the data source saying the level does not exist here, so it stands.
+            std::lock_guard<std::mutex> lock(_mutex);
+            std::shared_ptr<ElevationTileGrid> grid;
+            if (_gridCache.read(tile.getTileId(), grid)) {
+                if (grid) {
+                    return grid;
+                }
+                tileFailed = true; // recently failed to load, do not retry until the failure marker expires
+            }
+        } else {
             std::lock_guard<std::mutex> lock(_mutex);
             MapTile searchTile = tile;
             for (int depth = 0; depth <= MAX_ANCESTOR_SEARCH_DEPTH; depth++) {
@@ -260,7 +278,7 @@ namespace carto {
         return clampTileZoom(mapTile);
     }
 
-    void ElevationManager::prefetchTileGrid(const MapTile& mapTile) const {
+    void ElevationManager::prefetchTileGrid(const MapTile& mapTile, int priority) const {
         if (!_neighbourPrefetch.load()) {
             return;
         }
@@ -289,13 +307,20 @@ namespace carto {
             if (!_prefetchTileIds.insert(tileId).second) {
                 return; // already queued
             }
-            _prefetchQueue.push_back(tile);
-            while (_prefetchQueue.size() > MAX_PREFETCH_QUEUE_SIZE) {
-                _prefetchTileIds.erase(_prefetchQueue.front().getTileId());
-                _prefetchQueue.pop_front();
+            std::deque<MapTile>& queue = (priority >= 2 ? _prefetchQueueHigh : _prefetchQueue);
+            // The queues are drained newest first, so the lowest priority requests (diagonal
+            // neighbours) go to the far end instead of the near one.
+            if (priority <= 0) {
+                queue.push_front(tile);
+            } else {
+                queue.push_back(tile);
             }
-            if (!_prefetchThread.joinable()) {
-                _prefetchThread = std::thread([this]() { runPrefetchWorker(); });
+            while (queue.size() > MAX_PREFETCH_QUEUE_SIZE) {
+                _prefetchTileIds.erase(queue.front().getTileId());
+                queue.pop_front();
+            }
+            while (static_cast<int>(_prefetchThreads.size()) < PREFETCH_THREADS) {
+                _prefetchThreads.emplace_back([this]() { runPrefetchWorker(); });
             }
         }
         _prefetchCondition.notify_one();
@@ -306,18 +331,20 @@ namespace carto {
             MapTile tile(0, 0, 0, 0);
             {
                 std::unique_lock<std::mutex> lock(_prefetchMutex);
-                _prefetchCondition.wait(lock, [this]() { return _prefetchStopped || !_prefetchQueue.empty(); });
+                _prefetchCondition.wait(lock, [this]() { return _prefetchStopped || !_prefetchQueue.empty() || !_prefetchQueueHigh.empty(); });
                 if (_prefetchStopped) {
                     return;
                 }
-                // Newest request first: it belongs to the current viewport, while the oldest
+                // High priority (a tile's own elevation level) before border neighbours, and
+                // newest request first: it belongs to the current viewport, while the oldest
                 // entries may already have scrolled out of view.
-                tile = _prefetchQueue.back();
-                _prefetchQueue.pop_back();
+                std::deque<MapTile>& queue = (_prefetchQueueHigh.empty() ? _prefetchQueue : _prefetchQueueHigh);
+                tile = queue.back();
+                queue.pop_back();
                 _prefetchTileIds.erase(tile.getTileId());
             }
             try {
-                getTileGrid(tile, LoadMode::ALLOW_LOAD);
+                getTileGrid(tile, LoadMode::LOAD_EXACT);
             }
             catch (const std::exception& ex) {
                 Log::Warnf("ElevationManager::runPrefetchWorker: Failed to prefetch elevation tile: %s", ex.what());

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -46,6 +46,8 @@ namespace carto {
         _dataSourceListener(),
         _exaggeration(1.0f),
         _seamlessTileEdges(true),
+        _surfaceResolution(32),
+        _gridSizeHint(256),
         _neighbourPrefetch(true),
         _version(1),
         _maxSeenElevation(0.0f),
@@ -98,6 +100,13 @@ namespace carto {
     void ElevationManager::setSeamlessTileEdgesEnabled(bool enabled) {
         if (_seamlessTileEdges.exchange(enabled) != enabled) {
             _version++; // elevation texture borders change, force a rebuild
+        }
+    }
+
+    void ElevationManager::setSurfaceResolution(int resolution) {
+        int value = std::max(1, resolution);
+        if (_surfaceResolution.exchange(value) != value) {
+            _version++; // the elevation level cap changes with it
         }
     }
 
@@ -523,6 +532,14 @@ namespace carto {
 
     MapTile ElevationManager::clampTileZoom(const MapTile& mapTile) const {
         MapTile tile = mapTile;
+        // Cap by the resolution the terrain mesh can express: an elevation tile is 256-512 texels
+        // while the surface has _surfaceResolution cells, so taking the tile zoom literally would
+        // give every tile its own elevation tile - and its own decoded grid and GL texture - for
+        // detail that cannot be rendered. One texel per half surface cell is the useful limit.
+        int surfaceResolution = _surfaceResolution.load();
+        for (int size = _gridSizeHint.load(); size > 2 * surfaceResolution && tile.getZoom() > 0; size /= 2) {
+            tile = tile.getParent();
+        }
         int maxZoom = _dataSource->getMaxZoom();
         while (tile.getZoom() > maxZoom) {
             tile = tile.getParent();
@@ -562,6 +579,10 @@ namespace carto {
                                  MapPos(std::max(internalMin.getX(), internalMax.getX()), std::max(internalMin.getY(), internalMax.getY())));
 
         std::array<double, 4> coeffs = _elevationDecoder->getColorComponentCoefficients();
-        return ElevationTileGrid::DecodeBitmap(mapTile, internalBounds, tileBitmap, coeffs);
+        std::shared_ptr<ElevationTileGrid> grid = ElevationTileGrid::DecodeBitmap(mapTile, internalBounds, tileBitmap, coeffs);
+        if (grid && grid->getWidth() > 0) {
+            _gridSizeHint.store(grid->getWidth()); // drives the elevation level cap in clampTileZoom
+        }
+        return grid;
     }
 }

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -20,6 +20,7 @@ namespace carto {
     static const std::size_t DEFAULT_CACHE_CAPACITY = 64 * 1024 * 1024;
     static const int FAILED_TILE_TTL_MILLISECONDS = 30 * 1000;
     static const int MAX_ANCESTOR_SEARCH_DEPTH = 8;
+    static const std::size_t MAX_PREFETCH_QUEUE_SIZE = 64;
     static constexpr double NO_DATA_ELEVATION = -1000000.0;
     static constexpr double DEFAULT_MIN_ELEVATION = -500.0;
     static constexpr double DEFAULT_MAX_ELEVATION = 9000.0;
@@ -43,16 +44,29 @@ namespace carto {
         _projection(dataSource->getProjection()),
         _dataSourceListener(),
         _exaggeration(1.0f),
+        _seamlessTileEdges(true),
+        _neighbourPrefetch(true),
         _version(1),
         _maxSeenElevation(0.0f),
         _gridCache(DEFAULT_CACHE_CAPACITY),
-        _mutex()
+        _mutex(),
+        _prefetchStopped(false)
     {
         _dataSourceListener = std::make_shared<DataSourceListener>(*this);
         _dataSource->registerOnChangeListener(_dataSourceListener);
     }
 
     ElevationManager::~ElevationManager() {
+        {
+            std::lock_guard<std::mutex> lock(_prefetchMutex);
+            _prefetchStopped = true;
+            _prefetchQueue.clear();
+            _prefetchTileIds.clear();
+        }
+        _prefetchCondition.notify_all();
+        if (_prefetchThread.joinable()) {
+            _prefetchThread.join();
+        }
         _dataSource->unregisterOnChangeListener(_dataSourceListener);
     }
 
@@ -71,6 +85,24 @@ namespace carto {
     void ElevationManager::setExaggeration(float exaggeration) {
         _exaggeration.store(std::max(0.0f, exaggeration));
         _version++;
+    }
+
+    bool ElevationManager::isSeamlessTileEdgesEnabled() const {
+        return _seamlessTileEdges.load();
+    }
+
+    void ElevationManager::setSeamlessTileEdgesEnabled(bool enabled) {
+        if (_seamlessTileEdges.exchange(enabled) != enabled) {
+            _version++; // elevation texture borders change, force a rebuild
+        }
+    }
+
+    bool ElevationManager::isNeighbourPrefetchEnabled() const {
+        return _neighbourPrefetch.load();
+    }
+
+    void ElevationManager::setNeighbourPrefetchEnabled(bool enabled) {
+        _neighbourPrefetch.store(enabled);
     }
 
     std::size_t ElevationManager::getCacheCapacity() const {
@@ -222,6 +254,75 @@ namespace carto {
             _version++;
         }
         return grid;
+    }
+
+    MapTile ElevationManager::getDataTile(const MapTile& mapTile) const {
+        return clampTileZoom(mapTile);
+    }
+
+    void ElevationManager::prefetchTileGrid(const MapTile& mapTile) const {
+        if (!_neighbourPrefetch.load()) {
+            return;
+        }
+        MapTile tile = clampTileZoom(mapTile);
+        if (tile.getZoom() < _dataSource->getMinZoom()) {
+            return;
+        }
+
+        long long tileId = tile.getTileId();
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            std::shared_ptr<ElevationTileGrid> grid;
+            if (_gridCache.read(tileId, grid)) {
+                return; // already loaded, resolved via an ancestor, or recently failed
+            }
+            if (_pendingLoads.find(tileId) != _pendingLoads.end()) {
+                return; // already being loaded by another thread
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(_prefetchMutex);
+            if (_prefetchStopped) {
+                return;
+            }
+            if (!_prefetchTileIds.insert(tileId).second) {
+                return; // already queued
+            }
+            _prefetchQueue.push_back(tile);
+            while (_prefetchQueue.size() > MAX_PREFETCH_QUEUE_SIZE) {
+                _prefetchTileIds.erase(_prefetchQueue.front().getTileId());
+                _prefetchQueue.pop_front();
+            }
+            if (!_prefetchThread.joinable()) {
+                _prefetchThread = std::thread([this]() { runPrefetchWorker(); });
+            }
+        }
+        _prefetchCondition.notify_one();
+    }
+
+    void ElevationManager::runPrefetchWorker() const {
+        while (true) {
+            MapTile tile(0, 0, 0, 0);
+            {
+                std::unique_lock<std::mutex> lock(_prefetchMutex);
+                _prefetchCondition.wait(lock, [this]() { return _prefetchStopped || !_prefetchQueue.empty(); });
+                if (_prefetchStopped) {
+                    return;
+                }
+                // Newest request first: it belongs to the current viewport, while the oldest
+                // entries may already have scrolled out of view.
+                tile = _prefetchQueue.back();
+                _prefetchQueue.pop_back();
+                _prefetchTileIds.erase(tile.getTileId());
+            }
+            try {
+                getTileGrid(tile, LoadMode::ALLOW_LOAD);
+            }
+            catch (const std::exception& ex) {
+                Log::Warnf("ElevationManager::runPrefetchWorker: Failed to prefetch elevation tile: %s", ex.what());
+            }
+        }
     }
 
     double ElevationManager::getDisplayScale(double internalY) const {

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -72,6 +72,16 @@ namespace carto {
         bool isNeighbourPrefetchEnabled() const;
         void setNeighbourPrefetchEnabled(bool enabled);
 
+        /**
+         * Sets the terrain surface resolution (mesh cells per tile edge). Elevation levels are
+         * capped so that one elevation texel covers at most half a surface cell: finer data cannot
+         * be expressed by the mesh, but every level costs four times the tiles, decoded grids and
+         * GL textures. The cap applies to EVERY elevation query, so the displaced surface, the
+         * elevation lookups, the ray intersection used for billboard occlusion and the CPU-side
+         * element placement all agree on one height field.
+         */
+        void setSurfaceResolution(int resolution);
+
         std::size_t getCacheCapacity() const;
         void setCacheCapacity(std::size_t capacityInBytes);
 
@@ -172,6 +182,8 @@ namespace carto {
 
         std::atomic<float> _exaggeration;
         std::atomic<bool> _seamlessTileEdges;
+        std::atomic<int> _surfaceResolution;      // terrain mesh cells per tile edge
+        mutable std::atomic<int> _gridSizeHint;   // texels per elevation tile edge, from the last decoded grid
         std::atomic<bool> _neighbourPrefetch;
         mutable std::atomic<unsigned int> _version;
         mutable std::atomic<float> _maxSeenElevation;

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -12,10 +12,14 @@
 #include "core/MapTile.h"
 
 #include <atomic>
+#include <condition_variable>
+#include <deque>
 #include <future>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
+#include <thread>
 #include <vector>
 
 #include <stdext/timed_lru_cache.h>
@@ -56,6 +60,12 @@ namespace carto {
         float getExaggeration() const;
         void setExaggeration(float exaggeration);
 
+        bool isSeamlessTileEdgesEnabled() const;
+        void setSeamlessTileEdgesEnabled(bool enabled);
+
+        bool isNeighbourPrefetchEnabled() const;
+        void setNeighbourPrefetchEnabled(bool enabled);
+
         std::size_t getCacheCapacity() const;
         void setCacheCapacity(std::size_t capacityInBytes);
 
@@ -89,6 +99,20 @@ namespace carto {
          * The tile must be in XYZ convention (y=0 north, same as vt::TileId and TileDataSource::loadTile).
          */
         std::shared_ptr<ElevationTileGrid> getTileGrid(const MapTile& mapTile, LoadMode mode) const;
+
+        /**
+         * Returns the tile that actually carries the elevation data for the given tile: the same
+         * tile, or its ancestor at the data source maximum zoom level.
+         */
+        MapTile getDataTile(const MapTile& mapTile) const;
+
+        /**
+         * Requests an asynchronous load of the given elevation tile. Never blocks and never
+         * performs IO on the calling thread. A no-op if the grid is already cached, already
+         * queued or currently being loaded, or if neighbour prefetching is disabled.
+         * The tile must be in XYZ convention (y=0 north, same as getTileGrid).
+         */
+        void prefetchTileGrid(const MapTile& mapTile) const;
 
         /**
          * Returns the meters-to-internal-display-units scale at the given internal y coordinate
@@ -131,6 +155,7 @@ namespace carto {
         std::shared_ptr<ElevationTileGrid> getGridForInternalPos(double internalX, double internalY, LoadMode mode) const;
         std::shared_ptr<ElevationTileGrid> loadTileGrid(const MapTile& mapTile) const;
         void getMinMaxDisplayHeight(const MapTile& tile, double& minZ, double& maxZ, bool exact) const;
+        void runPrefetchWorker() const;
 
         const std::shared_ptr<TileDataSource> _dataSource;
         const std::shared_ptr<ElevationDecoder> _elevationDecoder;
@@ -138,12 +163,24 @@ namespace carto {
         std::shared_ptr<DataSourceListener> _dataSourceListener;
 
         std::atomic<float> _exaggeration;
+        std::atomic<bool> _seamlessTileEdges;
+        std::atomic<bool> _neighbourPrefetch;
         mutable std::atomic<unsigned int> _version;
         mutable std::atomic<float> _maxSeenElevation;
 
         mutable cache::timed_lru_cache<long long, std::shared_ptr<ElevationTileGrid> > _gridCache;
         mutable std::map<long long, std::shared_future<std::shared_ptr<ElevationTileGrid> > > _pendingLoads; // single-flight de-duplication of concurrent loads
         mutable std::mutex _mutex;
+
+        // Background prefetch worker: loads elevation tiles requested by the render thread
+        // (visible tiles + their neighbours) without ever blocking it. The thread is started
+        // on the first request and joined in the destructor.
+        mutable std::deque<MapTile> _prefetchQueue;
+        mutable std::set<long long> _prefetchTileIds;
+        mutable std::thread _prefetchThread;
+        mutable std::condition_variable _prefetchCondition;
+        mutable bool _prefetchStopped;
+        mutable std::mutex _prefetchMutex;
     };
 }
 

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -48,7 +48,13 @@ namespace carto {
             /**
              * The elevation tile may be synchronously loaded from the data source. May block on IO/network.
              */
-            ALLOW_LOAD
+            ALLOW_LOAD,
+            /**
+             * Like ALLOW_LOAD, but a cached ancestor is not accepted as a stand-in: the tile itself
+             * is loaded unless the data source has already answered that this level does not exist.
+             * May block on IO/network.
+             */
+            LOAD_EXACT
         };
 
         ElevationManager(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& elevationDecoder);
@@ -110,9 +116,11 @@ namespace carto {
          * Requests an asynchronous load of the given elevation tile. Never blocks and never
          * performs IO on the calling thread. A no-op if the grid is already cached, already
          * queued or currently being loaded, or if neighbour prefetching is disabled.
+         * Priority 2 (the tile's own elevation level) is served before 1 (edge neighbours),
+         * which is served before 0 (diagonal neighbours, which only fill a corner texel).
          * The tile must be in XYZ convention (y=0 north, same as getTileGrid).
          */
-        void prefetchTileGrid(const MapTile& mapTile) const;
+        void prefetchTileGrid(const MapTile& mapTile, int priority) const;
 
         /**
          * Returns the meters-to-internal-display-units scale at the given internal y coordinate
@@ -175,9 +183,10 @@ namespace carto {
         // Background prefetch worker: loads elevation tiles requested by the render thread
         // (visible tiles + their neighbours) without ever blocking it. The thread is started
         // on the first request and joined in the destructor.
-        mutable std::deque<MapTile> _prefetchQueue;
+        mutable std::deque<MapTile> _prefetchQueue;      // low priority (neighbour borders)
+        mutable std::deque<MapTile> _prefetchQueueHigh;  // high priority (the tile's own level)
         mutable std::set<long long> _prefetchTileIds;
-        mutable std::thread _prefetchThread;
+        mutable std::vector<std::thread> _prefetchThreads;
         mutable std::condition_variable _prefetchCondition;
         mutable bool _prefetchStopped;
         mutable std::mutex _prefetchMutex;

--- a/all/native/terrain/ElevationTileGrid.cpp
+++ b/all/native/terrain/ElevationTileGrid.cpp
@@ -87,33 +87,53 @@ namespace carto {
         int paddedHeight = _height + 2;
         rgbaData.resize(static_cast<std::size_t>(paddedWidth) * paddedHeight * 4);
 
-        auto compatible = [this](const std::shared_ptr<ElevationTileGrid>& grid) {
-            return grid && grid->_width == _width && grid->_height == _height;
+        // Same DEM level and grid size: the border texel is one of the neighbour's own
+        // texels, so it can be copied bit-exactly by index.
+        auto sameLevel = [this](const std::shared_ptr<ElevationTileGrid>& grid) {
+            // The same grid standing in for a neighbour (both tiles resolved to one ancestor)
+            // must NOT be index-copied - that would wrap around to its opposite edge.
+            return grid && grid->_width == _width && grid->_height == _height && grid->_tile.getZoom() == _tile.getZoom() && !(grid->_tile == _tile);
+        };
+        // Different level (a coarser ancestor grid stands in for the neighbour): sample the
+        // neighbour's height field at the geographic position of the border texel center.
+        // Real DEM data at the tile edge beats duplicating our own edge texel, which leaves
+        // a full-texel height step (tens of meters on a slope) at the tile border.
+        double texelX = (_internalBounds.getMax().getX() - _internalBounds.getMin().getX()) / _width;
+        double texelY = (_internalBounds.getMax().getY() - _internalBounds.getMin().getY()) / _height;
+        auto sampleValue = [&, this](const ElevationTileGrid* grid, int gx, int gy) -> std::uint16_t {
+            double px = _internalBounds.getMin().getX() + (gx + 0.5) * texelX;
+            double py = _internalBounds.getMin().getY() + (gy + 0.5) * texelY;
+            return EncodeHeight(grid->sampleHeight(px, py));
         };
         // texel value at padded coordinates (gx, gy in [-1, width/height]); border texels
         // come from the neighbour that actually covers them, falling back to edge clamping
         auto rawValue = [&, this](int gx, int gy) -> std::uint16_t {
-            const ElevationTileGrid* grid = this;
-            if (gx < 0 && gy >= 0 && gy < _height && compatible(neighbours[0])) {
-                grid = neighbours[0].get(); gx += _width;
-            } else if (gx >= _width && gy >= 0 && gy < _height && compatible(neighbours[1])) {
-                grid = neighbours[1].get(); gx -= _width;
-            } else if (gy < 0 && gx >= 0 && gx < _width && compatible(neighbours[2])) {
-                grid = neighbours[2].get(); gy += _height;
-            } else if (gy >= _height && gx >= 0 && gx < _width && compatible(neighbours[3])) {
-                grid = neighbours[3].get(); gy -= _height;
-            } else if (gx < 0 && gy < 0 && compatible(neighbours[4])) {
-                grid = neighbours[4].get(); gx += _width; gy += _height;
-            } else if (gx >= _width && gy < 0 && compatible(neighbours[5])) {
-                grid = neighbours[5].get(); gx -= _width; gy += _height;
-            } else if (gx < 0 && gy >= _height && compatible(neighbours[6])) {
-                grid = neighbours[6].get(); gx += _width; gy -= _height;
-            } else if (gx >= _width && gy >= _height && compatible(neighbours[7])) {
-                grid = neighbours[7].get(); gx -= _width; gy -= _height;
+            static const std::array<std::pair<int, int>, 8> DIRS = { {
+                { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 }, { -1, -1 }, { 1, -1 }, { -1, 1 }, { 1, 1 }
+            } };
+            int dx = (gx < 0 ? -1 : (gx >= _width ? 1 : 0));
+            int dy = (gy < 0 ? -1 : (gy >= _height ? 1 : 0));
+            if (dx != 0 || dy != 0) {
+                for (std::size_t i = 0; i < DIRS.size(); i++) {
+                    if (DIRS[i].first != dx || DIRS[i].second != dy) {
+                        continue;
+                    }
+                    const std::shared_ptr<ElevationTileGrid>& neighbour = neighbours[i];
+                    if (sameLevel(neighbour)) {
+                        int nx = gx - dx * _width;
+                        int ny = gy - dy * _height;
+                        return neighbour->_heights[static_cast<std::size_t>(ny) * neighbour->_width + nx];
+                    }
+                    if (neighbour) {
+                        return sampleValue(neighbour.get(), gx, gy);
+                    }
+                    break;
+                }
             }
-            gx = std::min(std::max(gx, 0), grid->_width - 1);
-            gy = std::min(std::max(gy, 0), grid->_height - 1);
-            return grid->_heights[static_cast<std::size_t>(gy) * grid->_width + gx];
+            // no neighbour data: duplicate our own edge texel
+            int cx = std::min(std::max(gx, 0), _width - 1);
+            int cy = std::min(std::max(gy, 0), _height - 1);
+            return _heights[static_cast<std::size_t>(cy) * _width + cx];
         };
 
         std::size_t i = 0;

--- a/all/native/terrain/ElevationTileGrid.h
+++ b/all/native/terrain/ElevationTileGrid.h
@@ -59,8 +59,10 @@ namespace carto {
 
         /**
          * Like encodeTexture, but pads the texture with a 1-texel border taken from the
-         * neighbouring grids (same DEM level, order: W, E, S, N, SW, SE, NW, NE; null or
-         * differently-sized neighbours fall back to duplicating this grid's edge texels).
+         * neighbouring grids (order: W, E, S, N, SW, SE, NW, NE). Same-level neighbours are
+         * copied texel-exactly; coarser (ancestor) neighbour grids are sampled at the border
+         * texel centers, which still gives real DEM data across the tile border. Only missing
+         * neighbours fall back to duplicating this grid's edge texels.
          * Adjacent tiles then interpolate across the border from IDENTICAL texel pairs,
          * making same-level tile borders seam-free. The padded texture covers the grid
          * bounds extended by one texel on each side.


### PR DESCRIPTION
Neighbouring terrain tiles could disagree on the height along their shared edge, showing as a ridge or a bright see-through hairline at tile borders — most visible with an elevation tileset whose tiles do not match exactly (mapterhorn).

MapLibre solves the same problem with a backfilled 1-texel DEM border (`backfillDEM` re-uploads both tiles' textures when a neighbour lands) plus skirts for cross-LOD cracks. This branch does the border part, fixes the loading path that kept tiles on the wrong elevation level, and adds optional geometric stitching.

### What is in here

- **Elevation texture borders from real neighbours.** Same-level neighbours are copied texel-exactly; coarser ancestor grids are sampled at the border texel centres instead of duplicating our own edge texel (which leaves a step of a full DEM texel of relief — tens of metres on a slope). Opt out with `TerrainOptions.setSeamlessTileEdgesEnabled(false)`.
- **Elevation tile prefetching.** Elevation tiles used to load only as a side effect of map-tile fetches, so map tiles served from the cache never triggered one. Visible tiles now request their own elevation tile and its neighbours through a background worker (3 threads, priority: own level, then edge neighbours, then diagonals). Opt out with `TerrainOptions.setElevationPrefetchEnabled(false)` — this is the one that costs tile requests.
- **`LoadMode::LOAD_EXACT`.** `getTileGrid` returned any cached ancestor without ever loading the tile itself, even in `ALLOW_LOAD` mode, so a tile that fell back to a parent grid stayed on it forever. Neighbouring tiles then rendered from different elevation levels — a parent grid is the 2x2 average of its children, i.e. a different height field — which is what tore the surface open. This was the root cause of the hairline crack.
- **One elevation level cap for every consumer.** Elevation levels are capped at what the surface mesh can express (one texel per half `MeshResolution` cell) in `ElevationManager::clampTileZoom`, so the drawn surface, the ray march behind billboard occlusion, element placement and `getElevation` all resolve the same tile. Without the cap every render tile took its own elevation texture for detail the mesh cannot show: with shadows on (caster set = visible + margin, times the cascades) the working set thrashed the elevation cache at **4 fps against 150** — 14183 ms per 60 frames, 244-523 ms after.
- **Elevation texture cache budgeted in bytes** (32 MB) instead of 96 entries — that count was sized for 256-texel grids, but a 512-texel grid makes each texture 1.06 MB.
- **Cross-LOD edge stitching** (`TerrainOptions.setTileEdgeStitchingEnabled`, default true): tiles whose neighbour is at a coarser zoom follow that neighbour's grid nodes along the shared edge. Costs one uniform per tile; needs the regular grid surface mode and an even `MeshResolution`. Implemented in farfromrefug/mobile-carto-libs#13; the submodule pointer moves to `98aa23a`.
- **`PainterOrderDepthEnabled` now defaults to true**, which also turns the shared regular grid surface mode on by default.

### Verification

Android emulator, mapterhorn DEM over Grenoble. Elevation levels now resolve exactly (`z14 -> z14`, `z13 -> z13`, … where they used to be stuck on `z12`), the hairline crack is gone at the reported cameras, terrain is visibly sharper, and shadows are back at full speed (numbers above). The last commit (`091ed0149`) is not yet verified on device — the test emulator wedged before it could be re-run.

Not addressed here: faint speckles where a tile borders one at a different LOD ring — the two tiles sample different levels of the pyramid, which stitching aligns geometrically but cannot reconcile in the field itself; the planned fix is a per-edge DEM-level box filter for edge vertices. A separate, pre-existing bug (map background showing through the drape after zooming across z11, reproduced identically on the pre-branch build) is also still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)