### PR TITLE
feat(vectortiles): load fonts from the system when the style does not package them

### DIFF
--- a/all/native/utils/SystemFontUtils.h
+++ b/all/native/utils/SystemFontUtils.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_SYSTEMFONTUTILS_H_
+#define _CARTO_SYSTEMFONTUTILS_H_
+
+#include <memory>
+#include <string>
+
+namespace carto {
+    class BinaryData;
+
+    /**
+     * Access to the fonts installed on the device. Used by vector tile decoders to resolve
+     * font names that are not part of the style asset package.
+     */
+    class SystemFontUtils {
+    public:
+        /**
+         * Loads the system font best matching the given name.
+         * Generic names ("Arial", "Helvetica", "sans-serif", "serif", "monospace", ...) are mapped
+         * to the closest font of the platform, and a name without any match falls back to the
+         * default system font.
+         * @param name The requested font name, optionally followed by a style ("Arial Bold").
+         * @return The font file data or null if the platform has no usable font at all.
+         */
+        static std::shared_ptr<BinaryData> LoadFont(const std::string& name);
+
+    private:
+        SystemFontUtils();
+    };
+
+}
+
+#endif

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -24,6 +24,7 @@
 #include "vectortiles/utils/CartoCSSAssetLoader.h"
 #include "utils/AssetPackage.h"
 #include "utils/FileUtils.h"
+#include "utils/SystemFontUtils.h"
 #include "utils/Const.h"
 #include "utils/Log.h"
 
@@ -604,15 +605,7 @@ namespace carto {
             auto strokeMap = std::make_shared<vt::StrokeMap>(STROKEMAP_SIZE, STROKEMAP_SIZE);
             auto glyphMap = std::make_shared<vt::GlyphMap>(GLYPHMAP_SIZE, GLYPHMAP_SIZE);
 
-            std::shared_ptr<const vt::Font> fallbackFont;
-            for (auto it = _fallbackFonts.rbegin(); it != _fallbackFonts.rend(); it++) {
-                std::shared_ptr<BinaryData> fontData = *it;
-                std::string fontName = fontManager->loadFontData(*fontData->getDataPtr());
-                fallbackFont = fontManager->getFont(fontName, fallbackFont);
-            }
-            mvt::SymbolizerContext::Settings settings(DEFAULT_TILE_SIZE, std::make_shared<std::map<std::string, mvt::Value>>(), fallbackFont);
-            symbolizerContext = std::make_shared<mvt::SymbolizerContext>(bitmapManager, fontManager, strokeMap, glyphMap, settings);
-
+            // Register the fonts of the style first, they take precedence over the system fonts
             if (assetPackage) {
                 std::string fontPrefix = map->getSettings().fontDirectory;
                 fontPrefix = FileUtils::NormalizePath(FileUtils::GetFilePath(styleAssetName) + fontPrefix + "/");
@@ -625,6 +618,27 @@ namespace carto {
                     }
                 }
             }
+
+            // Fonts the style asks for but does not provide are loaded from the system
+            fontManager->setFontDataLoader([](const std::string& name) {
+                if (std::shared_ptr<BinaryData> fontData = SystemFontUtils::LoadFont(name)) {
+                    return *fontData->getDataPtr();
+                }
+                return std::vector<unsigned char>();
+            });
+
+            std::shared_ptr<const vt::Font> fallbackFont;
+            for (auto it = _fallbackFonts.rbegin(); it != _fallbackFonts.rend(); it++) {
+                std::shared_ptr<BinaryData> fontData = *it;
+                std::string fontName = fontManager->loadFontData(*fontData->getDataPtr());
+                fallbackFont = fontManager->getFont(fontName, fallbackFont);
+            }
+            if (!fallbackFont) {
+                // Styles without any font (inline CartoCSS, for example) still need a font for their labels
+                fallbackFont = fontManager->getFont(DEFAULT_FALLBACK_FONT_NAME, fallbackFont);
+            }
+            mvt::SymbolizerContext::Settings settings(DEFAULT_TILE_SIZE, std::make_shared<std::map<std::string, mvt::Value>>(), fallbackFont);
+            symbolizerContext = std::make_shared<mvt::SymbolizerContext>(bitmapManager, fontManager, strokeMap, glyphMap, settings);
         }
 
         auto parameterValueMap = std::make_shared<std::map<std::string, mvt::Value>>();
@@ -667,6 +681,7 @@ namespace carto {
         _cachedFeatureDecoder.second.reset();
     }
 
+    const std::string MBVectorTileDecoder::DEFAULT_FALLBACK_FONT_NAME = "Arial";
     const int MBVectorTileDecoder::DEFAULT_TILE_SIZE = 256;
     const int MBVectorTileDecoder::STROKEMAP_SIZE = 512;
     const int MBVectorTileDecoder::GLYPHMAP_SIZE = 2048;

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -201,6 +201,7 @@ namespace carto {
         bool setStyleParameterInternal(const std::string& param, const std::string& value);
         void updateSymbolizer();
 
+        static const std::string DEFAULT_FALLBACK_FONT_NAME;
         static const int DEFAULT_TILE_SIZE;
         static const int STROKEMAP_SIZE;
         static const int GLYPHMAP_SIZE;

--- a/android/native/utils/SystemFontUtils.cpp
+++ b/android/native/utils/SystemFontUtils.cpp
@@ -1,0 +1,190 @@
+#include "utils/SystemFontUtils.h"
+#include "core/BinaryData.h"
+#include "utils/Log.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <vector>
+
+#include <dirent.h>
+
+namespace carto {
+
+    namespace {
+
+        const char* const FONT_DIRECTORIES[] = { "/system/fonts", "/product/fonts", "/system/font", "/data/fonts", nullptr };
+
+        // Generic/foreign font names mapped to the Android font families, in preference order
+        const std::pair<const char*, const char*> FONT_ALIASES[] = {
+            { "arial",          "roboto notosans droidsans" },
+            { "helvetica",      "roboto notosans droidsans" },
+            { "helveticaneue",  "roboto notosans droidsans" },
+            { "verdana",        "roboto notosans droidsans" },
+            { "tahoma",         "roboto notosans droidsans" },
+            { "segoeui",        "roboto notosans droidsans" },
+            { "sansserif",      "roboto notosans droidsans" },
+            { "sans",           "roboto notosans droidsans" },
+            { "timesnewroman",  "notoserif droidserif tinos" },
+            { "times",          "notoserif droidserif tinos" },
+            { "georgia",        "notoserif droidserif tinos" },
+            { "serif",          "notoserif droidserif tinos" },
+            { "couriernew",     "droidsansmono notosansmono cousine" },
+            { "courier",        "droidsansmono notosansmono cousine" },
+            { "consolas",       "droidsansmono notosansmono cousine" },
+            { "monospace",      "droidsansmono notosansmono cousine" },
+            { "mono",           "droidsansmono notosansmono cousine" },
+            { nullptr, nullptr }
+        };
+
+        const char* const STYLE_SUFFIXES[] = { "bolditalic", "boldoblique", "bold", "italic", "oblique", "regular", "book", nullptr };
+
+        const char* const DEFAULT_FONTS[] = { "robotoregular", "notosansregular", "droidsans", "robotobold", nullptr };
+
+        std::string normalizeFontName(const std::string& name) {
+            std::string normalized;
+            for (char c : name) {
+                if (std::isalnum(static_cast<unsigned char>(c))) {
+                    normalized.append(1, static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+                }
+            }
+            return normalized;
+        }
+
+        // Maps normalized font names to font files. Built once, the set of installed fonts is fixed.
+        const std::map<std::string, std::string>& getSystemFontMap() {
+            static std::mutex mutex;
+            static std::map<std::string, std::string> fontMap;
+            static bool initialized = false;
+
+            std::lock_guard<std::mutex> lock(mutex);
+            if (!initialized) {
+                initialized = true;
+                for (int i = 0; FONT_DIRECTORIES[i]; i++) {
+                    DIR* dir = opendir(FONT_DIRECTORIES[i]);
+                    if (!dir) {
+                        continue;
+                    }
+                    while (struct dirent* entry = readdir(dir)) {
+                        std::string fileName = entry->d_name;
+                        std::size_t extPos = fileName.rfind('.');
+                        if (extPos == std::string::npos) {
+                            continue;
+                        }
+                        std::string ext = normalizeFontName(fileName.substr(extPos));
+                        if (ext != "ttf" && ext != "otf" && ext != "ttc") {
+                            continue;
+                        }
+                        fontMap.emplace(normalizeFontName(fileName.substr(0, extPos)), std::string(FONT_DIRECTORIES[i]) + "/" + fileName);
+                    }
+                    closedir(dir);
+                }
+                Log::Infof("SystemFontUtils: found %d system fonts", static_cast<int>(fontMap.size()));
+            }
+            return fontMap;
+        }
+
+        std::string findFontFile(const std::map<std::string, std::string>& fontMap, const std::string& normalizedName) {
+            if (normalizedName.empty()) {
+                return std::string();
+            }
+
+            auto it = fontMap.find(normalizedName);
+            if (it != fontMap.end()) {
+                return it->second;
+            }
+            it = fontMap.find(normalizedName + "regular");
+            if (it != fontMap.end()) {
+                return it->second;
+            }
+
+            // Accept a variant of the family ('roboto' -> 'robotomedium'), preferring the shortest name
+            for (auto it2 = fontMap.lower_bound(normalizedName); it2 != fontMap.end(); it2++) {
+                if (it2->first.compare(0, normalizedName.size(), normalizedName) != 0) {
+                    break;
+                }
+                return it2->second;
+            }
+            return std::string();
+        }
+
+        std::string resolveFontFile(const std::string& name) {
+            const std::map<std::string, std::string>& fontMap = getSystemFontMap();
+            std::string normalizedName = normalizeFontName(name);
+
+            std::string fileName = findFontFile(fontMap, normalizedName);
+            if (!fileName.empty()) {
+                return fileName;
+            }
+
+            // Split the trailing style ('arialbold' -> 'arial' + 'bold') and try the aliases of the family
+            std::string family = normalizedName;
+            std::string style;
+            for (int i = 0; STYLE_SUFFIXES[i]; i++) {
+                std::string suffix = STYLE_SUFFIXES[i];
+                if (normalizedName.size() > suffix.size() && normalizedName.compare(normalizedName.size() - suffix.size(), suffix.size(), suffix) == 0) {
+                    family = normalizedName.substr(0, normalizedName.size() - suffix.size());
+                    style = suffix;
+                    break;
+                }
+            }
+            for (int i = 0; FONT_ALIASES[i].first; i++) {
+                if (family != FONT_ALIASES[i].first) {
+                    continue;
+                }
+                std::string candidates = FONT_ALIASES[i].second;
+                for (std::size_t pos = 0; pos < candidates.size(); ) {
+                    std::size_t spacePos = candidates.find(' ', pos);
+                    std::string candidate = candidates.substr(pos, spacePos == std::string::npos ? std::string::npos : spacePos - pos);
+                    pos = (spacePos == std::string::npos ? candidates.size() : spacePos + 1);
+
+                    fileName = findFontFile(fontMap, candidate + style);
+                    if (fileName.empty()) {
+                        fileName = findFontFile(fontMap, candidate);
+                    }
+                    if (!fileName.empty()) {
+                        return fileName;
+                    }
+                }
+                break;
+            }
+
+            // Unresolved name, use the default system font
+            for (int i = 0; DEFAULT_FONTS[i]; i++) {
+                fileName = findFontFile(fontMap, DEFAULT_FONTS[i]);
+                if (!fileName.empty()) {
+                    return fileName;
+                }
+            }
+            return fontMap.empty() ? std::string() : fontMap.begin()->second;
+        }
+
+    }
+
+    std::shared_ptr<BinaryData> SystemFontUtils::LoadFont(const std::string& name) {
+        std::string fileName = resolveFontFile(name);
+        if (fileName.empty()) {
+            Log::Errorf("SystemFontUtils::LoadFont: No system font for %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+
+        std::ifstream file(fileName.c_str(), std::ios::binary);
+        if (!file) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to open %s", fileName.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+        std::vector<unsigned char> data((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+        if (data.empty()) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to read %s", fileName.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+        Log::Infof("SystemFontUtils::LoadFont: Using %s for %s", fileName.c_str(), name.c_str());
+        return std::make_shared<BinaryData>(std::move(data));
+    }
+
+    SystemFontUtils::SystemFontUtils() {
+    }
+
+}

--- a/ios/native/utils/SystemFontUtils.mm
+++ b/ios/native/utils/SystemFontUtils.mm
@@ -1,0 +1,45 @@
+#include "utils/SystemFontUtils.h"
+#include "core/BinaryData.h"
+#include "utils/CFUniquePtr.h"
+#include "utils/Log.h"
+
+#import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
+
+namespace carto {
+
+    std::shared_ptr<BinaryData> SystemFontUtils::LoadFont(const std::string& name) {
+        NSString* nsName = [NSString stringWithUTF8String:name.c_str()];
+
+        // CoreText substitutes the default system font if the name does not match any installed font
+        CFUniquePtr<CTFontRef> font(CTFontCreateWithName((__bridge CFStringRef)nsName, 12.0f, NULL));
+        if (!font) {
+            Log::Errorf("SystemFontUtils::LoadFont: No system font for %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+
+        // Note: for a font collection (.ttc) this gives the file of the whole collection, the first face is used
+        CFUniquePtr<CFURLRef> fontURL(static_cast<CFURLRef>(CTFontCopyAttribute(font, kCTFontURLAttribute)));
+        if (!fontURL) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to resolve the file of %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+        NSString* filePath = [(__bridge NSURL*)fontURL.get() path];
+
+        NSData* fileData = [NSData dataWithContentsOfFile:filePath];
+        if (!fileData) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to read %s", [filePath UTF8String]);
+            return std::shared_ptr<BinaryData>();
+        }
+
+        std::vector<unsigned char> data;
+        const unsigned char* bytes = static_cast<const unsigned char*>([fileData bytes]);
+        data.assign(bytes, bytes + [fileData length]);
+        Log::Infof("SystemFontUtils::LoadFont: Using %s for %s", [filePath UTF8String], name.c_str());
+        return std::make_shared<BinaryData>(std::move(data));
+    }
+
+    SystemFontUtils::SystemFontUtils() {
+    }
+
+}

--- a/winphone/native/utils/SystemFontUtils.cpp
+++ b/winphone/native/utils/SystemFontUtils.cpp
@@ -1,0 +1,116 @@
+#include "utils/SystemFontUtils.h"
+#include "core/BinaryData.h"
+#include "utils/Log.h"
+
+#include <utf8.h>
+
+#include <string>
+#include <vector>
+
+#include <wrl/client.h>
+#include <dwrite.h>
+
+namespace carto {
+
+    std::shared_ptr<BinaryData> SystemFontUtils::LoadFont(const std::string& name) {
+        using Microsoft::WRL::ComPtr;
+
+        ComPtr<IDWriteFactory> factory;
+        HRESULT hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), reinterpret_cast<IUnknown**>(factory.GetAddressOf()));
+        if (FAILED(hr)) {
+            Log::Error("SystemFontUtils::LoadFont: Failed to create DirectWrite factory");
+            return std::shared_ptr<BinaryData>();
+        }
+
+        ComPtr<IDWriteFontCollection> fontCollection;
+        hr = factory->GetSystemFontCollection(fontCollection.GetAddressOf());
+        if (FAILED(hr)) {
+            Log::Error("SystemFontUtils::LoadFont: Failed to get the system font collection");
+            return std::shared_ptr<BinaryData>();
+        }
+
+        std::wstring wname;
+        utf8::utf8to16(name.begin(), name.end(), std::back_inserter(wname));
+        UINT32 familyIndex = 0;
+        BOOL familyExists = FALSE;
+        hr = fontCollection->FindFamilyName(wname.c_str(), &familyIndex, &familyExists);
+        if (FAILED(hr) || !familyExists) {
+            // Unresolved name, use the default system font
+            hr = fontCollection->FindFamilyName(L"Segoe UI", &familyIndex, &familyExists);
+        }
+        if (FAILED(hr) || !familyExists) {
+            Log::Errorf("SystemFontUtils::LoadFont: No system font for %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+
+        ComPtr<IDWriteFontFamily> fontFamily;
+        hr = fontCollection->GetFontFamily(familyIndex, fontFamily.GetAddressOf());
+        if (FAILED(hr)) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to get the font family of %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+
+        ComPtr<IDWriteFont> font;
+        hr = fontFamily->GetFirstMatchingFont(DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL, font.GetAddressOf());
+        if (FAILED(hr)) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to get the font of %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+
+        ComPtr<IDWriteFontFace> fontFace;
+        hr = font->CreateFontFace(fontFace.GetAddressOf());
+        if (FAILED(hr)) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to create the font face of %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+
+        // Only single-file fonts are supported, this is the case for all the system fonts
+        UINT32 fileCount = 1;
+        ComPtr<IDWriteFontFile> fontFile;
+        hr = fontFace->GetFiles(&fileCount, fontFile.GetAddressOf());
+        if (FAILED(hr) || fileCount != 1 || !fontFile) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to get the font file of %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+
+        const void* referenceKey = nullptr;
+        UINT32 referenceKeySize = 0;
+        ComPtr<IDWriteFontFileLoader> fontFileLoader;
+        ComPtr<IDWriteFontFileStream> fontFileStream;
+        hr = fontFile->GetReferenceKey(&referenceKey, &referenceKeySize);
+        if (SUCCEEDED(hr)) {
+            hr = fontFile->GetLoader(fontFileLoader.GetAddressOf());
+        }
+        if (SUCCEEDED(hr)) {
+            hr = fontFileLoader->CreateStreamFromKey(referenceKey, referenceKeySize, fontFileStream.GetAddressOf());
+        }
+        if (FAILED(hr)) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to open the font file of %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+
+        UINT64 fileSize = 0;
+        hr = fontFileStream->GetFileSize(&fileSize);
+        if (FAILED(hr) || fileSize == 0) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to get the size of the font file of %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+
+        const void* fragmentStart = nullptr;
+        void* fragmentContext = nullptr;
+        hr = fontFileStream->ReadFileFragment(&fragmentStart, 0, fileSize, &fragmentContext);
+        if (FAILED(hr)) {
+            Log::Errorf("SystemFontUtils::LoadFont: Failed to read the font file of %s", name.c_str());
+            return std::shared_ptr<BinaryData>();
+        }
+        const unsigned char* bytes = static_cast<const unsigned char*>(fragmentStart);
+        std::vector<unsigned char> data(bytes, bytes + static_cast<std::size_t>(fileSize));
+        fontFileStream->ReleaseFileFragment(fragmentContext);
+
+        return std::make_shared<BinaryData>(std::move(data));
+    }
+
+    SystemFontUtils::SystemFontUtils() {
+    }
+
+}


### PR DESCRIPTION
## Summary

- New `SystemFontUtils` with a platform implementation each: Android scans `/system/fonts` (plus `/product/fonts`, ...) and maps generic names (`Arial`, `Helvetica`, `sans-serif`, `serif`, `monospace`, ...) onto the families actually installed; iOS/macOS asks CoreText; UWP asks DirectWrite.
- `MBVectorTileDecoder` plugs it into the vt `FontManager` as the font-data loader, so a `face-name` the style does not ship is resolved from the device. Style fonts are registered first, so they keep precedence.
- A style with no font at all - an inline CartoCSS string, which cannot carry a font asset package - defaults to `Arial`, mapped to the platform font.

Before this, such a style failed every label with `Failed to load text font` and drew no text.

## Testing

`clang++ -fsyntax-only -std=c++17` clean on `MBVectorTileDecoder.cpp`, `android/native/utils/SystemFontUtils.cpp` and (`-x objective-c++ -fobjc-arc`) `ios/native/utils/SystemFontUtils.mm`.

`scripts/android-dev` gradle build + emulator run with `--es ui false --es style inline`: logs `SystemFontUtils::LoadFont: Using /system/fonts/Roboto-Regular.ttf for Arial`, glyphs shape (`len=20 glyphs=20`), labels render.

**Not compiled:** the UWP/DirectWrite path - no Windows toolchain here. Reviewed only.

## Depends on

https://github.com/farfromrefug/mobile-carto-libs/pull/17 - merge that first, then rebase this pointer bump onto the merged commit.