### PR TITLE
fix(terrain): drop drape textures baked from a previous layer stack

### DIFF
--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1299,6 +1299,17 @@ namespace carto {
                         _terrainDrapeCache = std::make_unique<TerrainDrapeCache>();
                     }
                     _terrainDrapeCache->setResolution(terrainOptions->getDrapeResolution());
+                    // WHICH layers bake, not what is in them. Switching the base map's style
+                    // builds a new layer object, so the cached textures - including the ones held
+                    // off screen for panning - are pictures of the previous style. They are only
+                    // ever noticed through the per-tile fingerprint, which is re-baked at one tile
+                    // per frame, so panning kept bringing the old style back a tile at a time.
+                    std::size_t stackSignature = 0;
+                    for (const std::shared_ptr<TileLayer>& tileLayer : drapeLayers) {
+                        std::size_t layerHash = static_cast<std::size_t>(reinterpret_cast<std::uintptr_t>(tileLayer.get()));
+                        stackSignature ^= layerHash + 0x9e3779b9 + (stackSignature << 6) + (stackSignature >> 2);
+                    }
+                    _terrainDrapeCache->setStackSignature(stackSignature);
 
                     // Every participating layer's render tiles must exist before any of them
                     // bakes, so start their frames first.
@@ -1573,8 +1584,15 @@ namespace carto {
                     // second, which reads as the hillshade layer flashing on top of everything.
                     static const int DRAPE_BAKE_BUDGET_PARTIAL = 6;
                     static const int DRAPE_BAKE_BUDGET_STALE = 1;
+                    // A tile baked from a layer stack that no longer exists (the base map's style
+                    // was switched, a layer was turned off) shows the PREVIOUS MAP. One per frame
+                    // is the budget for a tile that is merely out of date; here the picture is
+                    // wrong, and since the cache keeps a generation of tiles alive off screen,
+                    // panning kept walking back over them and flashing the old style tile by tile.
+                    // Cleared at the blank-tile rate instead: a couple of frames, like a zoom.
+                    static const int DRAPE_BAKE_BUDGET_RESTACK = 8;
                     struct BakeRequest { vt::TileId tileId; std::size_t fingerprint; std::size_t drapedIndex; };
-                    std::vector<BakeRequest> blankTiles, standInTiles, partialTiles, staleTiles;
+                    std::vector<BakeRequest> blankTiles, standInTiles, partialTiles, staleTiles, restackTiles;
 
                     // A tile whose DEM has not been decoded yet is drawn FLAT, at sea level.
                     // Next to tiles that ARE displaced that is a slab of map hanging in space
@@ -1788,7 +1806,9 @@ namespace carto {
                             continue;
                         }
                         BakeRequest request { it->first, it->second, drapedIndex };
-                        if (baked && !complete) {
+                        if (baked && _terrainDrapeCache->isStale(it->first, 0)) {
+                            restackTiles.push_back(request);     // shows the previous layer stack
+                        } else if (baked && !complete) {
                             partialTiles.push_back(request);     // shows part of the stack: a layer is simply absent
                         } else if (baked) {
                             staleTiles.push_back(request);       // shows its own, older, picture
@@ -1827,6 +1847,10 @@ namespace carto {
                     };
                     int budget = DRAPE_BAKE_BUDGET_BLANK;
                     for (auto it = blankTiles.begin(); it != blankTiles.end() && budget > 0; it++, budget--) {
+                        bakeTile(*it);
+                    }
+                    budget = DRAPE_BAKE_BUDGET_RESTACK;
+                    for (auto it = restackTiles.begin(); it != restackTiles.end() && budget > 0; it++, budget--) {
                         bakeTile(*it);
                     }
                     budget = DRAPE_BAKE_BUDGET_STANDIN;

--- a/all/native/renderers/utils/TerrainDrapeCache.cpp
+++ b/all/native/renderers/utils/TerrainDrapeCache.cpp
@@ -27,6 +27,7 @@ namespace carto {
 
     TerrainDrapeCache::TerrainDrapeCache() :
         _resolution(1024),
+        _stackSignature(0),
         _frameBuffer(0),
         _entries(),
         _texturePool(),
@@ -62,6 +63,28 @@ namespace carto {
         _texturePool.clear();
     }
 
+    void TerrainDrapeCache::setStackSignature(std::size_t signature) {
+        if (signature == _stackSignature) {
+            return;
+        }
+        _stackSignature = signature;
+        // The textures are kept: a stale picture of the same ground is a better thing to show for
+        // the two or three frames the re-bake takes than the flat fill dropping them would leave.
+        // They just stop being trusted - re-baked with the blank-tile budget, and never copied
+        // into another tile.
+        for (auto it = _entries.begin(); it != _entries.end(); it++) {
+            it->second.stale = it->second.baked || it->second.seeded;
+            // A seed is a copy of other tiles' pictures, so a seed made from the old stack is old
+            // content too, and unlike a bake it has no fingerprint to notice that with.
+            it->second.seeded = false;
+        }
+    }
+
+    bool TerrainDrapeCache::isStale(const vt::TileId& tileId, int stack) const {
+        auto it = _entries.find(Key { tileId, stack });
+        return it != _entries.end() && it->second.stale;
+    }
+
     void TerrainDrapeCache::beginFrame() {
         _frameCounter++;
         for (auto it = _entries.begin(); it != _entries.end(); it++) {
@@ -94,12 +117,16 @@ namespace carto {
             entry.texture = createTexture();
             entry.baked = false;
             entry.seeded = false;
+            entry.stale = false;
         }
         entry.used = true;
         entry.lastUsedFrame = _frameCounter;
         // A changed fingerprint means the layers covering this tile changed - a style layer
         // finished loading, or a proxy was replaced by its native tile - so the texture is stale.
-        needsBake = !entry.baked || entry.fingerprint != fingerprint;
+        // Stale means baked from a stack that no longer exists. The fingerprint does not always
+        // catch that: dropping a layer leaves the remaining layers' content - and their hashes -
+        // unchanged for tiles the dropped layer had nothing in.
+        needsBake = !entry.baked || entry.stale || entry.fingerprint != fingerprint;
         // A seeded texture is not a bake, but it does show this tile's ground - sampling it is
         // right, and it is the difference between a stand-in and a flat fill.
         hasContent = entry.baked || entry.seeded;
@@ -113,6 +140,7 @@ namespace carto {
             it->second.layerMask = layerMask;
             it->second.baked = true;
             it->second.seeded = false;
+            it->second.stale = false;
         }
     }
 
@@ -138,7 +166,10 @@ namespace carto {
 
     unsigned int TerrainDrapeCache::findBaked(const vt::TileId& tileId, int stack) {
         auto it = _entries.find(Key { tileId, stack });
-        if (it == _entries.end() || !it->second.baked) {
+        // A stale entry must never be a source: seeding or standing in with it copies the previous
+        // stack's picture into tiles that never had it, and a seed carries no fingerprint, so the
+        // old content then survives every check that would have replaced it.
+        if (it == _entries.end() || !it->second.baked || it->second.stale) {
             return 0;
         }
         // Standing in for a tile that has no texture of its own IS use: without this the entry

--- a/all/native/renderers/utils/TerrainDrapeCache.h
+++ b/all/native/renderers/utils/TerrainDrapeCache.h
@@ -42,6 +42,22 @@ namespace carto {
         void setResolution(int resolution);
 
         /**
+         * Identifies the set of layers the textures are baked from. A tile's fingerprint only
+         * covers the CONTENT of the layers that are present, so replacing a layer (switching the
+         * base map's style rebuilds the layer) or removing one leaves every cached texture holding
+         * a picture of a stack that no longer exists - and those textures stay cached, off screen,
+         * until panning brings them back. That is the old style flashing back tile by tile.
+         * Changing the signature marks every entry stale: it may still be shown (it is better than
+         * a flat fill) but it is re-baked with priority and never seeds or stands in for another
+         * tile, so old content cannot spread into tiles that never had it.
+         */
+        void setStackSignature(std::size_t signature);
+        /**
+         * Whether this tile's texture was baked from an earlier layer stack.
+         */
+        bool isStale(const vt::TileId& tileId, int stack) const;
+
+        /**
          * Starts a frame. Tiles not acquired before endFrame() are released back to the pool.
          */
         void beginFrame();
@@ -116,6 +132,7 @@ namespace carto {
             std::size_t layerMask = 0;
             bool baked = false;
             bool seeded = false;
+            bool stale = false; // baked from an earlier layer stack
             bool used = false;
             unsigned int lastUsedFrame = 0;
         };
@@ -126,6 +143,7 @@ namespace carto {
         static const std::size_t MAX_ENTRIES;         // cached tiles kept alive across frames
 
         int _resolution;
+        std::size_t _stackSignature;
         unsigned int _frameBuffer;
         std::map<Key, Entry> _entries;
         std::vector<unsigned int> _texturePool;


### PR DESCRIPTION
## Problem

Start the demo on the ASSETS style (terrain + hillshade + satellite), switch to ZIP. The map updates, but panning keeps flashing tiles rendered with the *old* style.

## Cause

`TerrainDrapeCache` deliberately keeps ~160 baked tile textures alive off screen so panning back over that ground is a cache hit. Switching the style builds a **new** base layer object, but those cached textures still hold the previous style's picture.

Nothing told the cache the stack had changed:

- the only staleness signal is the per-tile fingerprint, and stale tiles are re-baked at `DRAPE_BAKE_BUDGET_STALE = 1` per frame;
- `findBaked()` handed those textures out as **seeds** and **stand-ins** for tiles that had never been baked with them, and a seed carries no fingerprint - so the old content spread and survived.

Panning therefore walked back over the previous generation and repainted the old style a tile at a time. Turning a layer off has the same shape: its content stays baked into every cached texture.

## Fix

Track *which* layers the textures were baked from, not only what is in them.

- `TerrainDrapeCache::setStackSignature()` + a per-entry `stale` flag. A changed signature marks every entry stale (textures are kept - a stale picture of the right ground beats a flat fill for the frame or two a re-bake takes) and drops seeds, which are copies of the old stack with no fingerprint of their own.
- Stale entries force `needsBake`, and `findBaked()` refuses them, so old content can no longer seed or stand in for a tile that never had it.
- `MapRenderer` computes the signature from the drape-layer list each frame and gives stale-stack tiles their own bake bucket at the blank-tile budget (8/frame instead of 1), so the cover clears in a couple of frames, like a zoom.

## Testing

Confirmed fixed on device by @farfromrefug (style switch ASSETS -> ZIP, then panning).

Emulator: post-fix run is clean at 45.2442/5.7606 z13.6 t45 - style switch, then repeated pans and far-pan-and-back show no ASSETS content. Note the pre-fix build did **not** reproduce the flashing on the emulator (it re-bakes fast enough there), so the device run is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)