### PR TITLE
fix(terrain): stop labels blinking against the terrain depth buffer

### DIFF
--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -877,7 +877,7 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
                     float screenWidth = static_cast<float>(viewState.getWidth());
                     float screenHeight = static_cast<float>(viewState.getHeight());
                     std::weak_ptr<MapRenderer> mapRendererWeak = _mapRenderer;
-                    float occlusionTolerance = 1.0f + terrainOptions->getBillboardOcclusionTolerance();
+                    float occlusionTolerance = 1.0f + std::max(MIN_OCCLUSION_TOLERANCE, terrainOptions->getBillboardOcclusionTolerance());
                     tileRenderer->setLabelOcclusionTest([mapRendererWeak, mvpMat, screenWidth, screenHeight, occlusionTolerance](const cglib::vec3<double>& pos) {
                         auto mapRenderer = mapRendererWeak.lock();
                         if (!mapRenderer) {
@@ -893,11 +893,27 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
                         }
                         float screenX = static_cast<float>((clipPos(0) / clipPos(3) * 0.5 + 0.5) * screenWidth);
                         float screenY = static_cast<float>((0.5 - clipPos(1) / clipPos(3) * 0.5) * screenHeight);
+                        // Farthest terrain depth around the anchor rather than the depth of its own
+                        // pixel: labels drawn on the ground sit exactly ON the terrain, the depth
+                        // buffer is read back downscaled and one frame late, and on a slope the
+                        // neighbouring pixel can be a good deal nearer - so an exact comparison
+                        // makes a label's own ground occlude it, differently on every frame, which
+                        // is what made labels blink while panning.
                         float depthW = terrainRenderer->getDepthW(screenX, screenY);
-                        // Occluded if clearly behind the terrain at this pixel. The tolerance is
-                        // relative to distance: at its default it only absorbs the mismatch
-                        // between the anchor and the terrain it sits on, and raising it lets
-                        // partly hidden features label (the peak-finder case).
+                        if (depthW < std::numeric_limits<float>::max()) {
+                            for (int i = 0; i < 4; i++) {
+                                float dx = (i & 1 ? OCCLUSION_SAMPLE_OFFSET : -OCCLUSION_SAMPLE_OFFSET);
+                                float dy = (i & 2 ? OCCLUSION_SAMPLE_OFFSET : -OCCLUSION_SAMPLE_OFFSET);
+                                float neighbourDepthW = terrainRenderer->getDepthW(screenX + dx, screenY + dy);
+                                if (neighbourDepthW < std::numeric_limits<float>::max()) {
+                                    depthW = std::max(depthW, neighbourDepthW);
+                                }
+                            }
+                        }
+                        // Occluded if clearly behind the terrain there. The tolerance is relative to
+                        // distance: at its default it only absorbs the mismatch between the anchor
+                        // and the terrain it sits on, and raising it lets partly hidden features
+                        // label (the peak-finder case).
                         return static_cast<float>(clipPos(3)) > depthW * occlusionTolerance;
                     });
                     return;

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -136,6 +136,9 @@ namespace carto {
 
         static constexpr int SURFACE_RESET_DELAY = 500; // minimum interval (ms) between elevation-driven tile surface rebuilds
 
+        static constexpr float OCCLUSION_SAMPLE_OFFSET = 8.0f; // screen pixels sampled around a label anchor for the terrain depth
+        static constexpr float MIN_OCCLUSION_TOLERANCE = 0.01f; // relative depth slack a label anchored on the terrain always gets
+
         static const std::string LIGHTING_SHADER_2D;
         static const std::string LIGHTING_SHADER_3D;
         static const std::string LIGHTING_SHADER_NORMALMAP;


### PR DESCRIPTION
## Summary

The dominant cause of labels flickering on 3D terrain was the **billboard occlusion
test**, not the label layout. A label drawn on the ground sits exactly *on* the terrain,
so its clip depth equals the terrain depth at its own pixel (measured ratios
0.9997–1.0009), the depth buffer is read back downscaled and a frame late, and the exact
`>` comparison therefore made a label's own ground occlude it — differently on every
frame.

- Sample the **farthest** terrain depth of a small neighbourhood around the anchor
  instead of the depth of its single pixel.
- Give every anchor a **1% relative depth slack** (`TerrainOptions.BillboardOcclusionTolerance`
  still raises it; nothing changes for apps that set it).
- Bumps `libs-carto` to the line-label layout fix (see below).

Occlusion still works: labels beyond the ridge stay hidden (A/B with `--es occlusion false`).

## Testing

Emulator (`scripts/android-dev`):

```
adb shell am start -n com.akylas.cartotest/.MainActivity --es ui false --es terrain true \
  --es contour false --es lon 5.730806 --es lat 45.214728 --es zoom 14.99 --es tilt 26 --es rotation -15.12
```

Instrumented the drawn-label set per frame and panned in ~10 px steps: **26** drawn-set
changes on a single pan before, **0** after (and the same run with `--es occlusion false`
was already 0, which is what identified the occlusion test). Verified occlusion still
hides labels past the ridge, and checked tilt 90 and terrain off for regressions.
Renderer change — this is an **emulator** result, an on-device check is still required.

## Depends on

https://github.com/farfromrefug/mobile-carto-libs/pull/20 — merge that first, then rebase
the pointer bump onto the merged `libs-carto` commit before merging this one.