### PR TITLE
fix(labels): place the labels of composite child layers

### DIFF
--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -786,6 +786,31 @@ namespace carto {
         }
     }
 
+    void CompositeVectorTileLayer::collectLabelLayers(std::vector<std::shared_ptr<VectorTileLayer> >& labelLayers) {
+        // Same order as renderComposite: group 0 is this layer itself, then every draw item. The
+        // label culler grid accumulates across the layers it is given, so the order decides which
+        // labels win a slot. Without the children, every style layer after the first external slot
+        // (contours and every other vector slot included) is never culled - and a label that is
+        // never culled is never placed, so it never becomes visible.
+        VectorTileLayer::collectLabelLayers(labelLayers);
+        if (!isVisible()) {
+            return;
+        }
+
+        std::lock_guard<std::recursive_mutex> lock(_sourceMutex);
+        for (const DrawItem& item : _drawItems) {
+            std::shared_ptr<Layer> childLayer;
+            if (item.kind == DRAW_ITEM_VT_GROUP) {
+                childLayer = item.groupLayer;
+            } else if (const ExternalSource* source = findExternalSource(item.slot)) {
+                childLayer = source->childLayer;
+            }
+            if (childLayer) {
+                childLayer->collectLabelLayers(labelLayers);
+            }
+        }
+    }
+
     bool CompositeVectorTileLayer::renderComposite(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain) {
         auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
 

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -180,6 +180,7 @@ namespace carto {
         virtual void calculateRayIntersectedElements(const cglib::ray3<double>& ray, const ViewState& viewState, std::vector<RayIntersectedElement>& results) const;
 
         virtual void collectDrapeLayers(std::vector<std::shared_ptr<TileLayer> >& drapeLayers, const ViewState& viewState);
+        virtual void collectLabelLayers(std::vector<std::shared_ptr<VectorTileLayer> >& labelLayers);
 
         virtual bool onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState);
         virtual bool onDrawFrame3D(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState);

--- a/all/native/layers/Layer.cpp
+++ b/all/native/layers/Layer.cpp
@@ -227,6 +227,10 @@ namespace carto {
         // Non-tile layers (vector elements, NML models) are not draped.
     }
 
+    void Layer::collectLabelLayers(std::vector<std::shared_ptr<VectorTileLayer> >& labelLayers) {
+        // Only vector tile layers carry vt labels.
+    }
+
     bool Layer::onDrawFrame3D(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState) {
         return false;
     }

--- a/all/native/layers/Layer.h
+++ b/all/native/layers/Layer.h
@@ -33,6 +33,7 @@ namespace carto {
     class CancelableThreadPool;
     class RayIntersectedElement;
     class TileLayer;
+    class VectorTileLayer;
     class ViewState;
     
     /**
@@ -165,6 +166,7 @@ namespace carto {
         friend class BackgroundRenderer;
         friend class TouchHandler;
         friend class CullWorker; // asks the style how far the map should be drawn
+        friend class VTLabelPlacementWorker; // collects the layers whose labels take part in placement
         friend class CompositeVectorTileLayer; // forwards lifecycle/draw to owned child layers
     
         Layer();
@@ -201,6 +203,12 @@ namespace carto {
         // must append them too, or their content is neither baked into the drape texture nor told
         // that the ground is draped - it then paints itself a second time as displaced geometry.
         virtual void collectDrapeLayers(std::vector<std::shared_ptr<TileLayer> >& drapeLayers, const ViewState& viewState);
+
+        // Appends every vector tile layer whose labels must take part in label placement, in draw
+        // order. A layer that owns child layers (CompositeVectorTileLayer) must append them too:
+        // the label culler only sees what is collected here, and a label of an uncollected layer
+        // is never placed, so it never becomes visible.
+        virtual void collectLabelLayers(std::vector<std::shared_ptr<VectorTileLayer> >& labelLayers);
 
         virtual std::shared_ptr<Bitmap> getBackgroundBitmap(const ViewState& viewState) const;
         // The flat colour behind this layer's content. Normally it reaches the screen through the

--- a/all/native/layers/VectorTileLayer.cpp
+++ b/all/native/layers/VectorTileLayer.cpp
@@ -312,6 +312,10 @@ namespace carto {
         return tile;
     }
     
+    void VectorTileLayer::collectLabelLayers(std::vector<std::shared_ptr<VectorTileLayer> >& labelLayers) {
+        labelLayers.push_back(std::static_pointer_cast<VectorTileLayer>(shared_from_this()));
+    }
+
     void VectorTileLayer::calculateDrawData(const MapTile& visTile, const MapTile& closestTile, bool preloadingTile) {
         std::lock_guard<std::recursive_mutex> lock(_mutex);
 

--- a/all/native/layers/VectorTileLayer.h
+++ b/all/native/layers/VectorTileLayer.h
@@ -194,6 +194,8 @@ namespace carto {
         virtual std::shared_ptr<VectorTileDecoder::TileMap> getTileMap(long long tileId) const;
         virtual std::shared_ptr<vt::Tile> getPoleTile(int y) const;
 
+        virtual void collectLabelLayers(std::vector<std::shared_ptr<VectorTileLayer> >& labelLayers);
+
         virtual void calculateDrawData(const MapTile& visTile, const MapTile& closestTile, bool preloadingTile);
         virtual void refreshDrawData(const std::shared_ptr<CullState>& cullState, bool tilesChanged);
     

--- a/all/native/renderers/workers/VTLabelPlacementWorker.cpp
+++ b/all/native/renderers/workers/VTLabelPlacementWorker.cpp
@@ -101,29 +101,26 @@ namespace carto {
         ViewState viewState = mapRenderer->getViewState();
         std::vector<std::shared_ptr<Layer>> layers = mapRenderer->getLayers()->getAll();
 
+        // A composite layer draws its style-layer groups and its vector slots through internal
+        // child layers that are not in the layer list - they append themselves here, in draw order.
+        std::vector<std::shared_ptr<VectorTileLayer> > labelLayers;
+        for (const std::shared_ptr<Layer>& layer : layers) {
+            layer->collectLabelLayers(labelLayers);
+        }
+
         vt::LabelCuller culler(Const::WORLD_SIZE);
 
         bool reversedOrder = mapRenderer->getOptions()->isLayersLabelsProcessedInReverseOrder();
         bool changed = false;
         if (reversedOrder) {
-            for (auto it = layers.rbegin(); it != layers.rend(); it++) {
-                auto vectorTileLayer = std::dynamic_pointer_cast<VectorTileLayer>(*it);
-                if (!vectorTileLayer) {
-                    continue;
-                }
-
-                if (vectorTileLayer->_tileRenderer->cullLabels(culler, viewState)) {
+            for (auto it = labelLayers.rbegin(); it != labelLayers.rend(); it++) {
+                if ((*it)->_tileRenderer->cullLabels(culler, viewState)) {
                     changed = true;
                 }
             }
         } else {
-            for (auto it = layers.begin(); it != layers.end(); it++) {
-                auto vectorTileLayer = std::dynamic_pointer_cast<VectorTileLayer>(*it);
-                if (!vectorTileLayer) {
-                    continue;
-                }
-
-                if (vectorTileLayer->_tileRenderer->cullLabels(culler, viewState)) {
+            for (auto it = labelLayers.begin(); it != labelLayers.end(); it++) {
+                if ((*it)->_tileRenderer->cullLabels(culler, viewState)) {
                     changed = true;
                 }
             }


### PR DESCRIPTION
## Summary

- `VTLabelPlacementWorker` culled the layers of the layer list only. A `CompositeVectorTileLayer` draws its style-layer groups and its vector slots through **internal child layers that are not in that list**, so their labels were never culled - and a label that is never culled is never placed, so it never becomes visible. Every style layer after the first external slot lost its labels; the contour slot lost all of them.
- New `Layer::collectLabelLayers` appends the layers whose labels take part in placement, in draw order (composite: group 0, then each draw item), and the worker culls that list. Measured on the demo inline style: contour labels reaching the culler 0 -> 274.
- Carries the pointer bump for the vt/mapnikvt line-label fixes.

## Testing

`clang++ -fsyntax-only` is not usable on these translation units here (they pull in GLES headers); covered by the `scripts/android-dev` gradle build, which compiles the SDK.

Emulator, `--es ui false --es style inline --es sat false --es hs false --es lon 5.7606 --es lat 45.2442 --es zoom 13.46`: contour labels go from absent to `valid=11 visible=11` in 2D and render in 3D. **An on-device check is still needed** - this is renderer behaviour.

## Depends on

https://github.com/farfromrefug/mobile-carto-libs/pull/18 - merge that first, then rebase this pointer bump onto the merged commit.