### PR TITLE
fix(terrain): stop far tiles rendering flat by re-clamping the elevation level

### DIFF
--- a/all/native/renderers/utils/ElevationTextureCache.cpp
+++ b/all/native/renderers/utils/ElevationTextureCache.cpp
@@ -63,7 +63,7 @@ namespace carto {
         // displaced surface and every CPU-side elevation query use the same height field.
         MapTile dataTile = _elevationManager->getDataTile(mapTile);
 
-        std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getTileGrid(dataTile, ElevationManager::LoadMode::CACHED_ONLY);
+        std::shared_ptr<ElevationTileGrid> grid = _elevationManager->getDataTileGrid(dataTile, ElevationManager::LoadMode::CACHED_ONLY);
         if (!grid || !(grid->getTile() == dataTile)) {
             // Missing or resolved through a coarser ancestor: request the real thing, ahead of
             // any neighbour request. Until it arrives this tile is displaced by an ancestor grid
@@ -92,7 +92,7 @@ namespace carto {
                 return std::shared_ptr<ElevationTileGrid>();
             }
             MapTile neighbourTile((gridTile.getX() + dx) & gridMask, ny, gridTile.getZoom(), 0);
-            std::shared_ptr<ElevationTileGrid> neighbour = _elevationManager->getTileGrid(neighbourTile, ElevationManager::LoadMode::CACHED_ONLY);
+            std::shared_ptr<ElevationTileGrid> neighbour = _elevationManager->getDataTileGrid(neighbourTile, ElevationManager::LoadMode::CACHED_ONLY);
             if (!neighbour || !(neighbour->getTile() == neighbourTile)) {
                 // Border texels want the real neighbour tile, but after every tile's own level:
                 // a missing neighbour costs one texel of border accuracy, a missing own level

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -188,7 +188,14 @@ namespace carto {
     }
 
     std::shared_ptr<ElevationTileGrid> ElevationManager::getTileGrid(const MapTile& mapTile, LoadMode mode) const {
-        MapTile tile = clampTileZoom(mapTile);
+        return lookupTileGrid(clampTileZoom(mapTile), mode);
+    }
+
+    std::shared_ptr<ElevationTileGrid> ElevationManager::getDataTileGrid(const MapTile& dataTile, LoadMode mode) const {
+        return lookupTileGrid(clampDataTileZoom(dataTile), mode);
+    }
+
+    std::shared_ptr<ElevationTileGrid> ElevationManager::lookupTileGrid(const MapTile& tile, LoadMode mode) const {
         if (tile.getZoom() < _dataSource->getMinZoom()) {
             return std::shared_ptr<ElevationTileGrid>();
         }
@@ -295,11 +302,11 @@ namespace carto {
         return clampTileZoom(mapTile);
     }
 
-    void ElevationManager::prefetchTileGrid(const MapTile& mapTile, int priority) const {
+    void ElevationManager::prefetchTileGrid(const MapTile& dataTile, int priority) const {
         if (!_neighbourPrefetch.load()) {
             return;
         }
-        MapTile tile = clampTileZoom(mapTile);
+        MapTile tile = clampDataTileZoom(dataTile);
         if (tile.getZoom() < _dataSource->getMinZoom()) {
             return;
         }
@@ -361,7 +368,7 @@ namespace carto {
                 _prefetchTileIds.erase(tile.getTileId());
             }
             try {
-                getTileGrid(tile, LoadMode::LOAD_EXACT);
+                getDataTileGrid(tile, LoadMode::LOAD_EXACT); // queued tiles are elevation tiles already
             }
             catch (const std::exception& ex) {
                 Log::Warnf("ElevationManager::runPrefetchWorker: Failed to prefetch elevation tile: %s", ex.what());
@@ -569,10 +576,20 @@ namespace carto {
         // while the surface has _surfaceResolution cells, so taking the tile zoom literally would
         // give every tile its own elevation tile - and its own decoded grid and GL texture - for
         // detail that cannot be rendered. One texel per half surface cell is the useful limit.
+        // NOTE: this maps a RENDER tile to its elevation tile and is deliberately NOT idempotent -
+        // it drops a fixed number of levels on every call. Applying it to an elevation tile again
+        // (getTileGrid on a getDataTile result, or on a neighbour of one) costs another level each
+        // hop, which is why the elevation-tile entry points use clampDataTileZoom instead.
         int surfaceResolution = _surfaceResolution.load();
         for (int size = _gridSizeHint.load(); size > 2 * surfaceResolution && tile.getZoom() > 0; size /= 2) {
             tile = tile.getParent();
         }
+        return clampDataTileZoom(tile);
+    }
+
+    MapTile ElevationManager::clampDataTileZoom(const MapTile& dataTile) const {
+        // Only the data source zoom range: idempotent, safe to apply to an elevation tile.
+        MapTile tile = dataTile;
         int maxZoom = _dataSource->getMaxZoom();
         while (tile.getZoom() > maxZoom) {
             tile = tile.getParent();

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -111,27 +111,38 @@ namespace carto {
         void getDisplayGradient(double internalX, double internalY, LoadMode mode, double& dhdx, double& dhdy) const;
 
         /**
-         * Returns the decoded elevation grid covering the given tile (the tile zoom is clamped to the
-         * data source zoom range and cached ancestors act as fallbacks). May return null.
+         * Returns the decoded elevation grid covering the given RENDER tile (the tile zoom is
+         * mapped to the elevation level by getDataTile and cached ancestors act as fallbacks).
+         * May return null.
          * The tile must be in XYZ convention (y=0 north, same as vt::TileId and TileDataSource::loadTile).
          */
         std::shared_ptr<ElevationTileGrid> getTileGrid(const MapTile& mapTile, LoadMode mode) const;
 
         /**
-         * Returns the tile that actually carries the elevation data for the given tile: the same
-         * tile, or its ancestor at the data source maximum zoom level.
+         * Like getTileGrid, but the tile is an ELEVATION tile (a getDataTile result or one of its
+         * neighbours), not a render tile: only the data source zoom range is applied to it. Passing
+         * an already-resolved elevation tile to getTileGrid would map it down a second time, which
+         * costs one elevation level per hop.
+         */
+        std::shared_ptr<ElevationTileGrid> getDataTileGrid(const MapTile& dataTile, LoadMode mode) const;
+
+        /**
+         * Returns the tile that actually carries the elevation data for the given render tile: the
+         * same tile, or an ancestor - capped by the data source maximum zoom level and by the
+         * resolution the terrain mesh can express.
          */
         MapTile getDataTile(const MapTile& mapTile) const;
 
         /**
-         * Requests an asynchronous load of the given elevation tile. Never blocks and never
+         * Requests an asynchronous load of the given ELEVATION tile (as returned by getDataTile,
+         * or one of its neighbours - it is not mapped down again). Never blocks and never
          * performs IO on the calling thread. A no-op if the grid is already cached, already
          * queued or currently being loaded, or if neighbour prefetching is disabled.
          * Priority 2 (the tile's own elevation level) is served before 1 (edge neighbours),
          * which is served before 0 (diagonal neighbours, which only fill a corner texel).
          * The tile must be in XYZ convention (y=0 north, same as getTileGrid).
          */
-        void prefetchTileGrid(const MapTile& mapTile, int priority) const;
+        void prefetchTileGrid(const MapTile& dataTile, int priority) const;
 
         /**
          * Returns the meters-to-internal-display-units scale at the given internal y coordinate
@@ -180,6 +191,8 @@ namespace carto {
         void bumpGlobalVersion();
         double wrapInternalX(double internalX) const;
         MapTile clampTileZoom(const MapTile& mapTile) const;
+        MapTile clampDataTileZoom(const MapTile& dataTile) const;
+        std::shared_ptr<ElevationTileGrid> lookupTileGrid(const MapTile& dataTile, LoadMode mode) const;
         std::shared_ptr<ElevationTileGrid> getGridForInternalPos(double internalX, double internalY, LoadMode mode) const;
         std::shared_ptr<ElevationTileGrid> loadTileGrid(const MapTile& mapTile) const;
         void getMinMaxDisplayHeight(const MapTile& tile, double& minZ, double& maxZ, bool exact) const;


### PR DESCRIPTION
`ElevationManager::clampTileZoom` maps a **render** tile to the elevation tile that carries its data: it drops a fixed number of levels (one texel per half surface cell, plus the data source maximum zoom). That mapping is not idempotent, but every entry point applied it:

```
ElevationTextureCache::resolveEntry   render z13 -> getDataTile      -> z12
prefetchTileGrid(z12)                                clamps again    -> z11
getTileGrid(z11, LOAD_EXACT) in the worker           clamps again    -> z10
```

So the level actually requested was two to three below the intended one, and tiles fell back to whatever coarse ancestor happened to be cached — permanently, because the prefetch meant to repair it asked for the wrong tile.

Measured on the Chartreuse demo camera (mapterhorn DEM, meshResolution 128, 512-texel tiles), render zoom -> grid zoom:

| render | before | after |
|---|---|---|
| z13 | z10 | z12 |
| z12 | z10 | z11 |
| z11 | z8/z9 | z10 |
| z10 | z8 | z9 |
| z9 (far LOD band) | z6/z7 | z8 |

A far z9 tile displaced by a z6 grid is about 2.4 km per texel — that is what "far tiles are flat" looked like.

The resolution cap belongs to the render tile only, so the elevation-tile entry points now apply the idempotent part alone (the data source zoom range): `getDataTileGrid()` for a resolved elevation tile or one of its neighbours, `clampDataTileZoom()` in `prefetchTileGrid` and in the prefetch worker. `getTileGrid()` keeps mapping a render tile as before for its render-tile callers (TileLayer, TerrainRenderer, TerrainTileTransformer, MapRenderer).

## Verification

Emulator, demo camera: every render tile now resolves to its own level with no ancestor fallbacks and no missing textures; mid and far relief gain their detail back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)