### PR TITLE
feat(terrain): light the fog with the sun and carry it into the sky

### DIFF
--- a/all/modules/components/SkyOptions.i
+++ b/all/modules/components/SkyOptions.i
@@ -24,6 +24,7 @@
 %attributeval(carto::SkyOptions, carto::Color, HorizonColor, getHorizonColor, setHorizonColor)
 %attributeval(carto::SkyOptions, carto::Color, GroundColor, getGroundColor, setGroundColor)
 %attribute(carto::SkyOptions, float, HorizonBlend, getHorizonBlend, setHorizonBlend)
+%attribute(carto::SkyOptions, float, FogBlend, getFogBlend, setFogBlend)
 %attribute(carto::SkyOptions, bool, SunDiscEnabled, isSunDiscEnabled, setSunDiscEnabled)
 %attributestring(carto::SkyOptions, std::string, ShaderSource, getShaderSource, setShaderSource)
 

--- a/all/native/components/SkyOptions.cpp
+++ b/all/native/components/SkyOptions.cpp
@@ -10,6 +10,7 @@ namespace carto {
         _horizonColorARGB(Color(171, 206, 236, 255).getARGB()),
         _groundColorARGB(Color(171, 206, 236, 255).getARGB()),
         _horizonBlend(12.0f),
+        _fogBlend(25.0f),
         _sunDiscEnabled(true),
         _shaderSource(),
         _shaderSourceMutex(),
@@ -69,6 +70,17 @@ namespace carto {
         float clamped = std::max(0.0f, std::min(90.0f, degrees));
         if (_horizonBlend.exchange(clamped) != clamped) {
             notifyOptionChanged("HorizonBlend");
+        }
+    }
+
+    float SkyOptions::getFogBlend() const {
+        return _fogBlend.load();
+    }
+
+    void SkyOptions::setFogBlend(float degrees) {
+        float clamped = std::max(0.0f, std::min(90.0f, degrees));
+        if (_fogBlend.exchange(clamped) != clamped) {
+            notifyOptionChanged("FogBlend");
         }
     }
 

--- a/all/native/components/SkyOptions.cpp
+++ b/all/native/components/SkyOptions.cpp
@@ -10,7 +10,7 @@ namespace carto {
         _horizonColorARGB(Color(171, 206, 236, 255).getARGB()),
         _groundColorARGB(Color(171, 206, 236, 255).getARGB()),
         _horizonBlend(12.0f),
-        _fogBlend(25.0f),
+        _fogBlend(12.0f),
         _sunDiscEnabled(true),
         _shaderSource(),
         _shaderSourceMutex(),

--- a/all/native/components/SkyOptions.h
+++ b/all/native/components/SkyOptions.h
@@ -124,6 +124,20 @@ namespace carto {
         void setHorizonBlend(float degrees);
 
         /**
+         * Returns how far up the sky the terrain fog is blended in.
+         * @return The fog blend height in degrees above the horizon. The default is 25.
+         */
+        float getFogBlend() const;
+        /**
+         * Sets how far above the horizon, in degrees, the terrain fog colour fades out of the sky.
+         * The fog (TerrainOptions/style fog colour, lit by the sun) is strongest right at the
+         * horizon and gone by this angle, so the haze the ground fades into continues into the sky
+         * instead of ending in a band at the skyline. Zero leaves the sky alone.
+         * @param degrees The new fog blend height in degrees (clamped to 0..90).
+         */
+        void setFogBlend(float degrees);
+
+        /**
          * Returns whether the built-in shader draws a sun disc.
          * @return True if the sun disc is drawn. The default is true.
          */
@@ -168,6 +182,7 @@ namespace carto {
         std::atomic<int> _horizonColorARGB;
         std::atomic<int> _groundColorARGB;
         std::atomic<float> _horizonBlend;
+        std::atomic<float> _fogBlend;
         std::atomic<bool> _sunDiscEnabled;
 
         std::string _shaderSource;

--- a/all/native/components/SkyOptions.h
+++ b/all/native/components/SkyOptions.h
@@ -125,7 +125,7 @@ namespace carto {
 
         /**
          * Returns how far up the sky the terrain fog is blended in.
-         * @return The fog blend height in degrees above the horizon. The default is 25.
+         * @return The fog blend height in degrees above the horizon. The default is 12.
          */
         float getFogBlend() const;
         /**

--- a/all/native/components/StyleEnvironment.cpp
+++ b/all/native/components/StyleEnvironment.cpp
@@ -1,4 +1,5 @@
 #include "StyleEnvironment.h"
+#include "components/TerrainOptions.h"
 #include "components/LightOptions.h"
 #include "utils/Const.h"
 
@@ -97,6 +98,46 @@ namespace carto {
             lighting.shadowCasterMargin = *env.shadowCasterMargin;
         }
         return lighting;
+    }
+
+
+    ResolvedFog resolveFog(const std::shared_ptr<TerrainOptions>& terrainOptions, const StyleEnvironment& env, const ResolvedLighting& lighting) {
+        ResolvedFog fog;
+        if (terrainOptions) {
+            fog.color = terrainOptions->getFogColor();
+            fog.startDistance = terrainOptions->getFogStartDistance();
+            fog.distance = terrainOptions->getFogDistance();
+        }
+        if (env.fogColor) {
+            fog.color = *env.fogColor;
+        }
+        if (env.fogStartDistance) {
+            fog.startDistance = *env.fogStartDistance;
+        }
+        if (env.fogDistance) {
+            fog.distance = *env.fogDistance;
+        }
+
+        // Light the fog. Haze is lit air: at noon it is the bright band the reference renderers
+        // show at the horizon, at night it is a dark one, and near sunset it takes the sun's
+        // colour. The scale is the same light the ground gets (ambient plus the sun once it is
+        // above the horizon), so fog and terrain darken together instead of the fog floating over
+        // a black map. The tint is applied in proportion to how much of that light is direct sun.
+        if (lighting.terrainLightingEnabled && fog.color.getA() > 0) {
+            float sunUp = std::max(0.0f, std::min(1.0f, lighting.sunDir(2)));
+            float direct = std::max(0.0f, lighting.sunIntensity) * sunUp;
+            float light = std::max(0.0f, std::min(1.0f, std::max(0.0f, lighting.ambientIntensity) + direct));
+            float sunShare = direct > 0.0f ? std::min(1.0f, direct / std::max(1.0e-3f, light)) : 0.0f;
+            auto channel = [&](int value, int sunValue) {
+                float tint = 1.0f + sunShare * (sunValue / 255.0f - 1.0f);
+                return static_cast<unsigned char>(std::max(0.0f, std::min(255.0f, value * light * tint)));
+            };
+            fog.color = Color(channel(fog.color.getR(), lighting.sunColor.getR()),
+                              channel(fog.color.getG(), lighting.sunColor.getG()),
+                              channel(fog.color.getB(), lighting.sunColor.getB()),
+                              fog.color.getA());
+        }
+        return fog;
     }
 
 }

--- a/all/native/components/StyleEnvironment.h
+++ b/all/native/components/StyleEnvironment.h
@@ -15,6 +15,7 @@
 #include <cglib/vec.h>
 
 namespace carto {
+    class TerrainOptions;
     class LightOptions;
 
     /**
@@ -75,6 +76,30 @@ namespace carto {
     };
 
     ResolvedLighting resolveLighting(const std::shared_ptr<LightOptions>& lightOptions, const StyleEnvironment& env);
+
+    /**
+     * The distance fog to actually render with: TerrainOptions, with every value the style
+     * defines substituted in, and the colour lit by the sun when terrain lighting is on.
+     * Distances are in meters, as in the API.
+     */
+    struct ResolvedFog {
+        Color color = Color(0, 0, 0, 0);
+        float startDistance = 0.0f;
+        float distance = 0.0f;
+
+        /**
+         * True when there is a fog to draw at all: a visible colour over a positive range.
+         */
+        bool active() const { return color.getA() > 0 && distance > startDistance; }
+    };
+
+    /**
+     * Resolves the fog and lights it: fog is air, so it is as bright as the light falling on it.
+     * Without this a fog tuned for daylight stays bright white through the night, floating over a
+     * dark map. Only applied when terrain lighting is on - otherwise there is no sun to speak of
+     * and the configured colour is used as-is.
+     */
+    ResolvedFog resolveFog(const std::shared_ptr<TerrainOptions>& terrainOptions, const StyleEnvironment& env, const ResolvedLighting& lighting);
 
 }
 

--- a/all/native/renderers/BackgroundRenderer.cpp
+++ b/all/native/renderers/BackgroundRenderer.cpp
@@ -1,6 +1,7 @@
 #include "BackgroundRenderer.h"
 #include "components/Layers.h"
 #include "components/Options.h"
+#include "components/StyleEnvironment.h"
 #include "components/TerrainOptions.h"
 #include "graphics/Color.h"
 #include "graphics/Bitmap.h"
@@ -186,15 +187,13 @@ namespace carto {
         if (enabled) {
             if (std::shared_ptr<TerrainOptions> terrainOptions = _options.getTerrainOptions()) {
                 if (terrainOptions->isEnabled()) {
-                    fogColor = terrainOptions->getFogColor();
-                    float fogStartDistance = terrainOptions->getFogStartDistance();
-                    float fogDistance = terrainOptions->getFogDistance();
-                    if (fogColor.getA() > 0 && fogDistance > fogStartDistance) {
+                    ResolvedLighting lighting = resolveLighting(_options.getLightOptions(), StyleEnvironment());
+                    ResolvedFog fog = resolveFog(terrainOptions, StyleEnvironment(), lighting);
+                    if (fog.active()) {
+                        fogColor = fog.color;
                         double metersToInternal = static_cast<double>(Const::WORLD_SIZE) / Const::EARTH_CIRCUMFERENCE;
-                        startDistance = static_cast<float>(fogStartDistance * metersToInternal);
-                        invRange = static_cast<float>(1.0 / std::max(1.0e-9, (fogDistance - fogStartDistance) * metersToInternal));
-                    } else {
-                        fogColor = Color(0, 0, 0, 0);
+                        startDistance = static_cast<float>(fog.startDistance * metersToInternal);
+                        invRange = static_cast<float>(1.0 / std::max(1.0e-9, (fog.distance - fog.startDistance) * metersToInternal));
                     }
                 }
             }

--- a/all/native/renderers/SkyRenderer.cpp
+++ b/all/native/renderers/SkyRenderer.cpp
@@ -2,6 +2,7 @@
 #include "components/Options.h"
 #include "components/LightOptions.h"
 #include "components/SkyOptions.h"
+#include "components/StyleEnvironment.h"
 #include "components/TerrainOptions.h"
 #include "graphics/ViewState.h"
 #include "renderers/utils/GLResourceManager.h"
@@ -31,6 +32,8 @@ namespace carto {
         _u_zoom(-1),
         _u_cameraHeight(-1),
         _u_resolution(-1),
+        _u_fogColor(-1),
+        _u_fogBlend(-1),
         _startTime(std::chrono::steady_clock::now()),
         _glResourceManager(),
         _options(options)
@@ -97,6 +100,8 @@ namespace carto {
         _u_zoom = glGetUniformLocation(progId, "u_zoom");
         _u_cameraHeight = glGetUniformLocation(progId, "u_cameraHeight");
         _u_resolution = glGetUniformLocation(progId, "u_resolution");
+        _u_fogColor = glGetUniformLocation(progId, "u_fogColor");
+        _u_fogBlend = glGetUniformLocation(progId, "u_fogBlend");
         return true;
     }
 
@@ -128,6 +133,12 @@ namespace carto {
             sunColor = lightOptions->getSunColor();
             sunIntensity = lightOptions->getSunIntensity();
         }
+
+        // The terrain fog, resolved and lit exactly as the ground fog is, so the haze the map
+        // fades into carries on into the sky instead of stopping in a band at the skyline.
+        ResolvedLighting lighting = resolveLighting(lightOptions, StyleEnvironment());
+        ResolvedFog fog = resolveFog(_options.getTerrainOptions(), StyleEnvironment(), lighting);
+        float fogBlend = fog.active() ? static_cast<float>(skyOptions->getFogBlend() * Const::DEG_TO_RAD) : 0.0f;
 
         Color skyColor = skyOptions->getSkyColor();
         Color horizonColor = skyOptions->getHorizonColor();
@@ -174,6 +185,12 @@ namespace carto {
         }
         if (_u_resolution >= 0) {
             glUniform2f(_u_resolution, static_cast<float>(viewState.getWidth()), static_cast<float>(viewState.getHeight()));
+        }
+        if (_u_fogColor >= 0) {
+            glUniform4f(_u_fogColor, fog.color.getR() / 255.0f, fog.color.getG() / 255.0f, fog.color.getB() / 255.0f, fog.color.getA() / 255.0f);
+        }
+        if (_u_fogBlend >= 0) {
+            glUniform1f(_u_fogBlend, fogBlend);
         }
 
         glDisable(GL_CULL_FACE);
@@ -223,6 +240,19 @@ namespace carto {
         uniform float u_zoom;
         uniform float u_cameraHeight;
         uniform vec2 u_resolution;
+        uniform vec4 u_fogColor;  // the terrain fog, already lit by the sun; a = strength at the horizon
+        uniform float u_fogBlend; // elevation angle (radians) where the fog has faded out of the sky; 0 = no fog
+
+        // The sky's share of the terrain fog for a view ray: full at the horizon, gone by
+        // u_fogBlend. Squared so the haze hugs the horizon instead of greying the whole sky.
+        float fogAmount(vec3 rayDir) {
+            if (u_fogBlend <= 0.0) {
+                return 0.0;
+            }
+            float elevation = asin(clamp(normalize(rayDir).z, -1.0, 1.0));
+            float t = clamp(1.0 - max(elevation, 0.0) / u_fogBlend, 0.0, 1.0);
+            return t * t * u_fogColor.a;
+        }
     )GLSL";
 
     // The default appearance: a horizon-to-zenith gradient, a broad glow around the sun and a
@@ -236,6 +266,9 @@ namespace carto {
             }
             float t = u_horizonBlend > 0.0 ? clamp(elevation / u_horizonBlend, 0.0, 1.0) : 1.0;
             vec4 color = mix(u_horizonColor, u_skyColor, t);
+            // Blend the ground fog into the sky above the horizon, so the two meet in a gradient
+            // rather than at a hard skyline.
+            color.rgb = mix(color.rgb, u_fogColor.rgb, fogAmount(rayDir));
             if (u_sunDisc > 0.5) {
                 // Chord length between the two unit vectors, which is the angle in radians to
                 // within 1% over the few degrees that matter here - and unlike acos/pow it keeps

--- a/all/native/renderers/SkyRenderer.cpp
+++ b/all/native/renderers/SkyRenderer.cpp
@@ -244,14 +244,15 @@ namespace carto {
         uniform float u_fogBlend; // elevation angle (radians) where the fog has faded out of the sky; 0 = no fog
 
         // The sky's share of the terrain fog for a view ray: full at the horizon, gone by
-        // u_fogBlend. Squared so the haze hugs the horizon instead of greying the whole sky.
+        // u_fogBlend. Cubed so the haze hugs the horizon and clears quickly with height instead
+        // of greying half the sky.
         float fogAmount(vec3 rayDir) {
             if (u_fogBlend <= 0.0) {
                 return 0.0;
             }
             float elevation = asin(clamp(normalize(rayDir).z, -1.0, 1.0));
             float t = clamp(1.0 - max(elevation, 0.0) / u_fogBlend, 0.0, 1.0);
-            return t * t * u_fogColor.a;
+            return t * t * t * u_fogColor.a;
         }
     )GLSL";
 

--- a/all/native/renderers/SkyRenderer.h
+++ b/all/native/renderers/SkyRenderer.h
@@ -69,6 +69,8 @@ namespace carto {
         GLint _u_zoom;
         GLint _u_cameraHeight;
         GLint _u_resolution;
+        GLint _u_fogColor;
+        GLint _u_fogBlend;
 
         std::chrono::steady_clock::time_point _startTime;
 

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -558,26 +558,14 @@ namespace carto {
                 terrainLighting.ambientIntensity = lighting.ambientIntensity;
             }
 
-            // Distance fog. Metric in the API and in the style, internal units in the renderer:
-            // the conversion is the equator one, the same the shadow distance uses.
-            Color fogColor = _styleEnvironment.fogColor ? *_styleEnvironment.fogColor : Color(0, 0, 0, 0);
-            float fogStartDistance = _styleEnvironment.fogStartDistance ? *_styleEnvironment.fogStartDistance : 0.0f;
-            float fogDistance = _styleEnvironment.fogDistance ? *_styleEnvironment.fogDistance : 0.0f;
-            if (std::shared_ptr<TerrainOptions> terrainOptions = options->getTerrainOptions()) {
-                if (!_styleEnvironment.fogColor) {
-                    fogColor = terrainOptions->getFogColor();
-                }
-                if (!_styleEnvironment.fogStartDistance) {
-                    fogStartDistance = terrainOptions->getFogStartDistance();
-                }
-                if (!_styleEnvironment.fogDistance) {
-                    fogDistance = terrainOptions->getFogDistance();
-                }
-            }
+            // Distance fog, lit by the same sun as the ground (see resolveFog). Metric in the API
+            // and in the style, internal units in the renderer: the conversion is the equator one,
+            // the same the shadow distance uses.
+            ResolvedFog fog = resolveFog(options->getTerrainOptions(), _styleEnvironment, lighting);
             double metersToInternal = static_cast<double>(Const::WORLD_SIZE) / Const::EARTH_CIRCUMFERENCE;
-            tileRenderer->setFog(vt::Color(fogColor.getR() / 255.0f, fogColor.getG() / 255.0f, fogColor.getB() / 255.0f, fogColor.getA() / 255.0f),
-                                 static_cast<float>(fogStartDistance * metersToInternal),
-                                 static_cast<float>(fogDistance * metersToInternal));
+            tileRenderer->setFog(vt::Color(fog.color.getR() / 255.0f, fog.color.getG() / 255.0f, fog.color.getB() / 255.0f, fog.color.getA() / 255.0f),
+                                 static_cast<float>(fog.startDistance * metersToInternal),
+                                 static_cast<float>(fog.distance * metersToInternal));
         }
         tileRenderer->setTerrainLighting(terrainLighting);
         tileRenderer->setTerrainDepthWrite(terrainMode && _terrainDepthWriteMode);


### PR DESCRIPTION
Stacked on #39 (`fix/terrain-view-distance-fog`) — merge that one first, then this base retargets to master.

The distance fog was a fixed colour: a haze tuned for daylight stayed bright white through the night, floating over a dark map, and it ended in a hard band at the skyline because the sky above it knew nothing about it.

## Fog is lit by the sun

`resolveFog()` (StyleEnvironment) now resolves the fog for every renderer in one place — TerrainOptions with the style's Map-block values substituted in — and lights it: fog is air, so its colour is scaled by the same light the ground gets (ambient plus the sun once it is above the horizon) and tinted towards the sun colour in proportion to how much of that light is direct. Night fog goes dark, midday fog stays as configured, a low sun tints it warm. Only applied when terrain lighting is on; otherwise the configured colour is used as-is. TileRenderer's own fog resolution is replaced by it, so tile content, background plane and sky all use one fog.

## The sky picks the fog up

`SkyRenderer` passes it as `u_fogColor` and blends it into the sky from the horizon upward, fading out by `SkyOptions.FogBlend` degrees (new property, default 12, cubic falloff so the haze hugs the horizon). The built-in sky shader applies it, and **custom sky shaders get both the uniform and a `fogAmount(rayDir)` helper** in the wrapper, so an app-provided sky can match the ground haze instead of meeting it at a hard skyline.

## Verification

Emulator over a day cycle (Chartreuse camera, terrain lighting plus the day-cycle demo sky): at night the fog is dark and the horizon fades into the star field, at midday it is the pale band the reference renderers show, at dusk it dims and warms — terrain and sky meet in a gradient at every hour.

Note: `SkyOptions.FogBlend` is a new SWIG attribute; the wrappers were regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)