### PR TITLE
feat(ui): objects in the sky, a camera that can look at them, and the demo rebuilt around it

### DIFF
--- a/all/modules/celestial/CelestialArc.i
+++ b/all/modules/celestial/CelestialArc.i
@@ -1,0 +1,31 @@
+#ifndef _CELESTIALARC_I
+#define _CELESTIALARC_I
+
+%module(directors="1") CelestialArc
+
+!proxy_imports(carto::CelestialArc, celestial.CelestialObject, core.DoubleVector)
+
+%{
+#include "celestial/CelestialArc.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <std_vector.i>
+%include <cartoswig.i>
+
+%import "celestial/CelestialObject.i"
+%import "core/DoubleVector.i"
+
+!polymorphic_shared_ptr(carto::CelestialArc, celestial.CelestialArc)
+
+%attribute(carto::CelestialArc, float, Radius, getRadius)
+%attribute(carto::CelestialArc, float, Width, getWidth, setWidth)
+%attribute(carto::CelestialArc, bool, BelowHorizonVisible, isBelowHorizonVisible, setBelowHorizonVisible)
+%ignore carto::CelestialArc::buildDirections;
+%std_exceptions(carto::CelestialArc::CelestialArc)
+
+%include "celestial/CelestialArc.h"
+
+#endif

--- a/all/modules/celestial/CelestialArc.i
+++ b/all/modules/celestial/CelestialArc.i
@@ -23,6 +23,8 @@
 %attribute(carto::CelestialArc, float, Radius, getRadius)
 %attribute(carto::CelestialArc, float, Width, getWidth, setWidth)
 %attribute(carto::CelestialArc, bool, BelowHorizonVisible, isBelowHorizonVisible, setBelowHorizonVisible)
+%attribute(carto::CelestialArc, float, ClickRadius, getClickRadius, setClickRadius)
+%attribute(carto::CelestialArc, bool, Segmented, isSegmented)
 %ignore carto::CelestialArc::buildDirections;
 %std_exceptions(carto::CelestialArc::CelestialArc)
 

--- a/all/modules/celestial/CelestialObject.i
+++ b/all/modules/celestial/CelestialObject.i
@@ -1,0 +1,46 @@
+#ifndef _CELESTIALOBJECT_I
+#define _CELESTIALOBJECT_I
+
+#pragma SWIG nowarn=401
+
+%module CelestialObject
+
+!proxy_imports(carto::CelestialObject, core.MapPos, core.Variant, graphics.Color)
+
+%{
+#include "celestial/CelestialObject.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_string.i>
+%include <std_shared_ptr.i>
+%include <std_vector.i>
+%include <cartoswig.i>
+
+%import "core/MapPos.i"
+%import "core/Variant.i"
+%import "graphics/Color.i"
+
+!polymorphic_shared_ptr(carto::CelestialObject, celestial.CelestialObject)
+!value_type(std::vector<std::shared_ptr<carto::CelestialObject> >, celestial.CelestialObjectVector)
+
+%attribute(carto::CelestialObject, bool, DirectionAnchored, isDirectionAnchored)
+%attribute(carto::CelestialObject, float, Azimuth, getAzimuth)
+%attribute(carto::CelestialObject, float, Altitude, getAltitude)
+%attribute(carto::CelestialObject, double, Distance, getDistance)
+%attributeval(carto::CelestialObject, carto::MapPos, Position, getPosition)
+%attribute(carto::CelestialObject, double, PositionAltitude, getPositionAltitude)
+%attributeval(carto::CelestialObject, carto::Color, Color, getColor, setColor)
+%attribute(carto::CelestialObject, bool, Visible, isVisible, setVisible)
+%ignore carto::CelestialObject::calculateDirectionVector;
+%ignore carto::CelestialObject::setComponents;
+%ignore carto::CelestialObject::getLayer;
+%std_exceptions(carto::CelestialObject::CelestialObject)
+!standard_equals(carto::CelestialObject);
+
+%include "celestial/CelestialObject.h"
+
+!value_template(std::vector<std::shared_ptr<carto::CelestialObject> >, celestial.CelestialObjectVector);
+
+#endif

--- a/all/modules/celestial/CelestialSprite.i
+++ b/all/modules/celestial/CelestialSprite.i
@@ -1,0 +1,31 @@
+#ifndef _CELESTIALSPRITE_I
+#define _CELESTIALSPRITE_I
+
+%module(directors="1") CelestialSprite
+
+!proxy_imports(carto::CelestialSprite, celestial.CelestialObject, graphics.Bitmap)
+
+%{
+#include "celestial/CelestialSprite.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <cartoswig.i>
+
+%import "celestial/CelestialObject.i"
+%import "graphics/Bitmap.i"
+
+!polymorphic_shared_ptr(carto::CelestialSprite, celestial.CelestialSprite)
+
+%attribute(carto::CelestialSprite, float, AngularSize, getAngularSize, setAngularSize)
+%attribute(carto::CelestialSprite, float, ScreenSize, getScreenSize, setScreenSize)
+!attributestring_polymorphic(carto::CelestialSprite, graphics.Bitmap, Bitmap, getBitmap, setBitmap)
+%attribute(carto::CelestialSprite, float, Softness, getSoftness, setSoftness)
+%attribute(carto::CelestialSprite, float, ClickRadius, getClickRadius, setClickRadius)
+%std_exceptions(carto::CelestialSprite::CelestialSprite)
+
+%include "celestial/CelestialSprite.h"
+
+#endif

--- a/all/modules/components/Options.i
+++ b/all/modules/components/Options.i
@@ -37,6 +37,7 @@
 %attribute(carto::Options, bool, KineticZoom, isKineticZoom, setKineticZoom)
 %attribute(carto::Options, bool, Rotatable, isRotatable, setRotatable)
 %attribute(carto::Options, bool, UserInput, isUserInput, setUserInput)
+%attribute(carto::Options, bool, FreeRoam, isFreeRoam, setFreeRoam)
 %attribute(carto::Options, bool, DebugTileBorders, isDebugTileBorders, setDebugTileBorders)
 %attribute(carto::Options, bool, ClickTypeDetection, isClickTypeDetection, setClickTypeDetection)
 %attribute(carto::Options, bool, DoubleClickDetection, isDoubleClickDetection, setDoubleClickDetection)

--- a/all/modules/components/Options.i
+++ b/all/modules/components/Options.i
@@ -21,6 +21,7 @@
 !enum(carto::PanningMode::PanningMode)
 !enum(carto::PivotMode::PivotMode)
 !enum(carto::FreeRoamMode::FreeRoamMode)
+!enum(carto::PanningSpeedMode::PanningSpeedMode)
 !shared_ptr(carto::Options, components.Options)
 
 %import "core/MapBounds.i"
@@ -38,6 +39,7 @@
 %attribute(carto::Options, bool, KineticZoom, isKineticZoom, setKineticZoom)
 %attribute(carto::Options, bool, Rotatable, isRotatable, setRotatable)
 %attribute(carto::Options, bool, UserInput, isUserInput, setUserInput)
+%attribute(carto::Options, carto::PanningSpeedMode::PanningSpeedMode, PanningSpeedMode, getPanningSpeedMode, setPanningSpeedMode)
 %attribute(carto::Options, carto::FreeRoamMode::FreeRoamMode, FreeRoamMode, getFreeRoamMode, setFreeRoamMode)
 %attribute(carto::Options, float, FreeRoamLookSensitivity, getFreeRoamLookSensitivity, setFreeRoamLookSensitivity)
 %attribute(carto::Options, float, FreeRoamMoveSpeed, getFreeRoamMoveSpeed, setFreeRoamMoveSpeed)

--- a/all/modules/components/Options.i
+++ b/all/modules/components/Options.i
@@ -20,6 +20,7 @@
 !enum(carto::RenderProjectionMode::RenderProjectionMode)
 !enum(carto::PanningMode::PanningMode)
 !enum(carto::PivotMode::PivotMode)
+!enum(carto::FreeRoamMode::FreeRoamMode)
 !shared_ptr(carto::Options, components.Options)
 
 %import "core/MapBounds.i"
@@ -37,7 +38,9 @@
 %attribute(carto::Options, bool, KineticZoom, isKineticZoom, setKineticZoom)
 %attribute(carto::Options, bool, Rotatable, isRotatable, setRotatable)
 %attribute(carto::Options, bool, UserInput, isUserInput, setUserInput)
-%attribute(carto::Options, bool, FreeRoam, isFreeRoam, setFreeRoam)
+%attribute(carto::Options, carto::FreeRoamMode::FreeRoamMode, FreeRoamMode, getFreeRoamMode, setFreeRoamMode)
+%attribute(carto::Options, float, FreeRoamLookSensitivity, getFreeRoamLookSensitivity, setFreeRoamLookSensitivity)
+%attribute(carto::Options, float, FreeRoamMoveSpeed, getFreeRoamMoveSpeed, setFreeRoamMoveSpeed)
 %attribute(carto::Options, bool, DebugTileBorders, isDebugTileBorders, setDebugTileBorders)
 %attribute(carto::Options, bool, ClickTypeDetection, isClickTypeDetection, setClickTypeDetection)
 %attribute(carto::Options, bool, DoubleClickDetection, isDoubleClickDetection, setDoubleClickDetection)

--- a/all/modules/layers/CelestialEventListener.i
+++ b/all/modules/layers/CelestialEventListener.i
@@ -1,0 +1,25 @@
+#ifndef _CELESTIALEVENTLISTENER_I
+#define _CELESTIALEVENTLISTENER_I
+
+%module(directors="1") CelestialEventListener
+
+!proxy_imports(carto::CelestialEventListener, celestial.CelestialObject, ui.ClickInfo)
+
+%{
+#include "layers/CelestialEventListener.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <cartoswig.i>
+
+%import "celestial/CelestialObject.i"
+%import "ui/ClickInfo.i"
+
+!polymorphic_shared_ptr(carto::CelestialEventListener, layers.CelestialEventListener)
+
+%feature("director") carto::CelestialEventListener;
+
+%include "layers/CelestialEventListener.h"
+
+#endif

--- a/all/modules/layers/CelestialLayer.i
+++ b/all/modules/layers/CelestialLayer.i
@@ -1,0 +1,33 @@
+#ifndef _CELESTIALLAYER_I
+#define _CELESTIALLAYER_I
+
+%module CelestialLayer
+
+!proxy_imports(carto::CelestialLayer, celestial.CelestialObject, celestial.CelestialObjectVector, layers.Layer, layers.CelestialEventListener)
+
+%{
+#include "layers/CelestialLayer.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <std_vector.i>
+%include <cartoswig.i>
+
+%import "layers/Layer.i"
+%import "layers/CelestialEventListener.i"
+%import "celestial/CelestialObject.i"
+
+!polymorphic_shared_ptr(carto::CelestialLayer, layers.CelestialLayer)
+
+!attributestring_polymorphic(carto::CelestialLayer, layers.CelestialEventListener, CelestialEventListener, getCelestialEventListener, setCelestialEventListener)
+%std_exceptions(carto::CelestialLayer::add)
+%std_exceptions(carto::CelestialLayer::addAll)
+%ignore carto::CelestialLayer::onDrawFrame;
+%ignore carto::CelestialLayer::calculateRayIntersectedElements;
+%ignore carto::CelestialLayer::processClick;
+
+%include "layers/CelestialLayer.h"
+
+#endif

--- a/all/native/celestial/CelestialArc.cpp
+++ b/all/native/celestial/CelestialArc.cpp
@@ -1,0 +1,124 @@
+#include "CelestialArc.h"
+#include "utils/Const.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace carto {
+
+    const int CelestialArc::CIRCLE_SEGMENTS = 180;
+
+    CelestialArc::CelestialArc() :
+        CelestialObject(),
+        _circular(true),
+        _axisAzimuth(0.0f),
+        _axisAltitude(90.0f),
+        _radius(45.0f),
+        _directions(),
+        _width(2.0f),
+        _belowHorizonVisible(false)
+    {
+    }
+
+    CelestialArc::~CelestialArc() {
+    }
+
+    void CelestialArc::setCircle(float axisAzimuth, float axisAltitude, float radius) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _circular = true;
+            _axisAzimuth = axisAzimuth;
+            _axisAltitude = axisAltitude;
+            _radius = std::max(0.0f, std::min(180.0f, radius));
+            _directions.clear();
+        }
+        notifyChanged();
+    }
+
+    void CelestialArc::setDirections(const std::vector<double>& directions) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _circular = false;
+            _directions = directions;
+        }
+        notifyChanged();
+    }
+
+    std::vector<double> CelestialArc::getDirections() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _directions;
+    }
+
+    float CelestialArc::getRadius() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _radius;
+    }
+
+    float CelestialArc::getWidth() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _width;
+    }
+
+    void CelestialArc::setWidth(float pixels) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _width = std::max(0.0f, pixels);
+        }
+        notifyChanged();
+    }
+
+    bool CelestialArc::isBelowHorizonVisible() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _belowHorizonVisible;
+    }
+
+    void CelestialArc::setBelowHorizonVisible(bool visible) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _belowHorizonVisible = visible;
+        }
+        notifyChanged();
+    }
+
+    std::vector<cglib::vec3<double> > CelestialArc::buildDirections() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        std::vector<cglib::vec3<double> > result;
+        auto toVector = [](double azimuthDeg, double altitudeDeg) {
+            double az = azimuthDeg * Const::DEG_TO_RAD;
+            double alt = altitudeDeg * Const::DEG_TO_RAD;
+            double cosAlt = std::cos(alt);
+            return cglib::vec3<double>(cosAlt * std::sin(az), cosAlt * std::cos(az), std::sin(alt));
+        };
+
+        if (!_circular) {
+            result.reserve(_directions.size() / 2);
+            for (std::size_t i = 0; i + 1 < _directions.size(); i += 2) {
+                result.push_back(toVector(_directions[i], _directions[i + 1]));
+            }
+            return result;
+        }
+
+        // A circle about an axis: take any two unit vectors perpendicular to the axis and sweep
+        // them. The whole curve is then axis*cos(radius) + (u*cos t + v*sin t)*sin(radius), which
+        // is a closed loop of constant angle to the axis - the path of a body at fixed declination.
+        cglib::vec3<double> axis = toVector(_axisAzimuth, _axisAltitude);
+        cglib::vec3<double> reference(0, 0, 1);
+        if (std::abs(cglib::dot_product(axis, reference)) > 0.99) {
+            reference = cglib::vec3<double>(0, 1, 0);
+        }
+        cglib::vec3<double> u = cglib::unit(cglib::vector_product(axis, reference));
+        cglib::vec3<double> v = cglib::vector_product(axis, u);
+
+        double radius = _radius * Const::DEG_TO_RAD;
+        double cosR = std::cos(radius);
+        double sinR = std::sin(radius);
+        result.reserve(CIRCLE_SEGMENTS + 1);
+        for (int i = 0; i <= CIRCLE_SEGMENTS; i++) {
+            double t = 2.0 * Const::PI * i / CIRCLE_SEGMENTS;
+            result.push_back(axis * cosR + (u * std::cos(t) + v * std::sin(t)) * sinR);
+        }
+        return result;
+    }
+
+}

--- a/all/native/celestial/CelestialArc.cpp
+++ b/all/native/celestial/CelestialArc.cpp
@@ -11,12 +11,14 @@ namespace carto {
     CelestialArc::CelestialArc() :
         CelestialObject(),
         _circular(true),
+        _segmented(false),
         _axisAzimuth(0.0f),
         _axisAltitude(90.0f),
         _radius(45.0f),
         _directions(),
         _width(2.0f),
-        _belowHorizonVisible(false)
+        _belowHorizonVisible(false),
+        _clickRadius(2.0f)
     {
     }
 
@@ -39,9 +41,25 @@ namespace carto {
         {
             std::lock_guard<std::mutex> lock(_mutex);
             _circular = false;
+            _segmented = false;
             _directions = directions;
         }
         notifyChanged();
+    }
+
+    void CelestialArc::setSegments(const std::vector<double>& directions) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _circular = false;
+            _segmented = true;
+            _directions = directions;
+        }
+        notifyChanged();
+    }
+
+    bool CelestialArc::isSegmented() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _segmented;
     }
 
     std::vector<double> CelestialArc::getDirections() const {
@@ -76,6 +94,19 @@ namespace carto {
         {
             std::lock_guard<std::mutex> lock(_mutex);
             _belowHorizonVisible = visible;
+        }
+        notifyChanged();
+    }
+
+    float CelestialArc::getClickRadius() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _clickRadius;
+    }
+
+    void CelestialArc::setClickRadius(float degrees) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _clickRadius = std::max(0.0f, degrees);
         }
         notifyChanged();
     }

--- a/all/native/celestial/CelestialArc.h
+++ b/all/native/celestial/CelestialArc.h
@@ -17,12 +17,12 @@ namespace carto {
      * A curve drawn on the sky.
      *
      * Two ways to define one, and the first is what a daily path is:
-     *  - as a CIRCLE about an axis: every direction at a fixed angle from the axis. The sun's path
-     *    across a day is exactly this - the axis is the celestial pole and the angle is 90 degrees
-     *    minus the declination - so an application draws it with an axis and one angle rather than
-     *    by sampling positions through the day.
+     *  - as a CIRCLE about an axis: every direction at a fixed angle from the axis. The daily
+     *    path of a distant body is exactly this - the axis is the rotation axis and the angle is
+     *    the complement of the declination - so an application draws it with an axis and one angle
+     *    rather than by sampling positions through the day.
      *  - as an explicit list of directions, for a path that is not a circle: a satellite track, a
-     *    flight plan, an analemma.
+     *    flight plan, a sampled trajectory.
      *
      * The curve is generated once and drawn as a line strip; its width is in pixels, so it stays
      * legible at any field of view.
@@ -46,6 +46,21 @@ namespace carto {
          * @param directions The directions, as alternating azimuth and altitude values in degrees.
          */
         void setDirections(const std::vector<double>& directions);
+
+        /**
+         * Defines the arc as a list of SEPARATE segments: every pair of directions is one line and
+         * consecutive pairs are not joined. A figure drawn between fixed directions is exactly
+         * this - a set of lines that is not a single path - and it stays ONE object, so it is one
+         * draw call and one clickable thing.
+         * @param directions The directions, as alternating azimuth and altitude values in degrees.
+         */
+        void setSegments(const std::vector<double>& directions);
+
+        /**
+         * Returns true if the directions are read as separate segments rather than as a path.
+         * @return True if the arc is a segment list.
+         */
+        bool isSegmented() const;
 
         /**
          * Returns the directions of an explicitly defined arc.
@@ -76,11 +91,24 @@ namespace carto {
          */
         bool isBelowHorizonVisible() const;
         /**
-         * Sets whether the part of the curve below the horizon is drawn. A sun path looks right
-         * with this off - the arc then rises and sets like the sun does.
+         * Sets whether the part of the curve below the horizon is drawn. A daily path looks
+         * right with this off - the arc then rises and sets like the body on it does.
          * @param visible True to draw the curve below the horizon.
          */
         void setBelowHorizonVisible(bool visible);
+
+        /**
+         * Returns the click radius of the curve.
+         * @return The click radius in degrees.
+         */
+        float getClickRadius() const;
+        /**
+         * Sets the click radius of the curve: how far, in degrees, a touch ray may miss the curve
+         * and still hit it. A curve is a line a pixel or two wide, so without this nothing could
+         * ever be aimed at. 0 makes the curve unclickable. The default is 2 degrees.
+         * @param degrees The click radius in degrees.
+         */
+        void setClickRadius(float degrees);
 
         /**
          * Builds the curve as unit direction vectors, in the map's local frame (x east, y north,
@@ -93,12 +121,14 @@ namespace carto {
         static const int CIRCLE_SEGMENTS;
 
         bool _circular;
+        bool _segmented;
         float _axisAzimuth;
         float _axisAltitude;
         float _radius;
         std::vector<double> _directions;
         float _width;
         bool _belowHorizonVisible;
+        float _clickRadius;
     };
 
 }

--- a/all/native/celestial/CelestialArc.h
+++ b/all/native/celestial/CelestialArc.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_CELESTIALARC_H_
+#define _CARTO_CELESTIALARC_H_
+
+#include "celestial/CelestialObject.h"
+
+#include <vector>
+
+namespace carto {
+
+    /**
+     * A curve drawn on the sky.
+     *
+     * Two ways to define one, and the first is what a daily path is:
+     *  - as a CIRCLE about an axis: every direction at a fixed angle from the axis. The sun's path
+     *    across a day is exactly this - the axis is the celestial pole and the angle is 90 degrees
+     *    minus the declination - so an application draws it with an axis and one angle rather than
+     *    by sampling positions through the day.
+     *  - as an explicit list of directions, for a path that is not a circle: a satellite track, a
+     *    flight plan, an analemma.
+     *
+     * The curve is generated once and drawn as a line strip; its width is in pixels, so it stays
+     * legible at any field of view.
+     */
+    class CelestialArc : public CelestialObject {
+    public:
+        CelestialArc();
+        virtual ~CelestialArc();
+
+        /**
+         * Defines the arc as a circle about an axis.
+         * @param axisAzimuth The azimuth of the axis in degrees, clockwise from north.
+         * @param axisAltitude The altitude of the axis in degrees above the horizon.
+         * @param radius The angular radius in degrees: the angle between the axis and the curve.
+         */
+        void setCircle(float axisAzimuth, float axisAltitude, float radius);
+
+        /**
+         * Defines the arc as an explicit list of directions, each an (azimuth, altitude) pair in
+         * degrees. The curve runs through them in order and is not closed.
+         * @param directions The directions, as alternating azimuth and altitude values in degrees.
+         */
+        void setDirections(const std::vector<double>& directions);
+
+        /**
+         * Returns the directions of an explicitly defined arc.
+         * @return The directions, as alternating azimuth and altitude values in degrees.
+         */
+        std::vector<double> getDirections() const;
+
+        /**
+         * Returns the angular radius of a circular arc.
+         * @return The angular radius in degrees.
+         */
+        float getRadius() const;
+
+        /**
+         * Returns the line width.
+         * @return The width in pixels.
+         */
+        float getWidth() const;
+        /**
+         * Sets the line width.
+         * @param pixels The width in pixels.
+         */
+        void setWidth(float pixels);
+
+        /**
+         * Returns whether the part of the curve below the horizon is drawn.
+         * @return True if the curve is drawn below the horizon.
+         */
+        bool isBelowHorizonVisible() const;
+        /**
+         * Sets whether the part of the curve below the horizon is drawn. A sun path looks right
+         * with this off - the arc then rises and sets like the sun does.
+         * @param visible True to draw the curve below the horizon.
+         */
+        void setBelowHorizonVisible(bool visible);
+
+        /**
+         * Builds the curve as unit direction vectors, in the map's local frame (x east, y north,
+         * z up). Called by the renderer; an application does not need it.
+         * @return The direction vectors along the curve.
+         */
+        std::vector<cglib::vec3<double> > buildDirections() const;
+
+    private:
+        static const int CIRCLE_SEGMENTS;
+
+        bool _circular;
+        float _axisAzimuth;
+        float _axisAltitude;
+        float _radius;
+        std::vector<double> _directions;
+        float _width;
+        bool _belowHorizonVisible;
+    };
+
+}
+
+#endif

--- a/all/native/celestial/CelestialObject.cpp
+++ b/all/native/celestial/CelestialObject.cpp
@@ -118,7 +118,7 @@ namespace carto {
     cglib::vec3<double> CelestialObject::calculateDirectionVector() const {
         std::lock_guard<std::mutex> lock(_mutex);
         // Same convention as LightOptions::getSunDirection - x east, y north, z up, azimuth
-        // clockwise from north - so an application can hand a sun or moon direction straight over.
+        // clockwise from north - so an application can hand a direction straight over.
         double az = _azimuth * Const::DEG_TO_RAD;
         double alt = _altitude * Const::DEG_TO_RAD;
         double cosAlt = std::cos(alt);

--- a/all/native/celestial/CelestialObject.cpp
+++ b/all/native/celestial/CelestialObject.cpp
@@ -1,0 +1,144 @@
+#include "CelestialObject.h"
+#include "layers/CelestialLayer.h"
+#include "utils/Const.h"
+
+#include <cmath>
+
+namespace carto {
+
+    CelestialObject::CelestialObject() :
+        _mutex(),
+        _directionAnchored(true),
+        _azimuth(0.0f),
+        _altitude(45.0f),
+        _distance(0.0),
+        _position(0, 0, 0),
+        _positionAltitude(0.0),
+        _color(0xFFFFFFFF),
+        _visible(true),
+        _metaData(),
+        _layer()
+    {
+    }
+
+    CelestialObject::~CelestialObject() {
+    }
+
+    bool CelestialObject::isDirectionAnchored() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _directionAnchored;
+    }
+
+    float CelestialObject::getAzimuth() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _azimuth;
+    }
+
+    float CelestialObject::getAltitude() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _altitude;
+    }
+
+    double CelestialObject::getDistance() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _distance;
+    }
+
+    void CelestialObject::setDirection(float azimuth, float altitude, double distance) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _directionAnchored = true;
+            _azimuth = azimuth;
+            _altitude = std::max(-90.0f, std::min(90.0f, altitude));
+            _distance = std::max(0.0, distance);
+        }
+        notifyChanged();
+    }
+
+    MapPos CelestialObject::getPosition() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _position;
+    }
+
+    double CelestialObject::getPositionAltitude() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _positionAltitude;
+    }
+
+    void CelestialObject::setPosition(const MapPos& pos, double altitude) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _directionAnchored = false;
+            _position = pos;
+            _positionAltitude = altitude;
+        }
+        notifyChanged();
+    }
+
+    Color CelestialObject::getColor() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _color;
+    }
+
+    void CelestialObject::setColor(const Color& color) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _color = color;
+        }
+        notifyChanged();
+    }
+
+    bool CelestialObject::isVisible() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _visible;
+    }
+
+    void CelestialObject::setVisible(bool visible) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _visible = visible;
+        }
+        notifyChanged();
+    }
+
+    Variant CelestialObject::getMetaDataElement(const std::string& key) const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto it = _metaData.find(key);
+        if (it == _metaData.end()) {
+            return Variant();
+        }
+        return it->second;
+    }
+
+    void CelestialObject::setMetaDataElement(const std::string& key, const Variant& element) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _metaData[key] = element;
+    }
+
+    cglib::vec3<double> CelestialObject::calculateDirectionVector() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        // Same convention as LightOptions::getSunDirection - x east, y north, z up, azimuth
+        // clockwise from north - so an application can hand a sun or moon direction straight over.
+        double az = _azimuth * Const::DEG_TO_RAD;
+        double alt = _altitude * Const::DEG_TO_RAD;
+        double cosAlt = std::cos(alt);
+        return cglib::vec3<double>(cosAlt * std::sin(az), cosAlt * std::cos(az), std::sin(alt));
+    }
+
+    void CelestialObject::setComponents(const std::shared_ptr<CelestialLayer>& layer) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _layer = layer;
+    }
+
+    std::shared_ptr<CelestialLayer> CelestialObject::getLayer() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _layer.lock();
+    }
+
+    void CelestialObject::notifyChanged() {
+        if (std::shared_ptr<CelestialLayer> layer = getLayer()) {
+            layer->refresh();
+        }
+    }
+
+}

--- a/all/native/celestial/CelestialObject.h
+++ b/all/native/celestial/CelestialObject.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_CELESTIALOBJECT_H_
+#define _CARTO_CELESTIALOBJECT_H_
+
+#include "core/MapPos.h"
+#include "core/Variant.h"
+#include "graphics/Color.h"
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <cglib/vec.h>
+
+namespace carto {
+    class CelestialLayer;
+
+    /**
+     * A base class for objects that are placed in the sky rather than on the map.
+     *
+     * An object is anchored in one of two ways:
+     *  - by DIRECTION (azimuth and altitude), with an optional distance. A distance of 0 means
+     *    infinitely far: the object keeps its direction whatever the camera does, which is what
+     *    the sun, the moon and the stars need. A finite distance gives real parallax and is what
+     *    an aircraft or a satellite overhead needs.
+     *  - by geographic POSITION plus an altitude in meters, for an object that belongs to a place
+     *    on the map but is above it.
+     *
+     * Objects are hit-tested against the touch ray like any other layer's elements, so a click on
+     * one is reported through the layer's listener, and terrain in front of it wins the hit.
+     */
+    class CelestialObject {
+    public:
+        virtual ~CelestialObject();
+
+        /**
+         * Returns true if the object is anchored by direction, false if by geographic position.
+         * @return True if the object is anchored by direction.
+         */
+        bool isDirectionAnchored() const;
+
+        /**
+         * Returns the azimuth of a direction-anchored object.
+         * @return The azimuth in degrees, clockwise from north.
+         */
+        float getAzimuth() const;
+        /**
+         * Returns the altitude of a direction-anchored object.
+         * @return The altitude in degrees above the horizon.
+         */
+        float getAltitude() const;
+        /**
+         * Returns the distance of a direction-anchored object.
+         * @return The distance in meters, or 0 for infinitely far.
+         */
+        double getDistance() const;
+        /**
+         * Anchors the object by direction. This is the anchor for anything that behaves like a
+         * celestial body.
+         * @param azimuth The azimuth in degrees, clockwise from north.
+         * @param altitude The altitude in degrees above the horizon.
+         * @param distance The distance in meters. 0 means infinitely far, so the object never
+         *                 parallaxes when the camera moves.
+         */
+        void setDirection(float azimuth, float altitude, double distance);
+
+        /**
+         * Returns the geographic position of a position-anchored object.
+         * @return The position, in the coordinate system of the layer's data source projection.
+         */
+        MapPos getPosition() const;
+        /**
+         * Returns the altitude of a position-anchored object.
+         * @return The altitude in meters above the ground.
+         */
+        double getPositionAltitude() const;
+        /**
+         * Anchors the object above a place on the map. Use this for aircraft, satellites, or
+         * anything else that has a real location.
+         * @param pos The position, in the coordinate system of the layer's data source projection.
+         * @param altitude The altitude in meters above the ground.
+         */
+        void setPosition(const MapPos& pos, double altitude);
+
+        /**
+         * Returns the color of the object.
+         * @return The color of the object.
+         */
+        Color getColor() const;
+        /**
+         * Sets the color of the object. The color multiplies the bitmap, if there is one.
+         * @param color The new color.
+         */
+        void setColor(const Color& color);
+
+        /**
+         * Returns the visibility of the object.
+         * @return True if the object is drawn.
+         */
+        bool isVisible() const;
+        /**
+         * Sets the visibility of the object. An invisible object is neither drawn nor clickable.
+         * @param visible The new visibility.
+         */
+        void setVisible(bool visible);
+
+        /**
+         * Returns a meta data value.
+         * @param key The key of the value.
+         * @return The value, or an empty variant if the key does not exist.
+         */
+        Variant getMetaDataElement(const std::string& key) const;
+        /**
+         * Sets a meta data value. Meta data is carried through to the click listener, which is how
+         * an application tells its objects apart.
+         * @param key The key of the value.
+         * @param element The value.
+         */
+        void setMetaDataElement(const std::string& key, const Variant& element);
+
+        /**
+         * Returns the direction of the object as a unit vector, in the map's local frame
+         * (x east, y north, z up). Meaningless for position-anchored objects.
+         * @return The unit direction vector.
+         */
+        cglib::vec3<double> calculateDirectionVector() const;
+
+        void setComponents(const std::shared_ptr<CelestialLayer>& layer);
+        std::shared_ptr<CelestialLayer> getLayer() const;
+
+    protected:
+        CelestialObject();
+
+        void notifyChanged();
+
+        mutable std::mutex _mutex;
+
+    private:
+        bool _directionAnchored;
+        float _azimuth;
+        float _altitude;
+        double _distance;
+        MapPos _position;
+        double _positionAltitude;
+        Color _color;
+        bool _visible;
+        std::map<std::string, Variant> _metaData;
+        std::weak_ptr<CelestialLayer> _layer;
+    };
+
+}
+
+#endif

--- a/all/native/celestial/CelestialObject.h
+++ b/all/native/celestial/CelestialObject.h
@@ -27,8 +27,8 @@ namespace carto {
      * An object is anchored in one of two ways:
      *  - by DIRECTION (azimuth and altitude), with an optional distance. A distance of 0 means
      *    infinitely far: the object keeps its direction whatever the camera does, which is what
-     *    the sun, the moon and the stars need. A finite distance gives real parallax and is what
-     *    an aircraft or a satellite overhead needs.
+     *    a body at an effectively infinite distance needs. A finite distance gives real parallax
+     *    and is what an aircraft or a satellite overhead needs.
      *  - by geographic POSITION plus an altitude in meters, for an object that belongs to a place
      *    on the map but is above it.
      *

--- a/all/native/celestial/CelestialSprite.cpp
+++ b/all/native/celestial/CelestialSprite.cpp
@@ -1,0 +1,85 @@
+#include "CelestialSprite.h"
+#include "graphics/Bitmap.h"
+
+#include <algorithm>
+
+namespace carto {
+
+    CelestialSprite::CelestialSprite() :
+        CelestialObject(),
+        _angularSize(0.5f),
+        _screenSize(0.0f),
+        _bitmap(),
+        _softness(0.25f),
+        _clickRadius(1.0f)
+    {
+    }
+
+    CelestialSprite::~CelestialSprite() {
+    }
+
+    float CelestialSprite::getAngularSize() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _angularSize;
+    }
+
+    void CelestialSprite::setAngularSize(float degrees) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _angularSize = std::max(0.0f, degrees);
+            _screenSize = 0.0f;
+        }
+        notifyChanged();
+    }
+
+    float CelestialSprite::getScreenSize() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _screenSize;
+    }
+
+    void CelestialSprite::setScreenSize(float pixels) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _screenSize = std::max(0.0f, pixels);
+            _angularSize = 0.0f;
+        }
+        notifyChanged();
+    }
+
+    std::shared_ptr<Bitmap> CelestialSprite::getBitmap() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _bitmap;
+    }
+
+    void CelestialSprite::setBitmap(const std::shared_ptr<Bitmap>& bitmap) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _bitmap = bitmap;
+        }
+        notifyChanged();
+    }
+
+    float CelestialSprite::getSoftness() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _softness;
+    }
+
+    void CelestialSprite::setSoftness(float softness) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _softness = std::max(0.0f, std::min(1.0f, softness));
+        }
+        notifyChanged();
+    }
+
+    float CelestialSprite::getClickRadius() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _clickRadius;
+    }
+
+    void CelestialSprite::setClickRadius(float degrees) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _clickRadius = std::max(0.0f, degrees);
+    }
+
+}

--- a/all/native/celestial/CelestialSprite.h
+++ b/all/native/celestial/CelestialSprite.h
@@ -15,13 +15,13 @@ namespace carto {
     class Bitmap;
 
     /**
-     * A flat, camera-facing object in the sky: the sun, the moon, a star, an aircraft icon.
+     * A flat, camera-facing object in the sky: a disc, a point of light, an icon overhead.
      *
      * Its size is given either as an ANGULAR size in degrees - which is what a real body has, so it
      * grows and shrinks with the field of view like everything else in the world - or as a fixed
      * SCREEN size in pixels, which is what an icon or a marker wants. A sprite with no bitmap is
-     * drawn as a soft disc in its own color, which is enough for a sun, a moon or a star and costs
-     * no texture at all.
+     * drawn as a soft disc in its own color, which is enough for most bodies and costs no
+     * texture at all.
      */
     class CelestialSprite : public CelestialObject {
     public:
@@ -34,8 +34,8 @@ namespace carto {
          */
         float getAngularSize() const;
         /**
-         * Sets the angular size of the sprite, the way a real body is measured. The sun and the
-         * moon are both about 0.5 degrees across.
+         * Sets the angular size of the sprite, the way a real body is measured - the disc then
+         * covers the same angle whatever the field of view.
          * @param degrees The angular diameter in degrees.
          */
         void setAngularSize(float degrees);
@@ -59,7 +59,7 @@ namespace carto {
         std::shared_ptr<Bitmap> getBitmap() const;
         /**
          * Sets the bitmap of the sprite. Sprites are batched per bitmap, so objects that share one
-         * bitmap - a whole star catalogue, for instance - cost a single draw call.
+         * bitmap - a catalogue of thousands, for instance - cost a single draw call.
          * @param bitmap The new bitmap, or null to draw a plain disc.
          */
         void setBitmap(const std::shared_ptr<Bitmap>& bitmap);
@@ -82,7 +82,7 @@ namespace carto {
         float getClickRadius() const;
         /**
          * Sets an extra angular radius that responds to a click, added to the sprite's own size. A
-         * star half a pixel across is impossible to hit otherwise.
+         * sprite half a pixel across is impossible to hit otherwise.
          * @param degrees The extra click radius in degrees.
          */
         void setClickRadius(float degrees);

--- a/all/native/celestial/CelestialSprite.h
+++ b/all/native/celestial/CelestialSprite.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_CELESTIALSPRITE_H_
+#define _CARTO_CELESTIALSPRITE_H_
+
+#include "celestial/CelestialObject.h"
+
+#include <memory>
+
+namespace carto {
+    class Bitmap;
+
+    /**
+     * A flat, camera-facing object in the sky: the sun, the moon, a star, an aircraft icon.
+     *
+     * Its size is given either as an ANGULAR size in degrees - which is what a real body has, so it
+     * grows and shrinks with the field of view like everything else in the world - or as a fixed
+     * SCREEN size in pixels, which is what an icon or a marker wants. A sprite with no bitmap is
+     * drawn as a soft disc in its own color, which is enough for a sun, a moon or a star and costs
+     * no texture at all.
+     */
+    class CelestialSprite : public CelestialObject {
+    public:
+        CelestialSprite();
+        virtual ~CelestialSprite();
+
+        /**
+         * Returns the angular size of the sprite.
+         * @return The angular diameter in degrees, or 0 if the sprite is sized in pixels.
+         */
+        float getAngularSize() const;
+        /**
+         * Sets the angular size of the sprite, the way a real body is measured. The sun and the
+         * moon are both about 0.5 degrees across.
+         * @param degrees The angular diameter in degrees.
+         */
+        void setAngularSize(float degrees);
+
+        /**
+         * Returns the screen size of the sprite.
+         * @return The diameter in pixels, or 0 if the sprite is sized by angle.
+         */
+        float getScreenSize() const;
+        /**
+         * Sets a fixed on-screen size, in pixels, independent of the field of view. Use this for
+         * icons and markers rather than for bodies.
+         * @param pixels The diameter in pixels.
+         */
+        void setScreenSize(float pixels);
+
+        /**
+         * Returns the bitmap of the sprite.
+         * @return The bitmap, or null if the sprite is drawn as a plain disc.
+         */
+        std::shared_ptr<Bitmap> getBitmap() const;
+        /**
+         * Sets the bitmap of the sprite. Sprites are batched per bitmap, so objects that share one
+         * bitmap - a whole star catalogue, for instance - cost a single draw call.
+         * @param bitmap The new bitmap, or null to draw a plain disc.
+         */
+        void setBitmap(const std::shared_ptr<Bitmap>& bitmap);
+
+        /**
+         * Returns the edge softness of a disc sprite.
+         * @return The softness, 0 for a hard edge and 1 for a fully soft one.
+         */
+        float getSoftness() const;
+        /**
+         * Sets the edge softness of a disc sprite. It has no effect on a sprite with a bitmap.
+         * @param softness The softness, 0 for a hard edge and 1 for a fully soft one.
+         */
+        void setSoftness(float softness);
+
+        /**
+         * Returns the extra radius that responds to a click.
+         * @return The extra click radius in degrees.
+         */
+        float getClickRadius() const;
+        /**
+         * Sets an extra angular radius that responds to a click, added to the sprite's own size. A
+         * star half a pixel across is impossible to hit otherwise.
+         * @param degrees The extra click radius in degrees.
+         */
+        void setClickRadius(float degrees);
+
+    private:
+        float _angularSize;
+        float _screenSize;
+        std::shared_ptr<Bitmap> _bitmap;
+        float _softness;
+        float _clickRadius;
+    };
+
+}
+
+#endif

--- a/all/native/components/Options.cpp
+++ b/all/native/components/Options.cpp
@@ -44,7 +44,9 @@ namespace carto {
         _skyBitmap(),
         _backgroundBitmap(GetDefaultBackgroundBitmap()),
         _userInput(true),
-        _freeRoam(false),
+        _freeRoamMode(FreeRoamMode::FREE_ROAM_MODE_OFF),
+        _freeRoamLookSensitivity(90.0f),
+        _freeRoamMoveSpeed(0.5f),
         _kineticPan(true),
         _kineticRotation(true),
         _kineticZoom(true),
@@ -533,20 +535,52 @@ namespace carto {
         notifyOptionChanged("UserInput");
     }
     
-    bool Options::isFreeRoam() const {
+    FreeRoamMode::FreeRoamMode Options::getFreeRoamMode() const {
         std::lock_guard<std::mutex> lock(_mutex);
-        return _freeRoam;
+        return _freeRoamMode;
     }
 
-    void Options::setFreeRoam(bool enabled) {
+    void Options::setFreeRoamMode(FreeRoamMode::FreeRoamMode mode) {
         {
             std::lock_guard<std::mutex> lock(_mutex);
-            if (_freeRoam == enabled) {
+            if (_freeRoamMode == mode) {
                 return;
             }
-            _freeRoam = enabled;
+            _freeRoamMode = mode;
         }
-        notifyOptionChanged("FreeRoam");
+        notifyOptionChanged("FreeRoamMode");
+    }
+
+    float Options::getFreeRoamLookSensitivity() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _freeRoamLookSensitivity;
+    }
+
+    void Options::setFreeRoamLookSensitivity(float degreesPerInch) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_freeRoamLookSensitivity == degreesPerInch) {
+                return;
+            }
+            _freeRoamLookSensitivity = degreesPerInch;
+        }
+        notifyOptionChanged("FreeRoamLookSensitivity");
+    }
+
+    float Options::getFreeRoamMoveSpeed() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _freeRoamMoveSpeed;
+    }
+
+    void Options::setFreeRoamMoveSpeed(float distancePerInch) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_freeRoamMoveSpeed == distancePerInch) {
+                return;
+            }
+            _freeRoamMoveSpeed = distancePerInch;
+        }
+        notifyOptionChanged("FreeRoamMoveSpeed");
     }
 
     bool Options::isKineticPan() {

--- a/all/native/components/Options.cpp
+++ b/all/native/components/Options.cpp
@@ -44,6 +44,7 @@ namespace carto {
         _skyBitmap(),
         _backgroundBitmap(GetDefaultBackgroundBitmap()),
         _userInput(true),
+        _freeRoam(false),
         _kineticPan(true),
         _kineticRotation(true),
         _kineticZoom(true),
@@ -532,6 +533,22 @@ namespace carto {
         notifyOptionChanged("UserInput");
     }
     
+    bool Options::isFreeRoam() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _freeRoam;
+    }
+
+    void Options::setFreeRoam(bool enabled) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_freeRoam == enabled) {
+                return;
+            }
+            _freeRoam = enabled;
+        }
+        notifyOptionChanged("FreeRoam");
+    }
+
     bool Options::isKineticPan() {
         std::lock_guard<std::mutex> lock(_mutex);
         return _kineticPan;

--- a/all/native/components/Options.cpp
+++ b/all/native/components/Options.cpp
@@ -49,7 +49,7 @@ namespace carto {
         _kineticRotation(true),
         _kineticZoom(true),
         _rotatable(true),
-        _tiltRange(Const::MIN_SUPPORTED_TILT_ANGLE, 90.0f),
+        _tiltRange(0.0f, 90.0f), // not MIN_SUPPORTED_TILT_ANGLE: looking above the horizon is opt-in
         _zoomRange(0.0, Const::MAX_SUPPORTED_ZOOM_LEVEL),
         _panBounds(MapPos(-std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()), MapPos(std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity())),
         _focusPointOffset(0, 0),

--- a/all/native/components/Options.cpp
+++ b/all/native/components/Options.cpp
@@ -44,6 +44,7 @@ namespace carto {
         _skyBitmap(),
         _backgroundBitmap(GetDefaultBackgroundBitmap()),
         _userInput(true),
+        _panningSpeedMode(PanningSpeedMode::PANNING_SPEED_MODE_ANCHORED),
         _freeRoamMode(FreeRoamMode::FREE_ROAM_MODE_OFF),
         _freeRoamLookSensitivity(90.0f),
         _freeRoamMoveSpeed(0.5f),
@@ -535,6 +536,22 @@ namespace carto {
         notifyOptionChanged("UserInput");
     }
     
+    PanningSpeedMode::PanningSpeedMode Options::getPanningSpeedMode() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _panningSpeedMode;
+    }
+
+    void Options::setPanningSpeedMode(PanningSpeedMode::PanningSpeedMode mode) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_panningSpeedMode == mode) {
+                return;
+            }
+            _panningSpeedMode = mode;
+        }
+        notifyOptionChanged("PanningSpeedMode");
+    }
+
     FreeRoamMode::FreeRoamMode Options::getFreeRoamMode() const {
         std::lock_guard<std::mutex> lock(_mutex);
         return _freeRoamMode;

--- a/all/native/components/Options.h
+++ b/all/native/components/Options.h
@@ -460,8 +460,9 @@ namespace carto {
          * sideways turns the heading, up and down changes the tilt - instead of panning the map,
          * and panning moves to a two-finger drag. Pinch still zooms. This is what makes content
          * placed in the sky (CelestialLayer) reachable, since it is normally off the top of the
-         * screen. The camera cannot tilt above the horizon, so the sky is visible from the horizon
-         * up to half the field of view. The default is false.
+         * screen. To look ABOVE the horizon the tilt range has to allow a negative tilt - e.g.
+         * setTiltRange(MapRange(-90, 90)) - as it stops at the horizon by default. The default is
+         * false.
          * @param enabled The new state of the free roam flag.
          */
         void setFreeRoam(bool enabled);
@@ -524,8 +525,11 @@ namespace carto {
         /**
          * Sets the tilt range constraint. This will limit the tilt angle of the camera to the specified range.
          * The current tilt angle will remain unaffected, until the next time the tilt angle changes.
-         * The minimum tilt angle is 30 degrees and the maximum is 90 degrees. Values that are out of range will be clamped.
-         * The default value is MapRange(30, 90).
+         * The minimum tilt angle is -90 degrees and the maximum is 90 degrees. Values that are out of range will be clamped.
+         * The default value is MapRange(0, 90).
+         * A NEGATIVE tilt looks above the horizon: the camera stays where it is and the view pitches
+         * up, which is what an application showing the sky needs. It is opt-in, as the default range
+         * stops at the horizon.
          * @param tiltRange The new tilt range constraint in degrees.
          */
         void setTiltRange(const MapRange& tiltRange);

--- a/all/native/components/Options.h
+++ b/all/native/components/Options.h
@@ -68,6 +68,38 @@ namespace carto {
         };
     }
     
+    namespace FreeRoamMode {
+        /**
+         * Possible free roam modes: what a one-finger drag does, and which camera model the
+         * tilt and the rotation follow.
+         */
+        enum FreeRoamMode {
+            /**
+             * Off: the standard map gestures. A one-finger drag pans the map.
+             */
+            FREE_ROAM_MODE_OFF,
+            /**
+             * Look: a one-finger drag looks around instead of panning - sideways turns the heading
+             * about the camera, up and down tilts the map the way the two-finger tilt does, so the
+             * camera still orbits its focus point. Panning moves to a two-finger drag; pinch and
+             * two-finger rotation are unchanged.
+             */
+            FREE_ROAM_MODE_LOOK,
+            /**
+             * First person: the camera stops orbiting anything. A one-finger drag turns the view
+             * about the CAMERA on both axes, like a mouse in a first person game - the position
+             * never changes - and a two-finger drag moves, forward/back and strafing, the way the
+             * keys would. Pinch and two-finger rotation are off, since neither belongs to that
+             * control scheme.
+             *
+             * The camera model applies to every source, not just to touch: setTilt and
+             * setMapRotation turn the view in place too, so a camera driven by the device's
+             * orientation behaves exactly like the drag.
+             */
+            FREE_ROAM_MODE_FIRST_PERSON
+        };
+    }
+
     namespace PivotMode {
         /**
          *  Possible pivot modes.
@@ -451,21 +483,45 @@ namespace carto {
         void setUserInput(bool enabled);
     
         /**
-         * Returns the state of the free roam flag.
-         * @return True if free roam is enabled.
+         * Returns the free roam mode.
+         * @return The free roam mode.
          */
-        bool isFreeRoam() const;
+        FreeRoamMode::FreeRoamMode getFreeRoamMode() const;
         /**
-         * Sets the state of the free roam flag. In free roam a ONE-finger drag looks around -
-         * sideways turns the heading, up and down changes the tilt - instead of panning the map,
-         * and panning moves to a two-finger drag. Pinch still zooms. This is what makes content
-         * placed in the sky (CelestialLayer) reachable, since it is normally off the top of the
-         * screen. To look ABOVE the horizon the tilt range has to allow a negative tilt - e.g.
-         * setTiltRange(MapRange(-90, 90)) - as it stops at the horizon by default. The default is
-         * false.
-         * @param enabled The new state of the free roam flag.
+         * Sets the free roam mode: what a one-finger drag does, and which camera model the tilt
+         * and the rotation follow. Free roam is what makes content placed in the sky
+         * (CelestialLayer) reachable, since it is normally off the top of the screen. To look
+         * ABOVE the horizon the tilt range has to allow a negative tilt - e.g.
+         * setTiltRange(MapRange(-90, 90)) - as it stops at the horizon by default.
+         * The default is FREE_ROAM_MODE_OFF.
+         * @param mode The new free roam mode.
          */
-        void setFreeRoam(bool enabled);
+        void setFreeRoamMode(FreeRoamMode::FreeRoamMode mode);
+
+        /**
+         * Returns how fast a free roam drag turns the view.
+         * @return The turn in degrees per inch of drag.
+         */
+        float getFreeRoamLookSensitivity() const;
+        /**
+         * Sets how fast a free roam drag turns the view, in degrees per inch of drag. The default
+         * is 90, i.e. an inch of drag turns a quarter turn.
+         * @param degreesPerInch The turn in degrees per inch of drag.
+         */
+        void setFreeRoamLookSensitivity(float degreesPerInch);
+
+        /**
+         * Returns how far a first person move drag travels.
+         * @return The distance per inch of drag, as a fraction of the camera to focus distance.
+         */
+        float getFreeRoamMoveSpeed() const;
+        /**
+         * Sets how far a two-finger move travels in FREE_ROAM_MODE_FIRST_PERSON, per inch of drag,
+         * as a fraction of the distance from the camera to its focus point - so a move covers the
+         * same part of the view at any zoom. The default is 0.5.
+         * @param distancePerInch The distance per inch of drag.
+         */
+        void setFreeRoamMoveSpeed(float distancePerInch);
 
         /**
          * Returns the state of the kinetic panning flag.
@@ -720,7 +776,9 @@ namespace carto {
         std::shared_ptr<Bitmap> _backgroundBitmap;
         
         bool _userInput;
-        bool _freeRoam;
+        FreeRoamMode::FreeRoamMode _freeRoamMode;
+        float _freeRoamLookSensitivity;
+        float _freeRoamMoveSpeed;
     
         bool _kineticPan;
         bool _kineticRotation;

--- a/all/native/components/Options.h
+++ b/all/native/components/Options.h
@@ -451,6 +451,22 @@ namespace carto {
         void setUserInput(bool enabled);
     
         /**
+         * Returns the state of the free roam flag.
+         * @return True if free roam is enabled.
+         */
+        bool isFreeRoam() const;
+        /**
+         * Sets the state of the free roam flag. In free roam a ONE-finger drag looks around -
+         * sideways turns the heading, up and down changes the tilt - instead of panning the map,
+         * and panning moves to a two-finger drag. Pinch still zooms. This is what makes content
+         * placed in the sky (CelestialLayer) reachable, since it is normally off the top of the
+         * screen. The camera cannot tilt above the horizon, so the sky is visible from the horizon
+         * up to half the field of view. The default is false.
+         * @param enabled The new state of the free roam flag.
+         */
+        void setFreeRoam(bool enabled);
+
+        /**
          * Returns the state of the kinetic panning flag.
          * @return True if kinetic panning is enabled.
          */
@@ -700,6 +716,7 @@ namespace carto {
         std::shared_ptr<Bitmap> _backgroundBitmap;
         
         bool _userInput;
+        bool _freeRoam;
     
         bool _kineticPan;
         bool _kineticRotation;

--- a/all/native/components/Options.h
+++ b/all/native/components/Options.h
@@ -100,6 +100,33 @@ namespace carto {
         };
     }
 
+    namespace PanningSpeedMode {
+        /**
+         * How fast a one-finger pan moves the map on a TILTED view, where a touch near the horizon
+         * corresponds to a point far away and a touch at the bottom of the screen to a near one.
+         */
+        enum PanningSpeedMode {
+            /**
+             * The map point under the finger follows it exactly, which is what a flat map does.
+             * On a tilted view the speed then changes DURING the gesture: a drag that starts near
+             * the camera and travels up the screen accelerates as the finger reaches parts of the
+             * screen that are further away.
+             */
+            PANNING_SPEED_MODE_MAP,
+            /**
+             * The scale is measured where the pan STARTS and stays fixed for the whole gesture:
+             * starting far away still pans fast and starting close still pans slowly, but the
+             * speed never changes while the finger is down. The default.
+             */
+            PANNING_SPEED_MODE_ANCHORED,
+            /**
+             * The scale is measured at the centre of the screen, so it depends neither on where
+             * the finger started nor on where it goes - every pan moves the map at the same rate.
+             */
+            PANNING_SPEED_MODE_CONSTANT
+        };
+    }
+
     namespace PivotMode {
         /**
          *  Possible pivot modes.
@@ -483,6 +510,20 @@ namespace carto {
         void setUserInput(bool enabled);
     
         /**
+         * Returns the panning speed mode.
+         * @return The panning speed mode.
+         */
+        PanningSpeedMode::PanningSpeedMode getPanningSpeedMode() const;
+        /**
+         * Sets how fast a one-finger pan moves the map on a tilted view. The default is
+         * PANNING_SPEED_MODE_ANCHORED, which keeps the speed a gesture starts with for as long as
+         * it lasts; PANNING_SPEED_MODE_MAP is the exact grab-the-world pan, which changes speed as
+         * the finger moves between near and far parts of the screen.
+         * @param mode The new panning speed mode.
+         */
+        void setPanningSpeedMode(PanningSpeedMode::PanningSpeedMode mode);
+
+        /**
          * Returns the free roam mode.
          * @return The free roam mode.
          */
@@ -776,6 +817,7 @@ namespace carto {
         std::shared_ptr<Bitmap> _backgroundBitmap;
         
         bool _userInput;
+        PanningSpeedMode::PanningSpeedMode _panningSpeedMode;
         FreeRoamMode::FreeRoamMode _freeRoamMode;
         float _freeRoamLookSensitivity;
         float _freeRoamMoveSpeed;

--- a/all/native/graphics/ViewState.cpp
+++ b/all/native/graphics/ViewState.cpp
@@ -804,6 +804,16 @@ namespace carto {
         if (_terrainHeightMax > _terrainHeightMin) {
             near = std::max(near, std::min(terrainNear, far * 0.5f));
         }
+        if (_cameraTilt != _tilt) {
+            // The view is pitched away from the camera geometry - looking above the horizon, or a
+            // first person camera. The loop above takes the near plane from where the sampled rays
+            // MEET THE GROUND, and as the view pitches up those hits walk off into the distance:
+            // the near plane follows them out and starts clipping everything close to the camera,
+            // worse the higher the view goes. What is close to the camera does not move when the
+            // view turns, so cap the near plane with the rule that does not depend on the view
+            // direction at all - tangram's `near = m_pos.z / 50`.
+            near = std::min(near, terrainNear);
+        }
         if (!groundVisible) {
             // Nothing but sky: no ray met the ground, so the loop above left far == near and the
             // depth range would collapse onto the near plane, taking everything drawn INTO the sky

--- a/all/native/graphics/ViewState.cpp
+++ b/all/native/graphics/ViewState.cpp
@@ -99,9 +99,23 @@ namespace carto {
         double cameraHeight = _cameraPos(2) - _focusPos(2);
         double minHeight = _terrainMinCameraZ - _focusPos(2);
         if (!(cameraHeight > 0) || !(minHeight > 0)) {
-            return static_cast<float>(_zoom + std::log2(_cameraPos(2) / _terrainMinCameraZ)); // degenerate: focus at or above the shell
+            // The camera is at or below the height of the focus - a horizontal view (tilt 0) or a
+            // look above the horizon (a negative tilt). Zooming moves the camera ALONG the
+            // camera-to-focus vector, so with no vertical component left there is no zoom that
+            // clears the terrain: any bound derived here is unreachable, and clampZoom chasing it
+            // walks the zoom towards minus infinity, one step per frame, until the map is gone.
+            return std::numeric_limits<float>::infinity();
         }
-        return _zoom + static_cast<float>(std::log2(cameraHeight / minHeight));
+        float maxZoom = _zoom + static_cast<float>(std::log2(cameraHeight / minHeight));
+        if (maxZoom < _zoomRange.getMin()) {
+            // Unsatisfiable. The camera's height above the focus is dist * sin(tilt), so as the
+            // view approaches the horizon it rises by almost nothing as it zooms out and the bound
+            // runs off to minus infinity. Clamping to it then throws the map to its minimum zoom -
+            // an empty world - instead of keeping the camera clear of the ground, which it cannot
+            // do at any zoom anyway.
+            return std::numeric_limits<float>::infinity();
+        }
+        return maxZoom;
     }
 
     void ViewState::setCameraPos(const cglib::vec3<double>& cameraPos) {
@@ -152,10 +166,30 @@ namespace carto {
     
     void ViewState::setTilt(float tilt) {
         if (!std::isfinite(tilt)) {
-            Log::Errorf("ViewState::setTilt: Invalid value %g", tilt); 
+            Log::Errorf("ViewState::setTilt: Invalid value %g", tilt);
             return;
         }
         _tilt = tilt;
+    }
+
+    float ViewState::getGroundTilt() const {
+        return std::max(_tilt, 0.0f);
+    }
+
+    cglib::vec3<double> ViewState::calculateViewDir() const {
+        cglib::vec3<double> viewVec = _focusPos - _cameraPos;
+        if (cglib::length(viewVec) == 0) {
+            return cglib::vec3<double>::zero();
+        }
+        viewVec = cglib::unit(viewVec);
+        if (_tilt >= 0) {
+            return viewVec;
+        }
+        cglib::vec3<double> axis = cglib::vector_product(viewVec, _upVec);
+        if (cglib::length(axis) == 0) {
+            return viewVec;
+        }
+        return cglib::unit(cglib::transform_vector(viewVec, cglib::rotate4_matrix(axis, -_tilt * Const::DEG_TO_RAD)));
     }
     
     float ViewState::getZoom() const {
@@ -516,7 +550,7 @@ namespace carto {
 
                 cglib::vec3<double> axis = cglib::vector_product(_focusPos - _cameraPos, _upVec);
                 if (cglib::length(axis) != 0) {
-                    cglib::mat4x4<double> transform = cglib::rotate4_matrix(axis, (90 - _tilt) * Const::DEG_TO_RAD);
+                    cglib::mat4x4<double> transform = cglib::rotate4_matrix(axis, (90 - getGroundTilt()) * Const::DEG_TO_RAD);
                     _cameraPos = _focusPos + cglib::transform_vector(_cameraPos - _focusPos, transform);
                     _upVec = cglib::transform_vector(_upVec, transform);
                 }
@@ -675,7 +709,9 @@ namespace carto {
         float tanHalfFOVY = std::tan(static_cast<float>(halfFOVY * Const::DEG_TO_RAD));
         float zoom0Distance = _height * 0.5 * Const::WORLD_SIZE / (_tileDrawSize * tanHalfFOVY * (_dpi / Const::UNSCALED_DPI));
         float initialZ = std::pow(2.0f, -_zoom) * zoom0Distance / 64.0f;
-        cglib::vec3<double> zProjVector = cglib::unit(_focusPos - _cameraPos);
+        // The direction the camera actually looks along, which above the horizon is not the
+        // direction of the focus point (calculateLookatMat).
+        cglib::vec3<double> zProjVector = calculateViewDir();
 
         cglib::mat4x4<double> projMat = calculatePerspMat(halfFOVY, initialZ, 2.0f * initialZ, options);
         cglib::mat4x4<double> modelviewMat = calculateLookatMat();
@@ -687,6 +723,7 @@ namespace carto {
         near = static_cast<float>(cglib::dot_product(options.getProjectionSurface()->calculateNearestPoint(_cameraPos, heightMax) - _cameraPos, zProjVector));
         far  = near;
         skyVisible = false;
+        bool groundVisible = false;
         // ... and where the sky starts on screen. The bisection below already walks each column
         // from the ground up to the first ray that reaches no ground at all, which IS the horizon;
         // the lowest such sample over the columns is where the sky can first appear. The sky quad
@@ -707,6 +744,7 @@ namespace carto {
                         float z = static_cast<float>(cglib::dot_product(ray(t) - worldPos0, zProjVector));
                         near = std::min(near, z);
                         far  = std::max(far,  z);
+                        groundVisible = true;
 
                         if (iter < 0) {
                             break;
@@ -752,6 +790,14 @@ namespace carto {
         }
         if (_terrainHeightMax > _terrainHeightMin) {
             near = std::max(near, std::min(terrainNear, far * 0.5f));
+        }
+        if (!groundVisible) {
+            // Nothing but sky: no ray met the ground, so the loop above left far == near and the
+            // depth range would collapse onto the near plane, taking everything drawn INTO the sky
+            // (celestial objects park just inside the far plane) with it. Give it the distance the
+            // ground would have been drawn to.
+            near = std::max(near, terrainNear);
+            far = std::max(static_cast<float>(viewDistance > 0 ? viewDistance : maxDist), near * 2.0f);
         }
     }
 
@@ -890,7 +936,22 @@ namespace carto {
     }
     
     cglib::mat4x4<double> ViewState::calculateLookatMat() const {
-        return cglib::lookat4_matrix(_cameraPos, _focusPos, _upVec);
+        if (_tilt >= 0) {
+            return cglib::lookat4_matrix(_cameraPos, _focusPos, _upVec);
+        }
+        // Above the horizon the camera stays exactly where the tilt geometry left it and only the
+        // view direction pitches up. Carrying on rotating the camera about the focus - which is
+        // what tilting does between 90 and 0 degrees - puts the camera under the ground, and the
+        // view comes back upside down because the up vector is derived from a focus point on the
+        // ground. Rotating the view about the CAMERA has neither problem, and it keeps
+        // dist(camera, focus), so zoom, culling and the near/far budget are untouched.
+        cglib::vec3<double> viewVec = _focusPos - _cameraPos;
+        cglib::vec3<double> axis = cglib::vector_product(viewVec, _upVec);
+        if (cglib::length(axis) == 0) {
+            return cglib::lookat4_matrix(_cameraPos, _focusPos, _upVec);
+        }
+        cglib::mat4x4<double> transform = cglib::rotate4_matrix(axis, -_tilt * Const::DEG_TO_RAD);
+        return cglib::lookat4_matrix(_cameraPos, _cameraPos + cglib::transform_vector(viewVec, transform), cglib::transform_vector(_upVec, transform));
     }
     
     cglib::mat4x4<double> ViewState::calculateModelViewMat(const carto::Options& options) const {

--- a/all/native/graphics/ViewState.cpp
+++ b/all/native/graphics/ViewState.cpp
@@ -25,6 +25,7 @@ namespace carto {
         _cameraChanged(true),
         _rotation(0),
         _tilt(90),
+        _cameraTilt(90),
         _zoom(0.0f),
         _2PowZoom(1.0f),
         _zoom0Distance(0.0f),
@@ -170,10 +171,21 @@ namespace carto {
             return;
         }
         _tilt = tilt;
+        // The map camera model: the camera sits at the tilt, and everything below the horizon is
+        // a rotation of the view about it. setViewTilt is the other model, where the camera stays.
+        _cameraTilt = std::max(tilt, 0.0f);
     }
 
-    float ViewState::getGroundTilt() const {
-        return std::max(_tilt, 0.0f);
+    void ViewState::setViewTilt(float tilt) {
+        if (!std::isfinite(tilt)) {
+            Log::Errorf("ViewState::setViewTilt: Invalid value %g", tilt);
+            return;
+        }
+        _tilt = tilt;
+    }
+
+    float ViewState::getCameraTilt() const {
+        return _cameraTilt;
     }
 
     cglib::vec3<double> ViewState::calculateViewDir() const {
@@ -182,14 +194,15 @@ namespace carto {
             return cglib::vec3<double>::zero();
         }
         viewVec = cglib::unit(viewVec);
-        if (_tilt >= 0) {
+        float viewPitch = _cameraTilt - _tilt;
+        if (viewPitch == 0) {
             return viewVec;
         }
         cglib::vec3<double> axis = cglib::vector_product(viewVec, _upVec);
         if (cglib::length(axis) == 0) {
             return viewVec;
         }
-        return cglib::unit(cglib::transform_vector(viewVec, cglib::rotate4_matrix(axis, -_tilt * Const::DEG_TO_RAD)));
+        return cglib::unit(cglib::transform_vector(viewVec, cglib::rotate4_matrix(axis, viewPitch * Const::DEG_TO_RAD)));
     }
     
     float ViewState::getZoom() const {
@@ -550,7 +563,7 @@ namespace carto {
 
                 cglib::vec3<double> axis = cglib::vector_product(_focusPos - _cameraPos, _upVec);
                 if (cglib::length(axis) != 0) {
-                    cglib::mat4x4<double> transform = cglib::rotate4_matrix(axis, (90 - getGroundTilt()) * Const::DEG_TO_RAD);
+                    cglib::mat4x4<double> transform = cglib::rotate4_matrix(axis, (90 - _cameraTilt) * Const::DEG_TO_RAD);
                     _cameraPos = _focusPos + cglib::transform_vector(_cameraPos - _focusPos, transform);
                     _upVec = cglib::transform_vector(_upVec, transform);
                 }
@@ -936,7 +949,8 @@ namespace carto {
     }
     
     cglib::mat4x4<double> ViewState::calculateLookatMat() const {
-        if (_tilt >= 0) {
+        float viewPitch = _cameraTilt - _tilt;
+        if (viewPitch == 0) {
             return cglib::lookat4_matrix(_cameraPos, _focusPos, _upVec);
         }
         // Above the horizon the camera stays exactly where the tilt geometry left it and only the
@@ -950,7 +964,7 @@ namespace carto {
         if (cglib::length(axis) == 0) {
             return cglib::lookat4_matrix(_cameraPos, _focusPos, _upVec);
         }
-        cglib::mat4x4<double> transform = cglib::rotate4_matrix(axis, -_tilt * Const::DEG_TO_RAD);
+        cglib::mat4x4<double> transform = cglib::rotate4_matrix(axis, viewPitch * Const::DEG_TO_RAD);
         return cglib::lookat4_matrix(_cameraPos, _cameraPos + cglib::transform_vector(viewVec, transform), cglib::transform_vector(_upVec, transform));
     }
     

--- a/all/native/graphics/ViewState.h
+++ b/all/native/graphics/ViewState.h
@@ -73,7 +73,7 @@ namespace carto {
         void setUpVec(const cglib::vec3<double>& upVec);
     
         /**
-         * Returns the camera tilt angle.
+         * Returns the camera tilt angle. A NEGATIVE tilt means the view looks above the horizon.
          * @return The camera tilt angle in degrees.
          */
         float getTilt() const;
@@ -83,6 +83,22 @@ namespace carto {
          * @param tilt The new camera tilt angle in degrees.
          */
         void setTilt(float tilt);
+
+        /**
+         * Returns the part of the tilt that positions the camera: the tilt, floored at 0.
+         * The camera-to-focus vector is built from this angle alone, and everything below the
+         * horizon (a negative tilt) is a rotation of the VIEW about the camera instead - see
+         * calculateLookatMat.
+         * @return The tilt angle in degrees, never negative.
+         */
+        float getGroundTilt() const;
+
+        /**
+         * Returns the unit direction the camera looks along, including the look above the horizon
+         * that a negative tilt adds.
+         * @return The view direction, or a zero vector if the camera and the focus coincide.
+         */
+        cglib::vec3<double> calculateViewDir() const;
 
         /**
          * Returns the camera zoom level.

--- a/all/native/graphics/ViewState.h
+++ b/all/native/graphics/ViewState.h
@@ -85,13 +85,20 @@ namespace carto {
         void setTilt(float tilt);
 
         /**
-         * Returns the part of the tilt that positions the camera: the tilt, floored at 0.
-         * The camera-to-focus vector is built from this angle alone, and everything below the
-         * horizon (a negative tilt) is a rotation of the VIEW about the camera instead - see
-         * calculateLookatMat.
-         * @return The tilt angle in degrees, never negative.
+         * Sets the tilt of the VIEW only, leaving the camera where it is. The difference between
+         * the camera tilt and this one is applied as a rotation of the view about the camera, so
+         * the camera does not move at all - which is what a first person look is.
+         * @param tilt The new view tilt angle in degrees.
          */
-        float getGroundTilt() const;
+        void setViewTilt(float tilt);
+
+        /**
+         * Returns the tilt the CAMERA POSITION is built at: the camera-to-focus vector is at this
+         * angle, never below the horizon, and the difference to the view tilt is a rotation of the
+         * view about the camera (see calculateLookatMat).
+         * @return The camera tilt angle in degrees, never negative.
+         */
+        float getCameraTilt() const;
 
         /**
          * Returns the unit direction the camera looks along, including the look above the horizon
@@ -450,6 +457,7 @@ namespace carto {
     
         float _rotation;
         float _tilt;
+        float _cameraTilt;
         float _zoom;
         float _2PowZoom;
         float _zoom0Distance;

--- a/all/native/layers/CelestialEventListener.h
+++ b/all/native/layers/CelestialEventListener.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_CELESTIALEVENTLISTENER_H_
+#define _CARTO_CELESTIALEVENTLISTENER_H_
+
+#include "ui/ClickInfo.h"
+
+#include <memory>
+
+namespace carto {
+    class CelestialObject;
+
+    /**
+     * Reports clicks on the objects of a CelestialLayer.
+     */
+    class CelestialEventListener {
+    public:
+        virtual ~CelestialEventListener() { }
+
+        /**
+         * Called when an object of the layer is clicked. Objects are tested against the touch ray
+         * together with every other layer's content, so an object behind terrain is not reported.
+         * @param clickInfo The click that hit the object.
+         * @param celestialObject The object that was clicked.
+         * @return True if the click was handled and must not be passed on, false otherwise.
+         */
+        virtual bool onCelestialObjectClicked(const ClickInfo& clickInfo, const std::shared_ptr<CelestialObject>& celestialObject) {
+            return false;
+        }
+    };
+
+}
+
+#endif

--- a/all/native/layers/CelestialLayer.cpp
+++ b/all/native/layers/CelestialLayer.cpp
@@ -1,0 +1,149 @@
+#include "CelestialLayer.h"
+#include "celestial/CelestialObject.h"
+#include "components/Exceptions.h"
+#include "layers/CelestialEventListener.h"
+#include "renderers/CelestialRenderer.h"
+#include "renderers/MapRenderer.h"
+#include "renderers/components/RayIntersectedElement.h"
+#include "ui/ClickInfo.h"
+#include "utils/Log.h"
+
+#include <algorithm>
+
+namespace carto {
+
+    CelestialLayer::CelestialLayer() :
+        Layer(),
+        _objects(),
+        _celestialRenderer(std::make_shared<CelestialRenderer>()),
+        _celestialEventListener()
+    {
+    }
+
+    CelestialLayer::~CelestialLayer() {
+    }
+
+    void CelestialLayer::add(const std::shared_ptr<CelestialObject>& object) {
+        if (!object) {
+            throw NullArgumentException("Null object");
+        }
+        addAll(std::vector<std::shared_ptr<CelestialObject> > { object });
+    }
+
+    void CelestialLayer::addAll(const std::vector<std::shared_ptr<CelestialObject> >& objects) {
+        {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            for (const std::shared_ptr<CelestialObject>& object : objects) {
+                if (!object) {
+                    throw NullArgumentException("Null object");
+                }
+                _objects.push_back(object);
+            }
+        }
+        for (const std::shared_ptr<CelestialObject>& object : objects) {
+            object->setComponents(std::static_pointer_cast<CelestialLayer>(shared_from_this()));
+        }
+        refreshRenderer();
+    }
+
+    bool CelestialLayer::remove(const std::shared_ptr<CelestialObject>& object) {
+        bool removed = false;
+        {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            auto it = std::find(_objects.begin(), _objects.end(), object);
+            if (it != _objects.end()) {
+                _objects.erase(it);
+                removed = true;
+            }
+        }
+        if (removed) {
+            object->setComponents(std::shared_ptr<CelestialLayer>());
+            refreshRenderer();
+        }
+        return removed;
+    }
+
+    void CelestialLayer::clear() {
+        std::vector<std::shared_ptr<CelestialObject> > objects;
+        {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            std::swap(objects, _objects);
+        }
+        for (const std::shared_ptr<CelestialObject>& object : objects) {
+            object->setComponents(std::shared_ptr<CelestialLayer>());
+        }
+        refreshRenderer();
+    }
+
+    std::vector<std::shared_ptr<CelestialObject> > CelestialLayer::getAll() const {
+        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        return _objects;
+    }
+
+    std::shared_ptr<CelestialEventListener> CelestialLayer::getCelestialEventListener() const {
+        return _celestialEventListener.get();
+    }
+
+    void CelestialLayer::setCelestialEventListener(const std::shared_ptr<CelestialEventListener>& listener) {
+        _celestialEventListener.set(listener);
+    }
+
+    bool CelestialLayer::isUpdateInProgress() const {
+        return false;
+    }
+
+    void CelestialLayer::setComponents(const std::shared_ptr<CancelableThreadPool>& envelopeThreadPool,
+                                       const std::shared_ptr<CancelableThreadPool>& tileThreadPool,
+                                       const std::weak_ptr<Options>& options,
+                                       const std::weak_ptr<MapRenderer>& mapRenderer,
+                                       const std::weak_ptr<TouchHandler>& touchHandler)
+    {
+        Layer::setComponents(envelopeThreadPool, tileThreadPool, options, mapRenderer, touchHandler);
+        _celestialRenderer->setComponents(options, mapRenderer);
+        refreshRenderer();
+    }
+
+    void CelestialLayer::loadData(const std::shared_ptr<CullState>& cullState) {
+        // Nothing to load: the objects are held by the layer itself, and where they end up on
+        // screen is decided per frame from the camera, not from the visible tile set.
+    }
+
+    void CelestialLayer::offsetLayerHorizontally(double offset) {
+        // Direction-anchored objects have no horizontal position to offset, and position-anchored
+        // ones are resolved through the projection surface every frame.
+    }
+
+    bool CelestialLayer::onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState) {
+        if (!isVisible() || !getVisibleZoomRange().inRange(viewState.getZoom()) || getOpacity() <= 0) {
+            return false;
+        }
+        return _celestialRenderer->onDrawFrame(deltaSeconds, getOpacity(), viewState);
+    }
+
+    void CelestialLayer::calculateRayIntersectedElements(const cglib::ray3<double>& ray, const ViewState& viewState, std::vector<RayIntersectedElement>& results) const {
+        std::shared_ptr<CelestialLayer> thisLayer = std::const_pointer_cast<CelestialLayer>(std::static_pointer_cast<const CelestialLayer>(shared_from_this()));
+        _celestialRenderer->calculateRayIntersectedElements(thisLayer, ray, viewState, results);
+    }
+
+    bool CelestialLayer::processClick(const ClickInfo& clickInfo, const RayIntersectedElement& intersectedElement, const ViewState& viewState) const {
+        DirectorPtr<CelestialEventListener> listener = _celestialEventListener;
+        if (!listener) {
+            return clickInfo.getClickType() == ClickType::CLICK_TYPE_SINGLE;
+        }
+        std::shared_ptr<CelestialObject> object = intersectedElement.getElement<CelestialObject>();
+        return listener->onCelestialObjectClicked(clickInfo, object);
+    }
+
+    void CelestialLayer::registerDataSourceListener() {
+    }
+
+    void CelestialLayer::unregisterDataSourceListener() {
+    }
+
+    void CelestialLayer::refreshRenderer() {
+        std::vector<std::shared_ptr<CelestialObject> > objects = getAll();
+        _celestialRenderer->refreshObjects(objects);
+        redraw();
+    }
+
+}

--- a/all/native/layers/CelestialLayer.h
+++ b/all/native/layers/CelestialLayer.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_CELESTIALLAYER_H_
+#define _CARTO_CELESTIALLAYER_H_
+
+#include "components/DirectorPtr.h"
+#include "layers/Layer.h"
+
+#include <memory>
+#include <vector>
+
+namespace carto {
+    class CelestialObject;
+    class CelestialRenderer;
+    class CelestialEventListener;
+
+    /**
+     * A layer of objects that live in the sky rather than on the map: the sun, the moon, stars,
+     * an aircraft overhead, the path a body traces across the day.
+     *
+     * Nothing here is tied to the map's coordinates unless an object asks for it (see
+     * CelestialObject::setPosition), so panning the map does not drag the sky along. The layer
+     * is drawn in its place in the layer order, so adding it FIRST puts every object behind the
+     * map and lets terrain hide what is behind a ridge, which is what a sky body wants.
+     *
+     * Objects are batched by bitmap, so a whole star catalogue that shares one bitmap - or none -
+     * costs a single draw call.
+     */
+    class CelestialLayer : public Layer {
+    public:
+        CelestialLayer();
+        virtual ~CelestialLayer();
+
+        /**
+         * Adds an object to the layer.
+         * @param object The object to add.
+         */
+        void add(const std::shared_ptr<CelestialObject>& object);
+        /**
+         * Adds a list of objects to the layer. Cheaper than adding them one at a time, which
+         * rebuilds the batches per object.
+         * @param objects The objects to add.
+         */
+        void addAll(const std::vector<std::shared_ptr<CelestialObject> >& objects);
+        /**
+         * Removes an object from the layer.
+         * @param object The object to remove.
+         * @return True if the object was found and removed.
+         */
+        bool remove(const std::shared_ptr<CelestialObject>& object);
+        /**
+         * Removes every object from the layer.
+         */
+        void clear();
+        /**
+         * Returns all objects of the layer.
+         * @return The objects of the layer.
+         */
+        std::vector<std::shared_ptr<CelestialObject> > getAll() const;
+
+        /**
+         * Returns the object event listener.
+         * @return The object event listener.
+         */
+        std::shared_ptr<CelestialEventListener> getCelestialEventListener() const;
+        /**
+         * Sets the object event listener, which reports clicks on objects of this layer.
+         * @param listener The new object event listener.
+         */
+        void setCelestialEventListener(const std::shared_ptr<CelestialEventListener>& listener);
+
+        virtual bool isUpdateInProgress() const;
+
+    protected:
+        virtual void setComponents(const std::shared_ptr<CancelableThreadPool>& envelopeThreadPool,
+                                   const std::shared_ptr<CancelableThreadPool>& tileThreadPool,
+                                   const std::weak_ptr<Options>& options,
+                                   const std::weak_ptr<MapRenderer>& mapRenderer,
+                                   const std::weak_ptr<TouchHandler>& touchHandler);
+
+        virtual void loadData(const std::shared_ptr<CullState>& cullState);
+
+        virtual void offsetLayerHorizontally(double offset);
+
+        virtual bool onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState);
+
+        virtual void calculateRayIntersectedElements(const cglib::ray3<double>& ray, const ViewState& viewState, std::vector<RayIntersectedElement>& results) const;
+        virtual bool processClick(const ClickInfo& clickInfo, const RayIntersectedElement& intersectedElement, const ViewState& viewState) const;
+
+        virtual void registerDataSourceListener();
+        virtual void unregisterDataSourceListener();
+
+    private:
+        void refreshRenderer();
+
+        std::vector<std::shared_ptr<CelestialObject> > _objects;
+        std::shared_ptr<CelestialRenderer> _celestialRenderer;
+        ThreadSafeDirectorPtr<CelestialEventListener> _celestialEventListener;
+    };
+
+}
+
+#endif

--- a/all/native/layers/CelestialLayer.h
+++ b/all/native/layers/CelestialLayer.h
@@ -19,15 +19,15 @@ namespace carto {
     class CelestialEventListener;
 
     /**
-     * A layer of objects that live in the sky rather than on the map: the sun, the moon, stars,
-     * an aircraft overhead, the path a body traces across the day.
+     * A layer of objects that live in the sky rather than on the map: anything placed by a
+     * direction, an object overhead, or a curve traced across the sky.
      *
      * Nothing here is tied to the map's coordinates unless an object asks for it (see
      * CelestialObject::setPosition), so panning the map does not drag the sky along. The layer
      * is drawn in its place in the layer order, so adding it FIRST puts every object behind the
-     * map and lets terrain hide what is behind a ridge, which is what a sky body wants.
+     * map and lets terrain hide what is behind a ridge, which is what an object in the sky wants.
      *
-     * Objects are batched by bitmap, so a whole star catalogue that shares one bitmap - or none -
+     * Objects are batched by bitmap, so a catalogue of thousands sharing one bitmap - or none -
      * costs a single draw call.
      */
     class CelestialLayer : public Layer {

--- a/all/native/renderers/CelestialRenderer.cpp
+++ b/all/native/renderers/CelestialRenderer.cpp
@@ -1,0 +1,446 @@
+#include "CelestialRenderer.h"
+#include "celestial/CelestialArc.h"
+#include "celestial/CelestialObject.h"
+#include "celestial/CelestialSprite.h"
+#include "components/Options.h"
+#include "graphics/Bitmap.h"
+#include "graphics/ViewState.h"
+#include "layers/CelestialLayer.h"
+#include "projections/Projection.h"
+#include "projections/ProjectionSurface.h"
+#include "renderers/MapRenderer.h"
+#include "renderers/components/RayIntersectedElement.h"
+#include "renderers/utils/GLResourceManager.h"
+#include "renderers/utils/Shader.h"
+#include "renderers/utils/Texture.h"
+#include "utils/Const.h"
+#include "utils/Log.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace carto {
+
+    const double CelestialRenderer::INFINITE_DISTANCE_FACTOR = 0.9;
+
+    CelestialRenderer::CelestialRenderer() :
+        _spriteShader(),
+        _arcShader(),
+        _options(),
+        _mapRenderer(),
+        _objects(),
+        _coordBuf(),
+        _colorBuf(),
+        _texCoordBuf(),
+        _indexBuf(),
+        _mutex()
+    {
+    }
+
+    CelestialRenderer::~CelestialRenderer() {
+    }
+
+    void CelestialRenderer::setComponents(const std::weak_ptr<Options>& options, const std::weak_ptr<MapRenderer>& mapRenderer) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _options = options;
+        _mapRenderer = mapRenderer;
+        _spriteShader.reset();
+        _arcShader.reset();
+    }
+
+    void CelestialRenderer::refreshObjects(const std::vector<std::shared_ptr<CelestialObject> >& objects) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _objects = objects;
+    }
+
+    bool CelestialRenderer::initializeRenderer() {
+        if (_spriteShader && _arcShader) {
+            return true;
+        }
+        std::shared_ptr<MapRenderer> mapRenderer = _mapRenderer.lock();
+        if (!mapRenderer) {
+            return false;
+        }
+        std::shared_ptr<GLResourceManager> resourceManager = mapRenderer->getGLResourceManager();
+        if (!resourceManager) {
+            return false;
+        }
+        _spriteShader = resourceManager->create<Shader>("celestial_sprite", SPRITE_VERTEX_SHADER, SPRITE_FRAGMENT_SHADER);
+        _arcShader = resourceManager->create<Shader>("celestial_arc", ARC_VERTEX_SHADER, ARC_FRAGMENT_SHADER);
+        return static_cast<bool>(_spriteShader) && static_cast<bool>(_arcShader);
+    }
+
+    bool CelestialRenderer::resolveWorldPos(const std::shared_ptr<CelestialObject>& object, const ViewState& viewState, cglib::vec3<double>& worldPos, double& distance) const {
+        std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
+        if (!projectionSurface) {
+            return false;
+        }
+        const cglib::vec3<double>& cameraPos = viewState.getCameraPos();
+
+        if (object->isDirectionAnchored()) {
+            // The direction is given in the local frame at the camera - x east, y north, z up -
+            // and the projection surface is what turns that into a world vector, so this works on
+            // a sphere as well as on a plane.
+            MapPos focusMapPos = projectionSurface->calculateMapPos(viewState.getFocusPos());
+            cglib::vec3<double> dir = object->calculateDirectionVector();
+            cglib::vec3<double> worldDir = projectionSurface->calculateVector(focusMapPos, MapVec(dir(0), dir(1), dir(2)));
+            if (cglib::norm(worldDir) < 1.0e-12) {
+                return false;
+            }
+            worldDir = cglib::unit(worldDir);
+
+            double objectDistance = object->getDistance();
+            if (objectDistance <= 0) {
+                // Infinitely far: park it just inside the far plane. Everything the map draws is
+                // nearer, so the map covers it, and it never moves when the camera pans.
+                distance = viewState.getFar() * INFINITE_DISTANCE_FACTOR;
+            } else {
+                distance = objectDistance * Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE;
+                distance = std::min(distance, static_cast<double>(viewState.getFar()) * INFINITE_DISTANCE_FACTOR);
+            }
+            worldPos = cameraPos + worldDir * distance;
+            return true;
+        }
+
+        std::shared_ptr<Options> options = _options.lock();
+        if (!options) {
+            return false;
+        }
+        MapPos internalPos = options->getBaseProjection()->toInternal(object->getPosition());
+        cglib::vec3<double> surfacePos = projectionSurface->calculatePosition(internalPos);
+        cglib::vec3<double> normal = projectionSurface->calculateNormal(internalPos);
+        double altitude = object->getPositionAltitude() * Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE;
+        worldPos = surfacePos + normal * altitude;
+        distance = cglib::length(worldPos - cameraPos);
+        return distance > 0;
+    }
+
+    void CelestialRenderer::buildSprites(const ViewState& viewState, float opacity, std::vector<SpriteInstance>& instances) const {
+        double tanHalfFovY = std::tan(viewState.getFOVY() * 0.5 * Const::DEG_TO_RAD);
+        float halfHeight = std::max(1.0f, viewState.getHalfHeight());
+
+        for (const std::shared_ptr<CelestialObject>& object : _objects) {
+            auto sprite = std::dynamic_pointer_cast<CelestialSprite>(object);
+            if (!sprite || !sprite->isVisible()) {
+                continue;
+            }
+            cglib::vec3<double> worldPos;
+            double distance = 0;
+            if (!resolveWorldPos(object, viewState, worldPos, distance)) {
+                continue;
+            }
+
+            float halfSize = 0;
+            if (sprite->getAngularSize() > 0) {
+                // A real body: its size is an angle, so what it covers in world units grows with
+                // the distance it was placed at, and it ends up the same angular size either way.
+                halfSize = static_cast<float>(distance * std::tan(sprite->getAngularSize() * 0.5 * Const::DEG_TO_RAD));
+            } else {
+                // A fixed number of pixels: one pixel is this many world units at that distance.
+                double worldPerPixel = distance * tanHalfFovY / halfHeight;
+                halfSize = static_cast<float>(sprite->getScreenSize() * 0.5 * worldPerPixel);
+            }
+            if (!(halfSize > 0)) {
+                continue;
+            }
+
+            Color color = sprite->getColor();
+            SpriteInstance instance;
+            instance.object = object;
+            instance.worldPos = worldPos;
+            instance.halfSize = halfSize;
+            instance.softness = sprite->getSoftness();
+            instance.color[0] = static_cast<unsigned char>(color.getR() * opacity);
+            instance.color[1] = static_cast<unsigned char>(color.getG() * opacity);
+            instance.color[2] = static_cast<unsigned char>(color.getB() * opacity);
+            instance.color[3] = static_cast<unsigned char>(color.getA() * opacity);
+            instance.bitmap = sprite->getBitmap();
+            instances.push_back(instance);
+        }
+
+        // Far to near, so overlapping discs blend in the order the eye expects.
+        const cglib::vec3<double>& cameraPos = viewState.getCameraPos();
+        std::sort(instances.begin(), instances.end(), [&cameraPos](const SpriteInstance& a, const SpriteInstance& b) {
+            return cglib::norm(a.worldPos - cameraPos) > cglib::norm(b.worldPos - cameraPos);
+        });
+    }
+
+    void CelestialRenderer::drawSprites(const std::vector<SpriteInstance>& instances, const ViewState& viewState) {
+        if (instances.empty()) {
+            return;
+        }
+        std::shared_ptr<MapRenderer> mapRenderer = _mapRenderer.lock();
+        if (!mapRenderer) {
+            return;
+        }
+
+        // Camera-facing basis, taken from the view matrix rows: everything is a billboard here.
+        const cglib::mat4x4<double>& mvMat = viewState.getModelviewMat();
+        cglib::vec3<double> right(mvMat(0, 0), mvMat(0, 1), mvMat(0, 2));
+        cglib::vec3<double> up(mvMat(1, 0), mvMat(1, 1), mvMat(1, 2));
+        const cglib::vec3<double>& cameraPos = viewState.getCameraPos();
+
+        glUseProgram(_spriteShader->getProgId());
+        GLuint a_coord = _spriteShader->getAttribLoc("a_coord");
+        GLuint a_texCoord = _spriteShader->getAttribLoc("a_texCoord");
+        GLuint a_color = _spriteShader->getAttribLoc("a_color");
+        glUniformMatrix4fv(_spriteShader->getUniformLoc("u_mvpMat"), 1, GL_FALSE, viewState.getRTEModelviewProjectionMat().data());
+        glUniform1i(_spriteShader->getUniformLoc("u_tex"), 0);
+        glActiveTexture(GL_TEXTURE0);
+        glEnableVertexAttribArray(a_coord);
+        glEnableVertexAttribArray(a_texCoord);
+        glEnableVertexAttribArray(a_color);
+
+        // One batch per bitmap: a whole star catalogue that shares a bitmap, or none at all, is a
+        // single draw call.
+        std::size_t index = 0;
+        while (index < instances.size()) {
+            const std::shared_ptr<Bitmap>& batchBitmap = instances[index].bitmap;
+            float batchSoftness = instances[index].softness;
+            _coordBuf.clear();
+            _colorBuf.clear();
+            _texCoordBuf.clear();
+            _indexBuf.clear();
+
+            std::size_t count = 0;
+            while (index < instances.size() && instances[index].bitmap == batchBitmap && instances[index].softness == batchSoftness) {
+                const SpriteInstance& instance = instances[index++];
+                cglib::vec3<double> rel = instance.worldPos - cameraPos;
+                static const float CORNERS[4][2] = { { -1, -1 }, { 1, -1 }, { 1, 1 }, { -1, 1 } };
+                for (int i = 0; i < 4; i++) {
+                    cglib::vec3<double> corner = rel + right * static_cast<double>(CORNERS[i][0] * instance.halfSize) + up * static_cast<double>(CORNERS[i][1] * instance.halfSize);
+                    _coordBuf.push_back(static_cast<float>(corner(0)));
+                    _coordBuf.push_back(static_cast<float>(corner(1)));
+                    _coordBuf.push_back(static_cast<float>(corner(2)));
+                    _texCoordBuf.push_back(CORNERS[i][0] * 0.5f + 0.5f);
+                    _texCoordBuf.push_back(CORNERS[i][1] * 0.5f + 0.5f);
+                    for (int c = 0; c < 4; c++) {
+                        _colorBuf.push_back(instance.color[c]);
+                    }
+                }
+                unsigned short base = static_cast<unsigned short>(count * 4);
+                _indexBuf.push_back(base + 0);
+                _indexBuf.push_back(base + 1);
+                _indexBuf.push_back(base + 2);
+                _indexBuf.push_back(base + 0);
+                _indexBuf.push_back(base + 2);
+                _indexBuf.push_back(base + 3);
+                count++;
+            }
+
+            std::shared_ptr<Texture> texture;
+            if (batchBitmap) {
+                texture = mapRenderer->getGLResourceManager()->create<Texture>(batchBitmap, false, false);
+            }
+            glUniform1f(_spriteShader->getUniformLoc("u_hasTex"), texture ? 1.0f : 0.0f);
+            glUniform1f(_spriteShader->getUniformLoc("u_softness"), std::max(0.001f, batchSoftness));
+            if (texture) {
+                glBindTexture(GL_TEXTURE_2D, texture->getTexId());
+            }
+
+            glVertexAttribPointer(a_coord, 3, GL_FLOAT, GL_FALSE, 0, _coordBuf.data());
+            glVertexAttribPointer(a_texCoord, 2, GL_FLOAT, GL_FALSE, 0, _texCoordBuf.data());
+            glVertexAttribPointer(a_color, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, _colorBuf.data());
+            glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(_indexBuf.size()), GL_UNSIGNED_SHORT, _indexBuf.data());
+        }
+
+        glDisableVertexAttribArray(a_coord);
+        glDisableVertexAttribArray(a_texCoord);
+        glDisableVertexAttribArray(a_color);
+    }
+
+    void CelestialRenderer::drawArcs(const ViewState& viewState, float opacity) {
+        std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
+        if (!projectionSurface) {
+            return;
+        }
+        const cglib::vec3<double>& cameraPos = viewState.getCameraPos();
+        MapPos focusMapPos = projectionSurface->calculateMapPos(viewState.getFocusPos());
+        double distance = viewState.getFar() * INFINITE_DISTANCE_FACTOR;
+
+        bool bound = false;
+        GLuint a_coord = 0;
+        for (const std::shared_ptr<CelestialObject>& object : _objects) {
+            auto arc = std::dynamic_pointer_cast<CelestialArc>(object);
+            if (!arc || !arc->isVisible()) {
+                continue;
+            }
+            std::vector<cglib::vec3<double> > directions = arc->buildDirections();
+            if (directions.size() < 2) {
+                continue;
+            }
+            bool belowHorizonVisible = arc->isBelowHorizonVisible();
+
+            _coordBuf.clear();
+            _indexBuf.clear();
+            unsigned short vertexCount = 0;
+            for (std::size_t i = 0; i + 1 < directions.size(); i++) {
+                if (!belowHorizonVisible && (directions[i](2) < 0 || directions[i + 1](2) < 0)) {
+                    continue;
+                }
+                for (int e = 0; e < 2; e++) {
+                    const cglib::vec3<double>& dir = directions[i + e];
+                    cglib::vec3<double> worldDir = projectionSurface->calculateVector(focusMapPos, MapVec(dir(0), dir(1), dir(2)));
+                    cglib::vec3<double> rel = worldDir * distance;
+                    _coordBuf.push_back(static_cast<float>(rel(0)));
+                    _coordBuf.push_back(static_cast<float>(rel(1)));
+                    _coordBuf.push_back(static_cast<float>(rel(2)));
+                    _indexBuf.push_back(vertexCount++);
+                }
+            }
+            if (_indexBuf.empty()) {
+                continue;
+            }
+
+            if (!bound) {
+                glUseProgram(_arcShader->getProgId());
+                a_coord = _arcShader->getAttribLoc("a_coord");
+                glUniformMatrix4fv(_arcShader->getUniformLoc("u_mvpMat"), 1, GL_FALSE, viewState.getRTEModelviewProjectionMat().data());
+                glEnableVertexAttribArray(a_coord);
+                bound = true;
+            }
+            Color color = arc->getColor();
+            glUniform4f(_arcShader->getUniformLoc("u_color"),
+                        color.getR() / 255.0f * opacity, color.getG() / 255.0f * opacity,
+                        color.getB() / 255.0f * opacity, color.getA() / 255.0f * opacity);
+            glLineWidth(std::max(1.0f, arc->getWidth()));
+            glVertexAttribPointer(a_coord, 3, GL_FLOAT, GL_FALSE, 0, _coordBuf.data());
+            glDrawElements(GL_LINES, static_cast<GLsizei>(_indexBuf.size()), GL_UNSIGNED_SHORT, _indexBuf.data());
+        }
+        if (bound) {
+            glDisableVertexAttribArray(a_coord);
+            glLineWidth(1.0f);
+        }
+    }
+
+    bool CelestialRenderer::onDrawFrame(float deltaSeconds, float opacity, const ViewState& viewState) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        if (_objects.empty()) {
+            return false;
+        }
+        if (!initializeRenderer()) {
+            return false;
+        }
+
+        // Depth-tested but not depth-writing: the map in front covers a sky object, and the object
+        // never occludes anything itself.
+        glEnable(GL_DEPTH_TEST);
+        glDepthMask(GL_FALSE);
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glDisable(GL_CULL_FACE);
+
+        std::vector<SpriteInstance> instances;
+        buildSprites(viewState, opacity, instances);
+        drawSprites(instances, viewState);
+        drawArcs(viewState, opacity);
+
+        glDepthMask(GL_TRUE);
+        glEnable(GL_CULL_FACE);
+        glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+        return false;
+    }
+
+    void CelestialRenderer::calculateRayIntersectedElements(const std::shared_ptr<CelestialLayer>& layer, const cglib::ray3<double>& ray, const ViewState& viewState, std::vector<RayIntersectedElement>& results) const {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        cglib::vec3<double> rayDir = cglib::unit(ray.direction);
+        for (const std::shared_ptr<CelestialObject>& object : _objects) {
+            auto sprite = std::dynamic_pointer_cast<CelestialSprite>(object);
+            if (!sprite || !sprite->isVisible()) {
+                continue;
+            }
+            cglib::vec3<double> worldPos;
+            double distance = 0;
+            if (!resolveWorldPos(object, viewState, worldPos, distance)) {
+                continue;
+            }
+            cglib::vec3<double> toObject = worldPos - ray.origin;
+            double objectDistance = cglib::length(toObject);
+            if (objectDistance <= 0) {
+                continue;
+            }
+            // Angular test, which is the natural one here: how far off the touch ray is from the
+            // direction the object sits in. A star is drawn a pixel across but gets the click
+            // radius its own setting asks for, or nobody could ever hit it.
+            double cosAngle = cglib::dot_product(cglib::unit(toObject), rayDir);
+            if (cosAngle <= 0) {
+                continue;
+            }
+            double angle = std::acos(std::min(1.0, cosAngle));
+            double radius = std::atan2(static_cast<double>(sprite->getScreenSize() > 0 ? 0.0f : sprite->getAngularSize()) * 0.5 * Const::DEG_TO_RAD, 1.0);
+            radius = std::max(radius, sprite->getClickRadius() * Const::DEG_TO_RAD);
+            if (sprite->getScreenSize() > 0) {
+                // A pixel-sized sprite: convert its half size on screen into an angle.
+                double tanHalfFovY = std::tan(viewState.getFOVY() * 0.5 * Const::DEG_TO_RAD);
+                double halfHeight = std::max(1.0f, viewState.getHalfHeight());
+                radius = std::max(radius, std::atan(sprite->getScreenSize() * 0.5 * tanHalfFovY / halfHeight));
+            }
+            if (angle > radius) {
+                continue;
+            }
+            cglib::vec3<double> hitPos = ray.origin + rayDir * objectDistance;
+            results.push_back(RayIntersectedElement(std::static_pointer_cast<CelestialObject>(object), layer, hitPos, worldPos, true));
+        }
+    }
+
+    const std::string CelestialRenderer::SPRITE_VERTEX_SHADER = R"GLSL(
+        attribute vec3 a_coord;
+        attribute vec2 a_texCoord;
+        attribute vec4 a_color;
+        uniform mat4 u_mvpMat;
+        varying vec2 v_texCoord;
+        varying vec4 v_color;
+        void main() {
+            v_texCoord = a_texCoord;
+            v_color = a_color;
+            gl_Position = u_mvpMat * vec4(a_coord, 1.0);
+        }
+    )GLSL";
+
+    const std::string CelestialRenderer::SPRITE_FRAGMENT_SHADER = R"GLSL(
+        #ifdef GL_FRAGMENT_PRECISION_HIGH
+        precision highp float;
+        #else
+        precision mediump float;
+        #endif
+        uniform sampler2D u_tex;
+        uniform float u_hasTex;
+        uniform float u_softness;
+        varying vec2 v_texCoord;
+        varying vec4 v_color;
+        void main() {
+            vec4 color = v_color;
+            if (u_hasTex > 0.5) {
+                color *= texture2D(u_tex, v_texCoord);
+            } else {
+                // No bitmap: a disc, soft at the edge by u_softness. Cheaper than a texture and
+                // enough for a sun, a moon or a star.
+                float d = length(v_texCoord - vec2(0.5)) * 2.0;
+                color.a *= 1.0 - smoothstep(1.0 - u_softness, 1.0, d);
+            }
+            gl_FragColor = color;
+        }
+    )GLSL";
+
+    const std::string CelestialRenderer::ARC_VERTEX_SHADER = R"GLSL(
+        attribute vec3 a_coord;
+        uniform mat4 u_mvpMat;
+        void main() {
+            gl_Position = u_mvpMat * vec4(a_coord, 1.0);
+        }
+    )GLSL";
+
+    const std::string CelestialRenderer::ARC_FRAGMENT_SHADER = R"GLSL(
+        #ifdef GL_FRAGMENT_PRECISION_HIGH
+        precision highp float;
+        #else
+        precision mediump float;
+        #endif
+        uniform vec4 u_color;
+        void main() {
+            gl_FragColor = u_color;
+        }
+    )GLSL";
+
+}

--- a/all/native/renderers/CelestialRenderer.cpp
+++ b/all/native/renderers/CelestialRenderer.cpp
@@ -191,8 +191,8 @@ namespace carto {
         glEnableVertexAttribArray(a_texCoord);
         glEnableVertexAttribArray(a_color);
 
-        // One batch per bitmap: a whole star catalogue that shares a bitmap, or none at all, is a
-        // single draw call.
+        // One batch per bitmap: a catalogue of thousands that shares a bitmap, or none at all, is
+        // a single draw call.
         std::size_t index = 0;
         while (index < instances.size()) {
             const std::shared_ptr<Bitmap>& batchBitmap = instances[index].bitmap;
@@ -270,11 +270,13 @@ namespace carto {
                 continue;
             }
             bool belowHorizonVisible = arc->isBelowHorizonVisible();
+            // A segmented arc is a set of separate lines, a plain one is a path through its points.
+            std::size_t step = (arc->isSegmented() ? 2 : 1);
 
             _coordBuf.clear();
             _indexBuf.clear();
             unsigned short vertexCount = 0;
-            for (std::size_t i = 0; i + 1 < directions.size(); i++) {
+            for (std::size_t i = 0; i + 1 < directions.size(); i += step) {
                 if (!belowHorizonVisible && (directions[i](2) < 0 || directions[i + 1](2) < 0)) {
                     continue;
                 }
@@ -345,6 +347,7 @@ namespace carto {
         std::lock_guard<std::mutex> lock(_mutex);
 
         cglib::vec3<double> rayDir = cglib::unit(ray.direction);
+        calculateRayIntersectedArcs(layer, ray, rayDir, viewState, results);
         for (const std::shared_ptr<CelestialObject>& object : _objects) {
             auto sprite = std::dynamic_pointer_cast<CelestialSprite>(object);
             if (!sprite || !sprite->isVisible()) {
@@ -361,8 +364,8 @@ namespace carto {
                 continue;
             }
             // Angular test, which is the natural one here: how far off the touch ray is from the
-            // direction the object sits in. A star is drawn a pixel across but gets the click
-            // radius its own setting asks for, or nobody could ever hit it.
+            // direction the object sits in. A sprite a pixel across gets the click radius its own
+            // setting asks for, or nobody could ever hit it.
             double cosAngle = cglib::dot_product(cglib::unit(toObject), rayDir);
             if (cosAngle <= 0) {
                 continue;
@@ -381,6 +384,64 @@ namespace carto {
             }
             cglib::vec3<double> hitPos = ray.origin + rayDir * objectDistance;
             results.push_back(RayIntersectedElement(std::static_pointer_cast<CelestialObject>(object), layer, hitPos, worldPos, true));
+        }
+    }
+
+    void CelestialRenderer::calculateRayIntersectedArcs(const std::shared_ptr<CelestialLayer>& layer, const cglib::ray3<double>& ray, const cglib::vec3<double>& rayDir, const ViewState& viewState, std::vector<RayIntersectedElement>& results) const {
+        std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
+        if (!projectionSurface) {
+            return;
+        }
+        MapPos focusMapPos = projectionSurface->calculateMapPos(viewState.getFocusPos());
+        double distance = viewState.getFar() * INFINITE_DISTANCE_FACTOR;
+
+        for (const std::shared_ptr<CelestialObject>& object : _objects) {
+            auto arc = std::dynamic_pointer_cast<CelestialArc>(object);
+            if (!arc || !arc->isVisible() || !(arc->getClickRadius() > 0)) {
+                continue;
+            }
+            std::vector<cglib::vec3<double> > directions = arc->buildDirections();
+            if (directions.size() < 2) {
+                continue;
+            }
+            bool belowHorizonVisible = arc->isBelowHorizonVisible();
+            double radius = arc->getClickRadius() * Const::DEG_TO_RAD;
+            double bestCos = std::cos(radius);
+            bool hit = false;
+            std::size_t step = (arc->isSegmented() ? 2 : 1);
+
+            // The same angular test the sprites use, against the nearest point of the curve: for
+            // every segment, the closest point of the chord to the ray direction, brought back onto
+            // the unit sphere. A curve drawn two pixels wide is otherwise unhittable.
+            for (std::size_t i = 0; i + 1 < directions.size(); i += step) {
+                if (!belowHorizonVisible && (directions[i](2) < 0 || directions[i + 1](2) < 0)) {
+                    continue;
+                }
+                cglib::vec3<double> u = cglib::unit(projectionSurface->calculateVector(focusMapPos, MapVec(directions[i](0), directions[i](1), directions[i](2))));
+                cglib::vec3<double> v = cglib::unit(projectionSurface->calculateVector(focusMapPos, MapVec(directions[i + 1](0), directions[i + 1](1), directions[i + 1](2))));
+                cglib::vec3<double> edge = v - u;
+                double edgeNorm = cglib::norm(edge);
+                double t = (edgeNorm > 0 ? cglib::dot_product(rayDir - u, edge) / edgeNorm : 0.0);
+                t = std::max(0.0, std::min(1.0, t));
+                cglib::vec3<double> closest = u + edge * t;
+                if (cglib::norm(closest) <= 0) {
+                    continue;
+                }
+                double cosAngle = cglib::dot_product(cglib::unit(closest), rayDir);
+                if (cosAngle > bestCos) {
+                    bestCos = cosAngle;
+                    hit = true;
+                }
+            }
+            if (hit) {
+                // Curves are all parked at the same distance, so the click handler - which orders
+                // by distance from the camera - would pick between two overlapping ones by list
+                // order. Reporting the hit a hair further away the wider it was missed makes the
+                // curve the touch actually aimed at win, and leaves sprites (reported at their
+                // true distance) ahead of a curve running through them.
+                cglib::vec3<double> hitPos = ray.origin + rayDir * (distance / bestCos);
+                results.push_back(RayIntersectedElement(std::static_pointer_cast<CelestialObject>(object), layer, hitPos, hitPos, true));
+            }
         }
     }
 
@@ -415,7 +476,7 @@ namespace carto {
                 color *= texture2D(u_tex, v_texCoord);
             } else {
                 // No bitmap: a disc, soft at the edge by u_softness. Cheaper than a texture and
-                // enough for a sun, a moon or a star.
+                // enough for a disc or a point of light.
                 float d = length(v_texCoord - vec2(0.5)) * 2.0;
                 color.a *= 1.0 - smoothstep(1.0 - u_softness, 1.0, d);
             }

--- a/all/native/renderers/CelestialRenderer.h
+++ b/all/native/renderers/CelestialRenderer.h
@@ -70,6 +70,7 @@ namespace carto {
         void buildSprites(const ViewState& viewState, float opacity, std::vector<SpriteInstance>& instances) const;
         void drawSprites(const std::vector<SpriteInstance>& instances, const ViewState& viewState);
         void drawArcs(const ViewState& viewState, float opacity);
+        void calculateRayIntersectedArcs(const std::shared_ptr<CelestialLayer>& layer, const cglib::ray3<double>& ray, const cglib::vec3<double>& rayDir, const ViewState& viewState, std::vector<RayIntersectedElement>& results) const;
 
         static const std::string SPRITE_VERTEX_SHADER;
         static const std::string SPRITE_FRAGMENT_SHADER;

--- a/all/native/renderers/CelestialRenderer.h
+++ b/all/native/renderers/CelestialRenderer.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_CELESTIALRENDERER_H_
+#define _CARTO_CELESTIALRENDERER_H_
+
+#include "renderers/utils/GLContext.h"
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <cglib/vec.h>
+#include <cglib/ray.h>
+
+namespace carto {
+    class Bitmap;
+    class CelestialLayer;
+    class CelestialObject;
+    class GLResourceManager;
+    class MapRenderer;
+    class Options;
+    class RayIntersectedElement;
+    class Shader;
+    class Texture;
+    class TextureManager;
+    class ViewState;
+
+    /**
+     * Draws the objects of a CelestialLayer.
+     *
+     * Sprites are billboards expanded in the vertex shader and batched by bitmap, so any number of
+     * objects sharing one bitmap - or none, the plain disc case - is a single draw call. Arcs are
+     * line strips built once per change and drawn together.
+     *
+     * Depth: objects are drawn depth-TESTED but do not write depth. A direction-anchored object is
+     * placed just inside the far plane, so the map and the terrain in front of it cover it exactly
+     * as they should, while it never occludes anything itself.
+     */
+    class CelestialRenderer {
+    public:
+        CelestialRenderer();
+        virtual ~CelestialRenderer();
+
+        void setComponents(const std::weak_ptr<Options>& options, const std::weak_ptr<MapRenderer>& mapRenderer);
+
+        void refreshObjects(const std::vector<std::shared_ptr<CelestialObject> >& objects);
+
+        bool onDrawFrame(float deltaSeconds, float opacity, const ViewState& viewState);
+
+        void calculateRayIntersectedElements(const std::shared_ptr<CelestialLayer>& layer, const cglib::ray3<double>& ray, const ViewState& viewState, std::vector<RayIntersectedElement>& results) const;
+
+    private:
+        // A sprite ready to draw: its world position for this frame, and the size that position
+        // implies in world units.
+        struct SpriteInstance {
+            std::shared_ptr<CelestialObject> object;
+            cglib::vec3<double> worldPos;
+            float halfSize;                 // world units at worldPos
+            float softness;
+            unsigned char color[4];
+            std::shared_ptr<Bitmap> bitmap;
+        };
+
+        bool initializeRenderer();
+        bool resolveWorldPos(const std::shared_ptr<CelestialObject>& object, const ViewState& viewState, cglib::vec3<double>& worldPos, double& distance) const;
+        void buildSprites(const ViewState& viewState, float opacity, std::vector<SpriteInstance>& instances) const;
+        void drawSprites(const std::vector<SpriteInstance>& instances, const ViewState& viewState);
+        void drawArcs(const ViewState& viewState, float opacity);
+
+        static const std::string SPRITE_VERTEX_SHADER;
+        static const std::string SPRITE_FRAGMENT_SHADER;
+        static const std::string ARC_VERTEX_SHADER;
+        static const std::string ARC_FRAGMENT_SHADER;
+
+        // How far inside the far plane an infinitely distant object is placed. Far enough that the
+        // map is always in front of it, close enough that it never clips.
+        static const double INFINITE_DISTANCE_FACTOR;
+
+        std::shared_ptr<Shader> _spriteShader;
+        std::shared_ptr<Shader> _arcShader;
+        std::weak_ptr<Options> _options;
+        std::weak_ptr<MapRenderer> _mapRenderer;
+
+        std::vector<std::shared_ptr<CelestialObject> > _objects;
+
+        std::vector<float> _coordBuf;
+        std::vector<unsigned char> _colorBuf;
+        std::vector<float> _texCoordBuf;
+        std::vector<unsigned short> _indexBuf;
+
+        mutable std::mutex _mutex;
+    };
+
+}
+
+#endif

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1910,10 +1910,16 @@ namespace carto {
                         // At the bottom of the zoom range there is no correction left to make, and
                         // issuing one anyway is another per-frame redraw that changes nothing.
                         bool zoomExhausted = viewState.getZoom() <= _options->getZoomRange().getMin() + 1.0e-4f;
-                        if (!zoomExhausted && cameraPos(2) > 0 && cameraPos(2) < minCameraZ - deadBand) {
-                            double scale = (cameraPos(2) > focusZ && minCameraZ > focusZ
+                        // A camera at or below the focus height - a horizontal view, or one looking
+                        // above the horizon - cannot be raised by zooming out at all: the zoom
+                        // scales the camera-to-focus vector, which is then horizontal. Correcting
+                        // anyway asks for a zoom that never arrives, every frame (see
+                        // ViewState::getTerrainMaxZoom, which drops its bound for the same reason).
+                        bool cameraAboveFocus = cameraPos(2) > focusZ + deadBand;
+                        if (!zoomExhausted && cameraAboveFocus && cameraPos(2) > 0 && cameraPos(2) < minCameraZ - deadBand) {
+                            double scale = (minCameraZ > focusZ
                                 ? (minCameraZ - focusZ) / (cameraPos(2) - focusZ)   // exact: the focus stays put
-                                : minCameraZ / cameraPos(2));                        // degenerate (focus above the camera)
+                                : minCameraZ / cameraPos(2));                        // degenerate (focus above the shell)
                             CameraZoomEvent zoomEvent;
                             zoomEvent.setZoomDelta(static_cast<float>(-std::log2(scale))); // negative: zoom out onto the clearance
                             calculateCameraEvent(zoomEvent, clampDuration, false);

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1258,7 +1258,10 @@ namespace carto {
         cglib::vec3<double> origin = viewState.getCameraPos();
         cglib::vec3<double> target = viewState.getProjectionSurface()->calculatePosition(targetPos);
         cglib::ray3<double> ray(origin, target - origin);
-    
+        calculateRayIntersectedElements(ray, viewState, results);
+    }
+
+    void MapRenderer::calculateRayIntersectedElements(const cglib::ray3<double>& ray, ViewState& viewState, std::vector<RayIntersectedElement>& results) {
         // Normal layer click detection is done in the layer order
         for (const std::shared_ptr<Layer>& layer : _layers->getAll()) {
             layer->calculateRayIntersectedElements(ray, viewState, results);

--- a/all/native/renderers/MapRenderer.h
+++ b/all/native/renderers/MapRenderer.h
@@ -20,6 +20,7 @@
 #include "components/StyleEnvironment.h"
 
 #include <cglib/mat.h>
+#include <cglib/ray.h>
 #include <vt/TileId.h>
 
 #include <array>
@@ -173,6 +174,9 @@ namespace carto {
         void setZBuffering(bool enable);
     
         void calculateRayIntersectedElements(const MapPos& targetPos, ViewState& viewState, std::vector<RayIntersectedElement>& results);
+        // Same, for a ray that never meets the ground - a touch aimed at the sky. Layers whose
+        // content is anchored in the sky (CelestialLayer) are only reachable this way.
+        void calculateRayIntersectedElements(const cglib::ray3<double>& ray, ViewState& viewState, std::vector<RayIntersectedElement>& results);
     
         void billboardsChanged();
         void vtLabelsChanged(const std::shared_ptr<Layer>& layer, bool delay);

--- a/all/native/renderers/cameraevents/CameraRotationEvent.cpp
+++ b/all/native/renderers/cameraevents/CameraRotationEvent.cpp
@@ -83,6 +83,12 @@ namespace carto {
         if (_useTarget) {
             // Use specified target instead of focus position, if specified
             targetPos = projectionSurface->calculatePosition(_targetPos);
+        } else if (options.getFreeRoamMode() == FreeRoamMode::FREE_ROAM_MODE_FIRST_PERSON) {
+            // First person: the view turns about the CAMERA. Turning about the focus point on the
+            // ground would swing the camera around a circle of the focus distance, which is not
+            // what turning your head does - and an orientation-driven camera calls setMapRotation,
+            // so it has to behave exactly like the drag.
+            targetPos = cameraPos;
         }
         
         cglib::vec3<double> axis = projectionSurface->calculateNormal(projectionSurface->calculateMapPos(targetPos));

--- a/all/native/renderers/cameraevents/CameraTiltEvent.cpp
+++ b/all/native/renderers/cameraevents/CameraTiltEvent.cpp
@@ -81,12 +81,27 @@ namespace carto {
             return;
         }
         
+        if (options.getFreeRoamMode() == FreeRoamMode::FREE_ROAM_MODE_FIRST_PERSON) {
+            // First person: the camera does not move at all, whatever the tilt does. The view is
+            // rotated about it instead (ViewState::calculateLookatMat), which is what a mouse look
+            // is - and what an orientation-driven camera needs, so that setTilt from a sensor
+            // behaves exactly like the drag.
+            viewState.setViewTilt(tilt);
+            viewState.cameraChanged();
+            if (_keepRotation) {
+                CameraRotationEvent cameraRotationEvent;
+                cameraRotationEvent.setRotation(rotation);
+                cameraRotationEvent.calculate(options, viewState);
+            }
+            return;
+        }
+
         // Only the part of the tilt at or above the horizon moves the camera. A negative tilt is a
         // look UP from wherever the camera already is - ViewState::calculateLookatMat pitches the
         // view about the camera for it - and rotating the camera on under the ground instead is
         // what flips the view over.
         float groundTilt = std::max(tilt, 0.0f);
-        cglib::mat4x4<double> tiltTransform = cglib::rotate4_matrix(axis, (groundTilt - viewState.getGroundTilt()) * Const::DEG_TO_RAD);
+        cglib::mat4x4<double> tiltTransform = cglib::rotate4_matrix(axis, (groundTilt - viewState.getCameraTilt()) * Const::DEG_TO_RAD);
         cameraPos = focusPos + cglib::transform_vector(cameraPos - focusPos, tiltTransform);
         upVec = cglib::transform_vector(upVec, tiltTransform);
     

--- a/all/native/renderers/cameraevents/CameraTiltEvent.cpp
+++ b/all/native/renderers/cameraevents/CameraTiltEvent.cpp
@@ -8,6 +8,7 @@
 #include "utils/Log.h"
 #include "utils/GeneralUtils.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace carto {
@@ -80,7 +81,12 @@ namespace carto {
             return;
         }
         
-        cglib::mat4x4<double> tiltTransform = cglib::rotate4_matrix(axis, (tilt - viewState.getTilt()) * Const::DEG_TO_RAD);
+        // Only the part of the tilt at or above the horizon moves the camera. A negative tilt is a
+        // look UP from wherever the camera already is - ViewState::calculateLookatMat pitches the
+        // view about the camera for it - and rotating the camera on under the ground instead is
+        // what flips the view over.
+        float groundTilt = std::max(tilt, 0.0f);
+        cglib::mat4x4<double> tiltTransform = cglib::rotate4_matrix(axis, (groundTilt - viewState.getGroundTilt()) * Const::DEG_TO_RAD);
         cameraPos = focusPos + cglib::transform_vector(cameraPos - focusPos, tiltTransform);
         upVec = cglib::transform_vector(upVec, tiltTransform);
     

--- a/all/native/ui/TouchHandler.cpp
+++ b/all/native/ui/TouchHandler.cpp
@@ -680,6 +680,21 @@ namespace carto {
         return dist > 0 && dist < viewState.getFar();
     }
 
+    cglib::ray3<double> TouchHandler::calculateScreenRay(const ScreenPos& screenPos, const ViewState& viewState) const {
+        // The same unprojection ViewState::screenToWorld does, stopping at the ray: two points at
+        // the near and far planes, which is a direction whether or not it ever meets the ground.
+        if (viewState.getWidth() <= 0 || viewState.getHeight() <= 0) {
+            double nan = std::numeric_limits<double>::quiet_NaN();
+            return cglib::ray3<double>(viewState.getCameraPos(), cglib::vec3<double>(nan, nan, nan));
+        }
+        cglib::mat4x4<double> invMVP = cglib::inverse(viewState.getModelviewProjectionMat());
+        double x = screenPos.getX() / viewState.getWidth() * 2 - 1;
+        double y = 1 - screenPos.getY() / viewState.getHeight() * 2;
+        cglib::vec3<double> near = cglib::transform_point(cglib::vec3<double>(x, y, -1), invMVP);
+        cglib::vec3<double> far = cglib::transform_point(cglib::vec3<double>(x, y, 1), invMVP);
+        return cglib::ray3<double>(near, far - near);
+    }
+
     MapPos TouchHandler::mapScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const {
         cglib::vec3<double> pos = viewState.screenToWorld(cglib::vec2<float>(screenPos.getX(), screenPos.getY()), _gestureAnchorHeight.load());
         return viewState.getProjectionSurface()->calculateMapPos(pos);
@@ -712,15 +727,23 @@ namespace carto {
 
     void TouchHandler::handleClick(const ClickInfo& clickInfo, const ScreenPos& screenPos) {
         ViewState viewState = _mapRenderer->getViewState();
-        if (!isValidScreenPosition(screenPos, viewState)) {
-            return;
-        }
-        updateGestureAnchorHeight(screenPos, viewState);
-        MapPos mapPos = mapScreenPosition(screenPos, viewState);
-
-        // Find all intersected elements
+        // A touch aimed at the SKY has no ground position - the ray never meets the plane - but it
+        // is still a ray, and layers anchored in the sky (CelestialLayer) live along it. Ask the
+        // layers with the ray alone in that case; there is no map position to report afterwards.
+        bool groundHit = isValidScreenPosition(screenPos, viewState);
         std::vector<RayIntersectedElement> results;
-        _mapRenderer->calculateRayIntersectedElements(mapPos, viewState, results);
+        MapPos mapPos;
+        if (groundHit) {
+            updateGestureAnchorHeight(screenPos, viewState);
+            mapPos = mapScreenPosition(screenPos, viewState);
+            _mapRenderer->calculateRayIntersectedElements(mapPos, viewState, results);
+        } else {
+            cglib::ray3<double> ray = calculateScreenRay(screenPos, viewState);
+            if (std::isnan(cglib::norm(ray.direction))) {
+                return;
+            }
+            _mapRenderer->calculateRayIntersectedElements(ray, viewState, results);
+        }
     
         // Sort the results but do 'reverse stable sort' to be consistent with the rendering order
         std::stable_sort(results.begin(), results.end(), RayIntersectedElementComparator(viewState));
@@ -733,7 +756,11 @@ namespace carto {
             }
         }
 
-        // Click was ignored by layers, call map event listener
+        // Click was ignored by layers, call map event listener. Nothing to report for a touch
+        // that never reached the ground.
+        if (!groundHit) {
+            return;
+        }
         DirectorPtr<MapEventListener> mapEventListener = _mapEventListener;
 
         if (mapEventListener) {

--- a/all/native/ui/TouchHandler.cpp
+++ b/all/native/ui/TouchHandler.cpp
@@ -131,7 +131,7 @@ namespace carto {
                     if (deltaTime >= DUAL_STOP_HOLD_DURATION) {
                         // Free roam turns the one-finger drag into a look: panning moves to two
                         // fingers, which dualPointerPan already does.
-                        if (_options->isFreeRoam()) {
+                        if (_options->getFreeRoamMode() != FreeRoamMode::FREE_ROAM_MODE_OFF) {
                             singlePointerLook(screenPos1, viewState);
                         } else {
                             singlePointerPan(screenPos1, viewState);
@@ -144,6 +144,9 @@ namespace carto {
                 break;
             case DUAL_POINTER_GUESS:
                 dualPointerGuess(screenPos1, screenPos2, viewState);
+                break;
+            case DUAL_POINTER_MOVE:
+                dualPointerMove(screenPos1, screenPos2, viewState);
                 break;
             case DUAL_POINTER_TILT:
                 dualPointerTilt(screenPos1, viewState);
@@ -184,6 +187,11 @@ namespace carto {
             }
             case SINGLE_POINTER_PAN:
                 _gestureMode = SINGLE_POINTER_CLICK_GUESS;
+                // A first person drag is a look, and a look does not glide on after the finger
+                // leaves: every kinetic handler pans, rotates or zooms the MAP.
+                if (_options->getFreeRoamMode() == FreeRoamMode::FREE_ROAM_MODE_FIRST_PERSON) {
+                    break;
+                }
                 if (_noDualPointerYet) {
                     _mapRenderer->getKineticEventHandler().startPan();
                 } else {
@@ -210,6 +218,7 @@ namespace carto {
             case DUAL_POINTER_ROTATE:
             case DUAL_POINTER_SCALE:
             case DUAL_POINTER_FREE:
+            case DUAL_POINTER_MOVE:
                 _dualPointerReleaseTime = std::chrono::steady_clock::now();
                 _prevScreenPos1 = screenPos2;
                 _gestureMode = SINGLE_POINTER_PAN;
@@ -228,6 +237,7 @@ namespace carto {
             case DUAL_POINTER_ROTATE:
             case DUAL_POINTER_SCALE:
             case DUAL_POINTER_FREE:
+            case DUAL_POINTER_MOVE:
                  _dualPointerReleaseTime = std::chrono::steady_clock::now();
                  _prevScreenPos1 = screenPos1;
                  _gestureMode = SINGLE_POINTER_PAN;
@@ -381,13 +391,13 @@ namespace carto {
             // The turn is about the CAMERA, not about the focus point on the ground: turning your
             // head does not move you. Rotating about the focus - what a map rotation does - swings
             // the camera around a circle of the focus distance, and at a low tilt that walks it
-            // straight through the terrain. The rotation event already takes a pivot, so this is
-            // the camera's own position handed to it.
+            // straight through the terrain. In first person the rotation event pivots there by
+            // itself (the whole camera model does); in LOOK mode it is asked for explicitly.
             if (dx != 0) {
                 std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
                 CameraRotationEvent cameraEvent;
-                cameraEvent.setRotationDelta(dx * INCHES_TO_LOOK_ROTATION_DELTA / dpi);
-                if (projectionSurface) {
+                cameraEvent.setRotationDelta(dx * _options->getFreeRoamLookSensitivity() / dpi);
+                if (projectionSurface && _options->getFreeRoamMode() != FreeRoamMode::FREE_ROAM_MODE_FIRST_PERSON) {
                     cameraEvent.setTargetPos(projectionSurface->calculateMapPos(viewState.getCameraPos()));
                 }
                 _cameraEvents |= CAMERA_ROTATE;
@@ -537,6 +547,63 @@ namespace carto {
         _prevScreenPos1 = screenPos;
     }
     
+    void TouchHandler::dualPointerMove(const ScreenPos& screenPos1, const ScreenPos& screenPos2, const ViewState& viewState) {
+        if (_options->isUserInput()) {
+            std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
+            if (!projectionSurface) {
+                return;
+            }
+
+            _mapRenderer->getAnimationHandler().stopPan();
+            _mapRenderer->getAnimationHandler().stopRotation();
+            _mapRenderer->getAnimationHandler().stopTilt();
+            _mapRenderer->getAnimationHandler().stopZoom();
+
+            // First person movement: the two fingers are the movement keys. Dragging them up walks
+            // forward, down walks back, sideways strafes - the camera keeps its height, its heading
+            // and its zoom, and nothing is anchored to a point on the ground, so this works just as
+            // well with the view aimed at the sky, where a map pan has no ground to hold on to.
+            float dx = (screenPos1.getX() + screenPos2.getX()) * 0.5f - (_prevScreenPos1.getX() + _prevScreenPos2.getX()) * 0.5f;
+            float dy = (screenPos1.getY() + screenPos2.getY()) * 0.5f - (_prevScreenPos1.getY() + _prevScreenPos2.getY()) * 0.5f;
+            _prevScreenPos1 = screenPos1;
+            _prevScreenPos2 = screenPos2;
+            if (dx == 0 && dy == 0) {
+                return;
+            }
+
+            // The horizontal frame the movement happens in, taken from the view itself: forward is
+            // where the camera looks, flattened onto the ground.
+            cglib::vec3<double> cameraPos = viewState.getCameraPos();
+            MapPos cameraMapPos = projectionSurface->calculateMapPos(cameraPos);
+            cglib::vec3<double> normal = projectionSurface->calculateNormal(cameraMapPos);
+            cglib::vec3<double> viewDir = viewState.calculateViewDir();
+            cglib::vec3<double> right = cglib::vector_product(viewDir, normal);
+            if (cglib::length(right) == 0) {
+                right = cglib::vector_product(viewState.getUpVec(), normal); // looking straight up or down
+            }
+            if (cglib::length(right) == 0) {
+                return;
+            }
+            right = cglib::unit(right);
+            cglib::vec3<double> forward = cglib::vector_product(normal, right);
+            if (cglib::length(forward) == 0) {
+                return;
+            }
+            forward = cglib::unit(forward);
+
+            // Distance per inch of drag, as a fraction of the camera to focus distance, so a move
+            // covers the same part of the view at any zoom.
+            double perInch = _options->getFreeRoamMoveSpeed() * viewState.calculateCameraDistance();
+            double dpi = _options->getDPI();
+            cglib::vec3<double> offset = forward * (-dy / dpi * perInch) + right * (-dx / dpi * perInch);
+
+            CameraPanEvent cameraEvent;
+            cameraEvent.setPosDelta(std::make_pair(cameraMapPos, projectionSurface->calculateMapPos(cameraPos + offset)));
+            _cameraEvents |= CAMERA_PAN;
+            _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
+        }
+    }
+
     void TouchHandler::dualPointerPan(const ScreenPos& screenPos1, const ScreenPos& screenPos2, bool rotate, bool scale, const ViewState& viewState) {
         if (_options->isUserInput()) {
             std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
@@ -831,7 +898,9 @@ namespace carto {
         _swipe2 = cglib::vec2<float>(0, 0);
         _prevScreenPos1 = screenPos1;
         _prevScreenPos2 = screenPos2;
-        _gestureMode = DUAL_POINTER_GUESS;
+        // First person: two fingers MOVE, and there is nothing to guess between - a pinch and a
+        // two-finger rotation are map gestures, and this control scheme has neither.
+        _gestureMode = (_options->getFreeRoamMode() == FreeRoamMode::FREE_ROAM_MODE_FIRST_PERSON ? DUAL_POINTER_MOVE : DUAL_POINTER_GUESS);
         ScreenPos middlePos((screenPos1.getX() + screenPos2.getX()) * 0.5f, (screenPos1.getY() + screenPos2.getY()) * 0.5f);
         updateGestureAnchorHeight(middlePos, _mapRenderer->getViewState());
     }
@@ -903,7 +972,6 @@ namespace carto {
     
     const float TouchHandler::INCHES_TO_TILT_DELTA = 32.0f;
     // A full turn takes about two swipes across a phone, which is what a look control wants.
-    const float TouchHandler::INCHES_TO_LOOK_ROTATION_DELTA = 90.0f;
 
     const float TouchHandler::INCHES_TO_ZOOM_DELTA = 1.0f;
         

--- a/all/native/ui/TouchHandler.cpp
+++ b/all/native/ui/TouchHandler.cpp
@@ -129,7 +129,13 @@ namespace carto {
                 {
                     auto deltaTime = std::chrono::steady_clock::now() - _dualPointerReleaseTime;
                     if (deltaTime >= DUAL_STOP_HOLD_DURATION) {
-                        singlePointerPan(screenPos1, viewState);
+                        // Free roam turns the one-finger drag into a look: panning moves to two
+                        // fingers, which dualPointerPan already does.
+                        if (_options->isFreeRoam()) {
+                            singlePointerLook(screenPos1, viewState);
+                        } else {
+                            singlePointerPan(screenPos1, viewState);
+                        }
                     }
                 }
                 break;
@@ -358,6 +364,40 @@ namespace carto {
         _prevScreenPos1 = screenPos;
     }
     
+    void TouchHandler::singlePointerLook(const ScreenPos& screenPos, const ViewState& viewState) {
+        if (_options->isUserInput()) {
+            _mapRenderer->getAnimationHandler().stopPan();
+            _mapRenderer->getAnimationHandler().stopRotation();
+            _mapRenderer->getAnimationHandler().stopTilt();
+            _mapRenderer->getAnimationHandler().stopZoom();
+
+            float dpi = _options->getDPI();
+            float dx = screenPos.getX() - _prevScreenPos1.getX();
+            float dy = screenPos.getY() - _prevScreenPos1.getY();
+
+            // Sideways turns the heading. Dragging left turns the view right, the way dragging the
+            // world does, so the gesture reads the same as panning does outside free roam.
+            if (dx != 0) {
+                CameraRotationEvent cameraEvent;
+                cameraEvent.setRotationDelta(dx * INCHES_TO_LOOK_ROTATION_DELTA / dpi);
+                _cameraEvents |= CAMERA_ROTATE;
+                _mapRenderer->calculateCameraEvent(cameraEvent, 0, false);
+            }
+            // Up and down changes the tilt, in the same direction the two-finger tilt uses.
+            if (dy != 0) {
+                float scale = INCHES_TO_TILT_DELTA / dpi;
+                if (_options->isTiltGestureReversed()) {
+                    scale = -scale;
+                }
+                CameraTiltEvent cameraEvent;
+                cameraEvent.setTiltDelta(dy * scale);
+                _cameraEvents |= CAMERA_TILT;
+                _mapRenderer->calculateCameraEvent(cameraEvent, 0, false);
+            }
+        }
+        _prevScreenPos1 = screenPos;
+    }
+
     void TouchHandler::singlePointerZoom(const ScreenPos& screenPos, const ViewState& viewState) {
         if (_options->isUserInput()) {
             _mapRenderer->getAnimationHandler().stopPan();
@@ -852,6 +892,8 @@ namespace carto {
     const float TouchHandler::WHEEL_TICK_TO_ZOOM_DELTA = 0.25f;
     
     const float TouchHandler::INCHES_TO_TILT_DELTA = 32.0f;
+    // A full turn takes about two swipes across a phone, which is what a look control wants.
+    const float TouchHandler::INCHES_TO_LOOK_ROTATION_DELTA = 90.0f;
 
     const float TouchHandler::INCHES_TO_ZOOM_DELTA = 1.0f;
         

--- a/all/native/ui/TouchHandler.cpp
+++ b/all/native/ui/TouchHandler.cpp
@@ -377,9 +377,19 @@ namespace carto {
 
             // Sideways turns the heading. Dragging left turns the view right, the way dragging the
             // world does, so the gesture reads the same as panning does outside free roam.
+            //
+            // The turn is about the CAMERA, not about the focus point on the ground: turning your
+            // head does not move you. Rotating about the focus - what a map rotation does - swings
+            // the camera around a circle of the focus distance, and at a low tilt that walks it
+            // straight through the terrain. The rotation event already takes a pivot, so this is
+            // the camera's own position handed to it.
             if (dx != 0) {
+                std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
                 CameraRotationEvent cameraEvent;
                 cameraEvent.setRotationDelta(dx * INCHES_TO_LOOK_ROTATION_DELTA / dpi);
+                if (projectionSurface) {
+                    cameraEvent.setTargetPos(projectionSurface->calculateMapPos(viewState.getCameraPos()));
+                }
                 _cameraEvents |= CAMERA_ROTATE;
                 _mapRenderer->calculateCameraEvent(cameraEvent, 0, false);
             }

--- a/all/native/ui/TouchHandler.cpp
+++ b/all/native/ui/TouchHandler.cpp
@@ -26,6 +26,7 @@ namespace carto {
     TouchHandler::TouchHandler(const std::shared_ptr<MapRenderer>& mapRenderer, const std::shared_ptr<Options>& options) :
         _gestureMode(SINGLE_POINTER_CLICK_GUESS),
         _gestureAnchorHeight(0.0),
+        _panScale(0.0),
         _prevScreenPos1(0, 0),
         _prevScreenPos2(0, 0),
         _swipe1(0, 0),
@@ -222,6 +223,7 @@ namespace carto {
                 _dualPointerReleaseTime = std::chrono::steady_clock::now();
                 _prevScreenPos1 = screenPos2;
                 _gestureMode = SINGLE_POINTER_PAN;
+                updatePanScale(screenPos2, viewState); // a new pan starts here: a new speed
                 break;
             }
             break;
@@ -241,6 +243,7 @@ namespace carto {
                  _dualPointerReleaseTime = std::chrono::steady_clock::now();
                  _prevScreenPos1 = screenPos1;
                  _gestureMode = SINGLE_POINTER_PAN;
+                 updatePanScale(screenPos1, viewState); // a new pan starts here: a new speed
                  break;
             default:
                 break;
@@ -361,6 +364,46 @@ namespace carto {
             _mapRenderer->getAnimationHandler().stopTilt();
             _mapRenderer->getAnimationHandler().stopZoom();
             
+            double panScale = _panScale.load();
+            if (_options->getPanningSpeedMode() != PanningSpeedMode::PANNING_SPEED_MODE_MAP && panScale > 0) {
+                // The pan travels the SCREEN delta at the scale the gesture started with. Grabbing
+                // the world exactly - the other mode - re-derives that scale from wherever the
+                // finger is now, so a drag that starts near the camera and travels up the screen
+                // speeds up as it goes, which is not something the hand asked for.
+                float dx = screenPos.getX() - _prevScreenPos1.getX();
+                float dy = screenPos.getY() - _prevScreenPos1.getY();
+                _prevScreenPos1 = screenPos;
+                if (dx == 0 && dy == 0) {
+                    return;
+                }
+
+                cglib::vec3<double> focusPos = viewState.getFocusPos();
+                MapPos focusMapPos = projectionSurface->calculateMapPos(focusPos);
+                cglib::vec3<double> normal = projectionSurface->calculateNormal(focusMapPos);
+                cglib::vec3<double> right = cglib::vector_product(viewState.calculateViewDir(), normal);
+                if (cglib::length(right) == 0) {
+                    right = cglib::vector_product(viewState.getUpVec(), normal); // straight up or down
+                }
+                if (cglib::length(right) == 0) {
+                    return;
+                }
+                right = cglib::unit(right);
+                cglib::vec3<double> forward = cglib::vector_product(normal, right);
+                if (cglib::length(forward) == 0) {
+                    return;
+                }
+                forward = cglib::unit(forward);
+
+                // Dragging the world down brings what was beyond the top edge into view, i.e. the
+                // camera goes forward; dragging it right takes the camera left.
+                cglib::vec3<double> offset = forward * (dy * panScale) + right * (-dx * panScale);
+                CameraPanEvent cameraEvent;
+                cameraEvent.setPosDelta(std::make_pair(focusMapPos, projectionSurface->calculateMapPos(focusPos + offset)));
+                _cameraEvents |= CAMERA_PAN;
+                _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
+                return;
+            }
+
             if (isValidScreenPosition(screenPos, viewState) && isValidScreenPosition(_prevScreenPos1, viewState)) {
                 MapPos currentPos = mapScreenPosition(screenPos, viewState);
                 MapPos prevPos = mapScreenPosition(_prevScreenPos1, viewState);
@@ -812,6 +855,45 @@ namespace carto {
         return cglib::ray3<double>(near, far - near);
     }
 
+    void TouchHandler::updatePanScale(const ScreenPos& screenPos, const ViewState& viewState) {
+        _panScale.store(calculatePanScale(screenPos, viewState));
+    }
+
+    /**
+     * How much map a screen pixel is worth where the gesture starts, which is what fixes the pan
+     * speed for the rest of it. On a tilted view this varies over the screen by orders of
+     * magnitude - that is the whole point of measuring it once.
+     */
+    double TouchHandler::calculatePanScale(const ScreenPos& screenPos, const ViewState& viewState) const {
+        std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
+        if (!projectionSurface || viewState.getHeight() <= 0) {
+            return 0;
+        }
+        // A pixel at the FAR plane is the largest a pixel can honestly be worth: near the horizon
+        // the two sample rays run almost parallel to the ground and their hit points fly apart.
+        double maxScale = viewState.getFar() * 2.0 * viewState.getTanHalfFOVY() / viewState.getHeight();
+
+        ScreenPos samplePos = screenPos;
+        if (_options->getPanningSpeedMode() == PanningSpeedMode::PANNING_SPEED_MODE_CONSTANT) {
+            samplePos = ScreenPos(viewState.getHalfWidth(), viewState.getHalfHeight());
+        }
+        double height = _gestureAnchorHeight.load();
+        for (int attempt = 0; attempt < 2; attempt++) {
+            cglib::vec3<double> pos0 = viewState.screenToWorld(cglib::vec2<float>(samplePos.getX(), samplePos.getY()), height);
+            cglib::vec3<double> pos1 = viewState.screenToWorld(cglib::vec2<float>(samplePos.getX(), samplePos.getY() + 1), height);
+            if (std::isfinite(cglib::norm(pos0)) && std::isfinite(cglib::norm(pos1))) {
+                double scale = projectionSurface->calculateDistance(pos0, pos1);
+                if (scale > 0) {
+                    return std::min(scale, maxScale);
+                }
+            }
+            // No ground under the touch - the view is aimed at the sky, or past the horizon. The
+            // centre of the screen is the fallback, and the far plane the last resort.
+            samplePos = ScreenPos(viewState.getHalfWidth(), viewState.getHalfHeight());
+        }
+        return maxScale;
+    }
+
     MapPos TouchHandler::mapScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const {
         cglib::vec3<double> pos = viewState.screenToWorld(cglib::vec2<float>(screenPos.getX(), screenPos.getY()), _gestureAnchorHeight.load());
         return viewState.getProjectionSurface()->calculateMapPos(pos);
@@ -889,7 +971,9 @@ namespace carto {
         std::lock_guard<std::recursive_mutex> lock(_mutex);
         _prevScreenPos1 = screenPos;
         _gestureMode = SINGLE_POINTER_PAN;
-        updateGestureAnchorHeight(screenPos, _mapRenderer->getViewState());
+        ViewState viewState = _mapRenderer->getViewState();
+        updateGestureAnchorHeight(screenPos, viewState);
+        updatePanScale(screenPos, viewState);
     }
 
     void TouchHandler::startDualPointer(const ScreenPos& screenPos1, const ScreenPos& screenPos2) {

--- a/all/native/ui/TouchHandler.h
+++ b/all/native/ui/TouchHandler.h
@@ -114,6 +114,7 @@ namespace carto {
         void doubleTapZoom(const ScreenPos& screenPos, const ViewState& viewState);
 
         bool isValidScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const;
+        cglib::ray3<double> calculateScreenRay(const ScreenPos& screenPos, const ViewState& viewState) const;
         MapPos mapScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const;
         double calculateTerrainHeight(const ScreenPos& screenPos, const ViewState& viewState) const;
         void updateGestureAnchorHeight(const ScreenPos& screenPos, const ViewState& viewState);

--- a/all/native/ui/TouchHandler.h
+++ b/all/native/ui/TouchHandler.h
@@ -108,6 +108,8 @@ namespace carto {
 
         void singlePointerPan(const ScreenPos& screenPos, const ViewState& viewState);
         void singlePointerLook(const ScreenPos& screenPos, const ViewState& viewState);
+        double calculatePanScale(const ScreenPos& screenPos, const ViewState& viewState) const;
+        void updatePanScale(const ScreenPos& screenPos, const ViewState& viewState);
         void singlePointerZoom(const ScreenPos& screenPos, const ViewState& viewState);
         bool singlePointerZoomStop(const ScreenPos& screenPos, const ViewState& viewState);
         void dualPointerGuess(const ScreenPos& screenPos1, const ScreenPos& screenPos2, const ViewState& viewState);
@@ -169,6 +171,7 @@ namespace carto {
         // Panning and picking are anchored to the plane at this height so that the touched
         // terrain point stays under the finger. 0 when terrain is not enabled.
         std::atomic<double> _gestureAnchorHeight;
+        std::atomic<double> _panScale; // internal units per screen pixel, frozen when a pan starts
 
         ScreenPos _prevScreenPos1;
         ScreenPos _prevScreenPos2;

--- a/all/native/ui/TouchHandler.h
+++ b/all/native/ui/TouchHandler.h
@@ -79,7 +79,8 @@ namespace carto {
             DUAL_POINTER_TILT,
             DUAL_POINTER_ROTATE,
             DUAL_POINTER_SCALE,
-            DUAL_POINTER_FREE
+            DUAL_POINTER_FREE,
+            DUAL_POINTER_MOVE
         };
 
         enum {
@@ -111,6 +112,7 @@ namespace carto {
         bool singlePointerZoomStop(const ScreenPos& screenPos, const ViewState& viewState);
         void dualPointerGuess(const ScreenPos& screenPos1, const ScreenPos& screenPos2, const ViewState& viewState);
         void dualPointerTilt(const ScreenPos& screenPos, const ViewState& viewState);
+        void dualPointerMove(const ScreenPos& screenPos1, const ScreenPos& screenPos2, const ViewState& viewState);
         void dualPointerPan(const ScreenPos& screenPos1, const ScreenPos& screenPos2, bool rotate, bool scale, const ViewState& viewState);
         void doubleTapZoom(const ScreenPos& screenPos, const ViewState& viewState);
 
@@ -143,7 +145,6 @@ namespace carto {
 
         // Determines how the finger sliding distance will be converted to tilt angle
         static const float INCHES_TO_TILT_DELTA;
-        static const float INCHES_TO_LOOK_ROTATION_DELTA;
 
         // Determines how finger sliding distance will be converted to zoom delta
         static const float INCHES_TO_ZOOM_DELTA;

--- a/all/native/ui/TouchHandler.h
+++ b/all/native/ui/TouchHandler.h
@@ -106,6 +106,7 @@ namespace carto {
         float calculateRotatingScalingFactor(const ScreenPos& screenPos1, const ScreenPos& screenPos2) const;
 
         void singlePointerPan(const ScreenPos& screenPos, const ViewState& viewState);
+        void singlePointerLook(const ScreenPos& screenPos, const ViewState& viewState);
         void singlePointerZoom(const ScreenPos& screenPos, const ViewState& viewState);
         bool singlePointerZoomStop(const ScreenPos& screenPos, const ViewState& viewState);
         void dualPointerGuess(const ScreenPos& screenPos1, const ScreenPos& screenPos2, const ViewState& viewState);
@@ -142,6 +143,7 @@ namespace carto {
 
         // Determines how the finger sliding distance will be converted to tilt angle
         static const float INCHES_TO_TILT_DELTA;
+        static const float INCHES_TO_LOOK_ROTATION_DELTA;
 
         // Determines how finger sliding distance will be converted to zoom delta
         static const float INCHES_TO_ZOOM_DELTA;

--- a/all/native/utils/Const.cpp
+++ b/all/native/utils/Const.cpp
@@ -20,7 +20,7 @@ namespace carto {
 
     const int Const::MAX_SUPPORTED_ZOOM_LEVEL = 24;
 
-    const float Const::MIN_SUPPORTED_TILT_ANGLE = 0.0f;
+    const float Const::MIN_SUPPORTED_TILT_ANGLE = -90.0f;
     const float Const::MIN_HEIGHT = (1 << 20) * 0.9988f - (1 << 20); // approx 64 subdivide levels
     const float Const::MAX_HEIGHT = (1 << 20) * 0.5f / 6400.0f; // approx 0.5km
     const float Const::MIN_NEAR = 1.0f / 16.0f;

--- a/all/native/utils/Const.h
+++ b/all/native/utils/Const.h
@@ -35,7 +35,9 @@ namespace carto {
         // Maximum supported zoom level
         static const int MAX_SUPPORTED_ZOOM_LEVEL;
     
-        // Min and max supported tilt angles
+        // Min and max supported tilt angles. Negative tilt looks ABOVE the horizon: the camera
+        // stays where it is and only the view direction pitches up (ViewState::calculateLookatMat).
+        // The default tilt range is still 0..90, so a map only gets there if it asks for it.
         static const float MIN_SUPPORTED_TILT_ANGLE;
         // Minimum height (negative value). This is needed for globe view as the globe is tesselated and surface may be 'below'
         // zero level. Should be approximately -WORLD_SIZE * cos(PI / TESSELATION_LEVEL) + WORLD_SIZE.

--- a/android/java/com/carto/ui/MapView.java
+++ b/android/java/com/carto/ui/MapView.java
@@ -129,6 +129,29 @@ public class MapView extends GLSurfaceView implements GLSurfaceView.Renderer, Ma
     }
 
     /**
+     * Makes the view translucent, so that whatever is behind it shows through wherever the map
+     * does not paint. Combine it with a transparent clear color - Options.setClearColor(new
+     * Color(0, 0, 0, 0)) - which is what leaves the frame empty; the SDK renders with premultiplied
+     * alpha, so the result composites correctly.
+     *
+     * IMPORTANT, and the usual trap: a MapView is a SurfaceView. Its surface is composited BELOW
+     * the window, so it can only reveal another surface below it - typically a camera preview -
+     * and NOT other views of the same layout, which are drawn above it. This method also raises the
+     * surface above other media surfaces (setZOrderMediaOverlay) so a preview placed behind it is
+     * what shows through.
+     *
+     * To blend with ordinary views instead, use TextureMapView, which is a real view in the
+     * hierarchy.
+     *
+     * Changing this after the view is attached recreates the GL surface.
+     * @param translucent True to make the view translucent.
+     */
+    public void setTranslucent(boolean translucent) {
+        setZOrderMediaOverlay(translucent);
+        getHolder().setFormat(translucent ? android.graphics.PixelFormat.TRANSLUCENT : android.graphics.PixelFormat.OPAQUE);
+    }
+
+    /**
      * Deletes the resources associated with the MapView.
      * The method can be used to dispose native objects immediately,
      * without waiting for next GC cycle.

--- a/android/java/com/carto/ui/TextureMapView.java
+++ b/android/java/com/carto/ui/TextureMapView.java
@@ -120,6 +120,22 @@ public class TextureMapView extends GLTextureView implements GLSurfaceView.Rende
     }
 
     /**
+     * Makes the view translucent, so that whatever is behind it shows through wherever the map
+     * does not paint. Combine it with a transparent clear color - Options.setClearColor(new
+     * Color(0, 0, 0, 0)) - which is what leaves the frame empty; the SDK renders with premultiplied
+     * alpha, so the result composites correctly.
+     *
+     * A TextureMapView is a TextureView, i.e. an ordinary view in the hierarchy, so unlike MapView
+     * it blends with the views BEHIND it in the layout as well as with anything the window is
+     * drawn over. That makes it the one to use for a map over other UI, and for a camera preview
+     * held in a TextureView.
+     * @param translucent True to make the view translucent.
+     */
+    public void setTranslucent(boolean translucent) {
+        setOpaque(!translucent);
+    }
+
+    /**
      * Deletes the resources associated with the MapView.
      * The method can be used to dispose native objects immediately,
      * without waiting for next GC cycle.

--- a/docs/rendering/04-terrain.md
+++ b/docs/rendering/04-terrain.md
@@ -128,6 +128,15 @@ floored at 1/16 of an internal unit — gave centimetre near planes next to a sl
 of 10⁴–10⁶, and NDC depth so non-linear that a constant-NDC bias was worth hundreds of metres at
 range. That is the mechanism behind every see-through this project has had.
 
+The floor is a floor and the ground walk is a **ceiling** too, but only when the view is pitched
+away from the camera geometry — free roam looking up, or a first person camera
+([13-celestial.md](13-celestial.md#seeing-them-free-roam)). The walk takes the near plane from
+where the sampled rays MEET THE GROUND; as the view pitches up those hits move off into the
+distance, the near plane follows them out, and everything close to the camera is clipped away —
+worse the higher the view goes. What is near the camera does not move when the view turns, so in
+that case `near` is capped by the same camera-height rule, which does not depend on the view
+direction at all.
+
 Their far plane (`2·height/cos(pitch + fovy/2)`) is available as
 `TerrainOptions::ViewDistanceFactor` but changes nothing at the cameras tested: the ground-derived far is
 already inside the bound it gives.

--- a/docs/rendering/13-celestial.md
+++ b/docs/rendering/13-celestial.md
@@ -62,6 +62,21 @@ but still has a ray, so the layers are now asked with the ray alone in that case
 gained the matching overload). Only the map-position callback is skipped — there is nothing to
 report.
 
+## Seeing them: free roam
+
+Sky content is normally off the top of the screen, because the map camera points at the ground.
+`Options::FreeRoam` changes what a one-finger drag does: sideways turns the heading, up and down
+changes the tilt, and panning moves to a two-finger drag. Pinch still zooms; the two-finger paths
+are untouched.
+
+**The camera cannot tilt above the horizon**, and that is a property of the camera model, not a
+setting: tilt is clamped to `Const::MIN_SUPPORTED_TILT_ANGLE` (0) and `Options::setTiltRange`
+clamps to it too. Lowering it was tried and the camera flips through the vertical - the view comes
+back inverted, ground below and sky at both edges - because the up vector is derived from a focus
+point on the ground. So the visible sky runs from the horizon up to roughly half the field of view.
+A body higher than that is drawn correctly and can be clicked, but cannot be brought into view
+without a first-person camera, which is a much larger change than this option.
+
 ## What lives in the app, not here
 
 The demo's `DemoCelestial` is worth reading as the worked example: the sun's direction comes from

--- a/docs/rendering/13-celestial.md
+++ b/docs/rendering/13-celestial.md
@@ -71,16 +71,41 @@ report.
 ## Seeing them: free roam
 
 Sky content is normally off the top of the screen, because the map camera points at the ground.
-`Options::FreeRoam` changes what a one-finger drag does: sideways turns the heading, up and down
-changes the tilt, and panning moves to a two-finger drag. Pinch still zooms; the two-finger paths
-are untouched.
+`Options::FreeRoamMode` changes what the gestures do, and there are three:
 
-The heading turn pivots about the **camera**, not about the focus point on the ground — turning
-your head does not move you. A map rotation rotates camera *and* focus about the focus, which
-swings the camera around a circle of the focus distance and, at a low tilt, straight through the
-terrain. `CameraRotationEvent` already takes a pivot (`setTargetPos`), so free roam hands it the
-camera's own position and the camera comes out of the gesture exactly where it went in
-(verified: camera unchanged to the metre across a 90° drag, focus orbiting it).
+| Mode | One finger | Two fingers | Camera model |
+|------|-----------|-------------|--------------|
+| `OFF` (default) | pans the map | pan / pinch / rotate | the map's: tilt and rotation orbit the focus |
+| `LOOK` | looks around | pan / pinch / rotate | the map's, except that the heading turns about the camera |
+| `FIRST_PERSON` | looks around, **the position never changes** | move: forward/back and strafe | the camera never orbits anything |
+
+`FIRST_PERSON` is a mouse look, and it is a **camera model, not a gesture mapping**: `CameraTiltEvent`
+and `CameraRotationEvent` both pivot about the camera whatever asks them to, so `setTilt` and
+`setMapRotation` driven by a device's orientation sensor behave exactly like the drag. That is the
+point — the same code path serves the finger and the phone being turned.
+
+What each piece is:
+
+- **Turning** pivots about the camera. A map rotation rotates camera *and* focus about the focus,
+  which swings the camera around a circle of the focus distance and, at a low tilt, straight
+  through the terrain. `CameraRotationEvent` already took a pivot (`setTargetPos`); in
+  `FIRST_PERSON` it defaults to the camera's own position, and in `LOOK` the touch handler hands it
+  over explicitly. Verified: the camera is unchanged to the metre across a 90° drag.
+- **Pitching** in `FIRST_PERSON` writes `ViewState::setViewTilt`, which moves nothing at all — the
+  camera keeps the position (and therefore the height) it had, and the difference to
+  `getCameraTilt()` is applied as a rotation of the view about the camera. In the other modes the
+  camera still orbits the focus, which is what a map tilt is.
+- **Moving** (`TouchHandler::dualPointerMove`) translates camera and focus together, forward along
+  the view flattened onto the ground and sideways along the right vector, `FreeRoamMoveSpeed` × the
+  camera-to-focus distance per inch of drag — so it covers the same part of the view at any zoom,
+  and it needs no ground under the touch, which matters when the view is aimed at the sky. Pinch,
+  two-finger rotation, two-finger tilt and the kinetic handlers are all off in this mode: they are
+  map gestures and this scheme has none of them.
+- **`FreeRoamLookSensitivity`** is the turn in degrees per inch of drag (default 90).
+
+A two-finger gesture cannot be synthesized with `adb` (one pointer only, and the emulator's touch
+devices are not writable from the shell), so the demo has a panel button that feeds `onTouchEvent`
+a real two-pointer `MotionEvent` sequence — same entry point as a finger.
 
 ## Looking above the horizon: a negative tilt
 

--- a/docs/rendering/13-celestial.md
+++ b/docs/rendering/13-celestial.md
@@ -1,0 +1,71 @@
+# Objects in the sky
+
+Scope: `all/native/celestial/`, `all/native/layers/CelestialLayer.*`,
+`all/native/renderers/CelestialRenderer.*`. The sky *itself* — gradient, sun disc, fog — is
+[08-lighting-sky-fog.md](08-lighting-sky-fog.md); this page is about objects placed **in** it.
+
+Everything the map draws is anchored to a position on the ground. A sun, a moon, a star, an
+aircraft overhead are not: they belong to a direction, or to a point in the air. `CelestialLayer`
+is the layer for those, and it is deliberately generic — **the SDK has no notion of a sun or a
+moon**. The demo's `DemoCelestial` builds both out of two sprites and an arc, and the same API
+carries a satellite track or a star catalogue with no SDK change.
+
+## Anchors
+
+An object is placed one of two ways (`CelestialObject`):
+
+- **By direction** — azimuth and altitude in degrees, plus a distance. Distance **0 means
+  infinitely far**: the object keeps its direction whatever the camera does, so it never
+  parallaxes when the map pans. That is what the sun, the moon and the stars need.
+  A finite distance gives real parallax, for something that is merely high up.
+- **By geographic position + altitude** — for an object that belongs to a place on the map but is
+  above it: an aircraft, a satellite pass.
+
+Directions use the same frame as `LightOptions::getSunDirection` — x east, y north, z up, azimuth
+clockwise from north — so an application can hand a computed sun direction straight over. The
+renderer converts through `ProjectionSurface::calculateVector` at the focus point, so it is correct
+on a sphere as well as on a plane.
+
+## Drawing
+
+`CelestialRenderer` draws with the layer, in layer order. **Add the layer first** and the map and
+the terrain then draw over it, which is what a body in the sky wants: a ridge in front of the sun
+hides it, for free, with no extra work.
+
+- **Sprites** are camera-facing quads expanded from the view matrix's right/up, sized either by
+  **angle** (a real body: the sun and the moon are both about 0.5°) or in **screen pixels** (an
+  icon). Batched **per bitmap**, so any number of objects sharing one bitmap — or none — is a
+  single draw call. With no bitmap the fragment shader draws a soft disc, which costs no texture
+  at all and is enough for a sun, a moon or a star.
+- **Arcs** are line strips. A circle about an axis covers the useful case exactly: the sun's path
+  across a day is the circle of constant declination about the celestial pole, so an application
+  gives an axis and one angle rather than sampling positions through the day. An explicit
+  direction list covers the rest.
+- **Depth**: depth-TESTED, never depth-WRITING. An infinitely distant object is parked just inside
+  the far plane, so everything the map draws is nearer and covers it, and it never occludes
+  anything itself.
+- Objects are sorted **far to near** before drawing so overlapping discs blend in the expected
+  order.
+
+## Clicking, and the gap it exposed
+
+Objects are hit-tested against the touch ray through the standard layer path
+(`calculateRayIntersectedElements` / `processClick`), so they sort against every other layer's
+content and a click on terrain in front of the sun does not report the sun. The test is **angular**
+— how far the ray is from the direction the object sits in — which is the natural measure here; a
+star drawn half a pixel wide would be unhittable otherwise, hence `CelestialSprite::ClickRadius`.
+
+This needed a fix in `TouchHandler::handleClick`, and it applies to any sky content, not just this
+layer: a touch was **dropped entirely** unless its ray met the ground (`isValidScreenPosition`),
+because the click path was built around a map position. A tap aimed at the sky has no map position
+but still has a ray, so the layers are now asked with the ray alone in that case (`MapRenderer`
+gained the matching overload). Only the map-position callback is skipped — there is nothing to
+report.
+
+## What lives in the app, not here
+
+The demo's `DemoCelestial` is worth reading as the worked example: the sun's direction comes from
+the SDK's own solar position (`LightOptions::setSunPositionFromTime`), so the sprite sits exactly
+where the light comes from — visibly, the sun disc lands **on** its own arc — while the moon's
+position and the arc's declination are computed in the app. Astronomy is application code; the
+layer only knows about directions, sizes and colors.

--- a/docs/rendering/13-celestial.md
+++ b/docs/rendering/13-celestial.md
@@ -103,6 +103,22 @@ What each piece is:
   map gestures and this scheme has none of them.
 - **`FreeRoamLookSensitivity`** is the turn in degrees per inch of drag (default 90).
 
+### Panning speed on a tilted view
+
+Not a free roam thing, but the same family of problem: on a tilted view a touch near the horizon
+corresponds to a map point far away, so the exact grab-the-world pan moves the map by kilometres
+for the same finger travel that moves it by metres at the bottom of the screen. Worse, the scale is
+re-derived from wherever the finger is NOW, so a drag that starts close and travels up the screen
+**accelerates while the finger is down** — measured at z15 tilt 65: the same 1300 px drag moved
+2160 m that way against 1186 m at the speed it started with.
+
+`Options::PanningSpeedMode` picks between them: `MAP` is the exact grab-the-world pan, `ANCHORED`
+(the default) measures the scale where the gesture starts and keeps it for the whole gesture, and
+`CONSTANT` always measures at the centre of the screen, so the speed depends neither on where the
+finger started nor on where it goes. The two new modes pan by the SCREEN delta in the ground frame,
+which also means they work with the view aimed at the sky, where there is no ground under the touch
+for a map pan to hold on to.
+
 A two-finger gesture cannot be synthesized with `adb` (one pointer only, and the emulator's touch
 devices are not writable from the shell), so the demo has a panel button that feeds `onTouchEvent`
 a real two-pointer `MotionEvent` sequence — same entry point as a finger.

--- a/docs/rendering/13-celestial.md
+++ b/docs/rendering/13-celestial.md
@@ -75,6 +75,13 @@ Sky content is normally off the top of the screen, because the map camera points
 changes the tilt, and panning moves to a two-finger drag. Pinch still zooms; the two-finger paths
 are untouched.
 
+The heading turn pivots about the **camera**, not about the focus point on the ground — turning
+your head does not move you. A map rotation rotates camera *and* focus about the focus, which
+swings the camera around a circle of the focus distance and, at a low tilt, straight through the
+terrain. `CameraRotationEvent` already takes a pivot (`setTargetPos`), so free roam hands it the
+camera's own position and the camera comes out of the gesture exactly where it went in
+(verified: camera unchanged to the metre across a 90° drag, focus orbiting it).
+
 ## Looking above the horizon: a negative tilt
 
 The tilt may now go **below 0**, and that is what "look up" is. It is opt-in: `MIN_SUPPORTED_TILT_ANGLE`
@@ -120,4 +127,30 @@ segmented arc per figure, planets). The layer only knows about directions, sizes
 
 The demo's star sky mode is also the answer to "draw nothing but the sky": the map layers leave the
 layer list entirely (not hidden — never built), the terrain is disabled and the clear colour goes
-fully transparent, so with a translucent surface whatever is behind the view shows through.
+fully transparent.
+
+## A transparent map
+
+Two halves, and both are needed:
+
+1. **A transparent clear colour** — `Options::setClearColor(Color(0, 0, 0, 0))`. The renderer works
+   in premultiplied alpha (`glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA)`), so what is left in the
+   framebuffer composites correctly; nothing else in the render path needs to change.
+2. **A view that admits it does not cover its pixels** — `setTranslucent(true)`, added on all three
+   view classes. The EGL configs already ask for RGBA8888 first, so this is about compositing, not
+   about the drawable.
+
+What each view can reveal is NOT the same, and this is the trap:
+
+- **`MapView` (Android, SurfaceView)** — its surface is composited **below the window**, so it can
+  only reveal *another surface* under it. Other views of the same layout are drawn *above* it and
+  are not affected. `setTranslucent` therefore also calls `setZOrderMediaOverlay`, which is what
+  puts the map above a camera preview surface. Changing it after attach recreates the GL surface.
+- **`TextureMapView` (Android, TextureView)** — an ordinary view in the hierarchy
+  (`setOpaque(false)`), so it blends with whatever is behind it in the layout. This is the one for
+  a map over other UI.
+- **`NTMapView` (iOS, GLKView)** — `opaque = NO` on the view and its layer, and a clear background.
+
+The demo wires the first case end to end (`DemoCameraPreview`): a plain `SurfaceView` added at
+index 0 runs a Camera2 preview, the map sits over it as a media overlay, and the sky is drawn on
+the camera image — verified on the emulator's virtual scene.

--- a/docs/rendering/13-celestial.md
+++ b/docs/rendering/13-celestial.md
@@ -37,10 +37,12 @@ hides it, for free, with no extra work.
   icon). Batched **per bitmap**, so any number of objects sharing one bitmap — or none — is a
   single draw call. With no bitmap the fragment shader draws a soft disc, which costs no texture
   at all and is enough for a sun, a moon or a star.
-- **Arcs** are line strips. A circle about an axis covers the useful case exactly: the sun's path
-  across a day is the circle of constant declination about the celestial pole, so an application
-  gives an axis and one angle rather than sampling positions through the day. An explicit
-  direction list covers the rest.
+- **Arcs** are line strips. A circle about an axis covers the useful case exactly: the daily path
+  of a distant body is the circle of constant declination about the rotation axis, so an
+  application gives an axis and one angle rather than sampling positions through the day. An
+  explicit direction list covers the rest, and `setSegments` reads that list as **disjoint pairs**
+  instead of a path — a figure drawn between fixed directions (the demo's constellation lines) is
+  then ONE object: one draw call, one clickable thing, one name.
 - **Depth**: depth-TESTED, never depth-WRITING. An infinitely distant object is parked just inside
   the far plane, so everything the map draws is nearer and covers it, and it never occludes
   anything itself.
@@ -53,7 +55,11 @@ Objects are hit-tested against the touch ray through the standard layer path
 (`calculateRayIntersectedElements` / `processClick`), so they sort against every other layer's
 content and a click on terrain in front of the sun does not report the sun. The test is **angular**
 — how far the ray is from the direction the object sits in — which is the natural measure here; a
-star drawn half a pixel wide would be unhittable otherwise, hence `CelestialSprite::ClickRadius`.
+sprite drawn half a pixel wide would be unhittable otherwise, hence `CelestialSprite::ClickRadius`.
+Arcs are hit the same way, against the nearest point of the curve (`CelestialArc::ClickRadius`,
+0 = not clickable). Every arc sits at the same distance, so the reported hit is pushed out by the
+angle it was missed by — otherwise two overlapping curves would be picked between by list order,
+and a sprite drawn on a curve would lose to it.
 
 This needed a fix in `TouchHandler::handleClick`, and it applies to any sky content, not just this
 layer: a touch was **dropped entirely** unless its ray met the ground (`isValidScreenPosition`),
@@ -69,18 +75,49 @@ Sky content is normally off the top of the screen, because the map camera points
 changes the tilt, and panning moves to a two-finger drag. Pinch still zooms; the two-finger paths
 are untouched.
 
-**The camera cannot tilt above the horizon**, and that is a property of the camera model, not a
-setting: tilt is clamped to `Const::MIN_SUPPORTED_TILT_ANGLE` (0) and `Options::setTiltRange`
-clamps to it too. Lowering it was tried and the camera flips through the vertical - the view comes
-back inverted, ground below and sky at both edges - because the up vector is derived from a focus
-point on the ground. So the visible sky runs from the horizon up to roughly half the field of view.
-A body higher than that is drawn correctly and can be clicked, but cannot be brought into view
-without a first-person camera, which is a much larger change than this option.
+## Looking above the horizon: a negative tilt
+
+The tilt may now go **below 0**, and that is what "look up" is. It is opt-in: `MIN_SUPPORTED_TILT_ANGLE`
+is -90 but the default tilt range is still `(0, 90)`, so a map only gets there if it asks —
+`setTiltRange(MapRange(-90, 90))`.
+
+The model matters, because the obvious version does not work. Tilting between 90 and 0 rotates the
+camera **about the focus**; carrying that on below 0 puts the camera under the ground and the view
+comes back inverted (ground below, sky at both edges), because the up vector is derived from a
+focus point on the ground. That was tried, and it is why the ceiling stood.
+
+What a negative tilt does instead: the camera **stays exactly where the tilt geometry left it** and
+only the view direction pitches up, about the camera (`ViewState::calculateLookatMat`, and
+`getGroundTilt()` — the tilt floored at 0 — is what positions the camera). `dist(camera, focus)` is
+untouched, so zoom, the visible tile set and the near/far budget all still mean what they meant.
+`CameraTiltEvent` spends only the part of the tilt at or above the horizon on moving the camera.
+
+Two consequences had to be handled:
+
+- **All-sky frames have no ground.** `calculateViewDistances` walks rays to the ground for near and
+  far; with none of them hitting, it used to leave `far == near` and collapse the depth range onto
+  the near plane — taking with it everything drawn into the sky, which parks just inside the far
+  plane. It now falls back to the view distance the ground would have been drawn to.
+- **The terrain clearance bound goes unsatisfiable.** The camera's height above the focus is
+  `dist * sin(tilt)`, so approaching the horizon it rises by almost nothing as it zooms out and
+  `ViewState::getTerrainMaxZoom` runs off to minus infinity. Clamping to that threw the map from
+  z16 to its minimum zoom in a few frames (and, with the per-frame correction in `MapRenderer`,
+  kept walking it out to z-33). Both now drop the bound when the camera is at or below the focus
+  height, or when the bound lands below the zoom range: no zoom clears the terrain at that tilt
+  anyway, and keeping the camera the user asked for beats emptying the world.
+
+At tilt ≤ 0 the camera sits at the height of its focus, i.e. on the ground — which is exactly right
+for looking at the sky, and means the terrain is seen edge-on at the horizon.
 
 ## What lives in the app, not here
 
-The demo's `DemoCelestial` is worth reading as the worked example: the sun's direction comes from
-the SDK's own solar position (`LightOptions::setSunPositionFromTime`), so the sprite sits exactly
-where the light comes from — visibly, the sun disc lands **on** its own arc — while the moon's
-position and the arc's declination are computed in the app. Astronomy is application code; the
-layer only knows about directions, sizes and colors.
+The demo is worth reading as the worked example, and it is where all the astronomy lives:
+`DemoAstro` (sun, moon and its phase, planets from JPL's Keplerian elements), `DemoStarCatalogue`
+(bright stars + constellation figures), `DemoCelestial` (sun and moon with their real paths for the
+day, sampled from the same ephemeris — visibly, each disc lands **on** its own arc, which is a free
+check on both since they are computed independently) and `DemoStars` (one sprite per star, one
+segmented arc per figure, planets). The layer only knows about directions, sizes and colors.
+
+The demo's star sky mode is also the answer to "draw nothing but the sky": the map layers leave the
+layer list entirely (not hidden — never built), the terrain is disabled and the clear colour goes
+fully transparent, so with a translucent surface whatever is behind the view shows through.

--- a/docs/rendering/README.md
+++ b/docs/rendering/README.md
@@ -22,6 +22,7 @@ loading the rest. Every page states its scope at the top and links out rather th
 | sun, shadows, sky, fog | [08-lighting-sky-fog.md](08-lighting-sky-fog.md) |
 | CompositeVectorTileLayer, style-driven slots | [09-composite-layer.md](09-composite-layer.md) |
 | markers, popups, app-drawn lines/polygons, picking | [12-vector-elements.md](12-vector-elements.md) |
+| sun/moon/stars/aircraft: objects placed in the sky | [13-celestial.md](13-celestial.md) |
 | making it faster, or measuring anything | [10-performance.md](10-performance.md) |
 | "why don't we just do what tangram does?" | [11-tangram-diff.md](11-tangram-diff.md) |
 

--- a/ios/objc/ui/MapView.h
+++ b/ios/objc/ui/MapView.h
@@ -47,6 +47,17 @@ __attribute__ ((visibility("default"))) @interface NTMapView : NTGLKView
  */
 -(NTLayers*)getLayers;
 /**
+ * Makes the view translucent, so that whatever is behind it shows through wherever the map does
+ * not paint. Combine it with a transparent clear color - [options setClearColor:
+ * [[NTColor alloc] initWithR:0 g:0 b:0 a:0]] - which is what leaves the frame empty; the SDK
+ * renders with premultiplied alpha, so the result composites correctly.
+ *
+ * The view is an ordinary UIView, so it blends with the views behind it: a camera preview layer,
+ * or any other content. The default is opaque.
+ * @param translucent True to make the view translucent.
+ */
+-(void)setTranslucent:(BOOL)translucent;
+/**
  * Returns the Options object, that can be used for modifying various map options.
  * @return the Option object.
  */

--- a/ios/objc/ui/MapView.mm
+++ b/ios/objc/ui/MapView.mm
@@ -126,6 +126,17 @@ static const int NATIVE_NO_COORDINATE = -1;
 #endif
 }
 
+-(void)setTranslucent:(BOOL)translucent {
+    // The GL view itself, and the layer it draws into: both have to stop claiming they cover
+    // their pixels, or the compositor skips whatever is underneath. The drawable is already
+    // RGBA8888 (see initContext), so the alpha the renderer writes is the one that is composited.
+    self.opaque = !translucent;
+    self.layer.opaque = !translucent;
+    if (translucent) {
+        self.backgroundColor = [UIColor clearColor];
+    }
+}
+
 -(void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
 

--- a/scripts/android-dev/app/src/main/AndroidManifest.xml
+++ b/scripts/android-dev/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- star sky mode only: the camera preview the transparent map is composited over -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage"/>

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/MainActivity.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/MainActivity.java
@@ -1,6 +1,7 @@
 package com.akylas.cartotest;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.WindowCompat;
 
 import android.os.Bundle;
 import android.util.Log;
@@ -16,6 +17,9 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         Log.d(TAG, "onCreate");
+        // Draw edge to edge: the map runs under the status and navigation bars, and the overlay
+        // (DemoPanel) insets itself so nothing lands under them.
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         setContentView(R.layout.main_activity);
         if (savedInstanceState == null) {
             getSupportFragmentManager().beginTransaction()

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoAstro.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoAstro.java
@@ -1,0 +1,250 @@
+package com.akylas.cartotest.demo;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+/**
+ * Where the sun, the moon and the planets really are, for a date and a place on Earth.
+ *
+ * This is DEMO content, not SDK code: the celestial API takes an azimuth and an altitude and knows
+ * nothing about astronomy. Everything here is the standard low-precision series (the Astronomical
+ * Almanac's sun, the abbreviated lunar series, and JPL's approximate Keplerian elements for the
+ * planets), which is worth a few arcminutes - far better than the half degree a body covers, and
+ * the point is that what the demo draws is where you can go outside and look.
+ *
+ * Conventions, everywhere in this file: angles in DEGREES, time in UTC, azimuth clockwise from
+ * north and altitude above the horizon - the same frame the celestial API and LightOptions use.
+ */
+public final class DemoAstro {
+
+    private DemoAstro() {
+    }
+
+    /** Days since J2000.0 (2000-01-01 12:00 UTC) for a UTC calendar date and fractional hour. */
+    public static double daysSinceJ2000(int year, int month, int day, double hourUtc) {
+        // Standard Julian day for a Gregorian date, valid well beyond any date this demo cares about.
+        long a = (14 - month) / 12;
+        long y = year + 4800 - a;
+        long m = month + 12 * a - 3;
+        long jdn = day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
+        return (jdn - 2451545.0) - 0.5 + hourUtc / 24.0;
+    }
+
+    /** Greenwich mean sidereal time in degrees. */
+    public static double gmstDegrees(double n) {
+        double gmstHours = (18.697374558 + 24.06570982441908 * n) % 24.0;
+        if (gmstHours < 0) {
+            gmstHours += 24.0;
+        }
+        return gmstHours * 15.0;
+    }
+
+    /** Mean obliquity of the ecliptic in degrees. */
+    public static double obliquity(double n) {
+        return 23.4392911 - 3.563E-7 * n;
+    }
+
+    /**
+     * Equatorial to horizon. The hour angle is the local sidereal time minus the right ascension,
+     * which is the whole of what makes the sky turn.
+     *
+     * @param rightAscension right ascension in DEGREES
+     * @param declination declination in degrees
+     * @return { azimuth, altitude } in degrees
+     */
+    public static double[] toHorizon(double rightAscension, double declination, double n, double lat, double lon) {
+        double hourAngle = Math.toRadians(gmstDegrees(n) + lon - rightAscension);
+        double decl = Math.toRadians(declination);
+        double latRad = Math.toRadians(lat);
+        double sinAlt = Math.sin(latRad) * Math.sin(decl) + Math.cos(latRad) * Math.cos(decl) * Math.cos(hourAngle);
+        double altitude = Math.asin(clamp(sinAlt));
+        double azimuth = Math.atan2(Math.sin(hourAngle),
+                Math.cos(hourAngle) * Math.sin(latRad) - Math.tan(decl) * Math.cos(latRad));
+        return new double[] { normalizeDegrees(Math.toDegrees(azimuth) + 180.0), Math.toDegrees(altitude) };
+    }
+
+    /** Ecliptic longitude/latitude (degrees) to right ascension (degrees) and declination. */
+    public static double[] eclipticToEquatorial(double eclipticLong, double eclipticLat, double n) {
+        double lambda = Math.toRadians(eclipticLong);
+        double beta = Math.toRadians(eclipticLat);
+        double eps = Math.toRadians(obliquity(n));
+        double rightAsc = Math.atan2(Math.sin(lambda) * Math.cos(eps) - Math.tan(beta) * Math.sin(eps), Math.cos(lambda));
+        double decl = Math.asin(clamp(Math.sin(beta) * Math.cos(eps) + Math.cos(beta) * Math.sin(eps) * Math.sin(lambda)));
+        return new double[] { normalizeDegrees(Math.toDegrees(rightAsc)), Math.toDegrees(decl) };
+    }
+
+    // =================================================================================================
+    // SUN
+    // =================================================================================================
+
+    /** Geocentric ecliptic longitude of the sun in degrees. */
+    public static double sunEclipticLongitude(double n) {
+        double meanLong = 280.460 + 0.9856474 * n;
+        double meanAnom = Math.toRadians(357.528 + 0.9856003 * n);
+        return normalizeDegrees(meanLong + 1.915 * Math.sin(meanAnom) + 0.020 * Math.sin(2 * meanAnom));
+    }
+
+    /** Right ascension (degrees) and declination of the sun. */
+    public static double[] sunEquatorial(double n) {
+        return eclipticToEquatorial(sunEclipticLongitude(n), 0.0, n);
+    }
+
+    /** Azimuth and altitude of the sun. */
+    public static double[] sunHorizon(double n, double lat, double lon) {
+        double[] eq = sunEquatorial(n);
+        return toHorizon(eq[0], eq[1], n, lat, lon);
+    }
+
+    // =================================================================================================
+    // MOON
+    // =================================================================================================
+
+    /** Geocentric ecliptic longitude and latitude of the moon, in degrees. */
+    public static double[] moonEcliptic(double n) {
+        double meanLong = 218.316 + 13.176396 * n;
+        double meanAnom = Math.toRadians(134.963 + 13.064993 * n);
+        double argLat = Math.toRadians(93.272 + 13.229350 * n);
+        double eclipticLong = meanLong + 6.289 * Math.sin(meanAnom);
+        double eclipticLat = 5.128 * Math.sin(argLat);
+        return new double[] { normalizeDegrees(eclipticLong), eclipticLat };
+    }
+
+    /** Right ascension (degrees) and declination of the moon. */
+    public static double[] moonEquatorial(double n) {
+        double[] ecliptic = moonEcliptic(n);
+        return eclipticToEquatorial(ecliptic[0], ecliptic[1], n);
+    }
+
+    /** Azimuth and altitude of the moon. */
+    public static double[] moonHorizon(double n, double lat, double lon) {
+        double[] eq = moonEquatorial(n);
+        return toHorizon(eq[0], eq[1], n, lat, lon);
+    }
+
+    /**
+     * The moon's phase: the illuminated fraction, and which limb is lit.
+     *
+     * The elongation between the moon and the sun IS the phase - 0 at new moon, 180 at full - and
+     * its sign says whether the moon is waxing (lit on the side towards the sun, i.e. the western
+     * limb in the northern hemisphere) or waning.
+     *
+     * @return { illuminated fraction 0..1, +1 waxing / -1 waning }
+     */
+    public static double[] moonPhase(double n) {
+        double elongation = normalizeDegrees(moonEcliptic(n)[0] - sunEclipticLongitude(n));
+        double illuminated = (1.0 - Math.cos(Math.toRadians(elongation))) * 0.5;
+        return new double[] { illuminated, elongation < 180.0 ? 1.0 : -1.0 };
+    }
+
+    // =================================================================================================
+    // PLANETS
+    // =================================================================================================
+
+    /** The planets the demo places, in the order of {@link #PLANET_ELEMENTS}. */
+    public static final String[] PLANET_NAMES = { "Mercury", "Venus", "Mars", "Jupiter", "Saturn" };
+
+    /**
+     * JPL's approximate Keplerian elements, valid 1800-2050 (the "Approximate Positions of the
+     * Major Planets" table): semi-major axis (au), eccentricity, inclination, mean longitude,
+     * longitude of perihelion and longitude of the ascending node, each with its rate per Julian
+     * century. Earth is last and is not drawn - it is what the geocentric view is taken from.
+     */
+    private static final double[][] PLANET_ELEMENTS = {
+        // a, e, I, L, longPeri, longNode  then the six rates per century
+        { 0.38709927, 0.20563593, 7.00497902, 252.25032350, 77.45779628, 48.33076593,
+          0.00000037, 0.00001906, -0.00594749, 149472.67411175, 0.16047689, -0.12534081 },
+        { 0.72333566, 0.00677672, 3.39467605, 181.97909950, 131.60246718, 76.67984255,
+          0.00000390, -0.00004107, -0.00078890, 58517.81538729, 0.00268329, -0.27769418 },
+        { 1.52371034, 0.09339410, 1.84969142, -4.55343205, -23.94362959, 49.55953891,
+          0.00001847, 0.00007882, -0.00813131, 19140.30268499, 0.44441088, -0.29257343 },
+        { 5.20288700, 0.04838624, 1.30439695, 34.39644051, 14.72847983, 100.47390909,
+          -0.00011607, -0.00013253, -0.00183714, 3034.74612775, 0.21252668, 0.20469106 },
+        { 9.53667594, 0.05386179, 2.48599187, 49.95424423, 92.59887831, 113.66242448,
+          -0.00125060, -0.00050991, 0.00193609, 1222.49362201, -0.41897216, -0.28867794 },
+        { 1.00000261, 0.01671123, -0.00001531, 100.46457166, 102.93768193, 0.0,
+          0.00000562, -0.00004392, -0.01294668, 35999.37244981, 0.32327364, 0.0 },
+    };
+
+    private static final int EARTH = PLANET_ELEMENTS.length - 1;
+
+    /**
+     * Azimuth and altitude of a planet, by index into {@link #PLANET_NAMES}.
+     *
+     * Heliocentric position from the elements, minus the Earth's, gives the geocentric ecliptic
+     * direction; the rest is the same conversion everything else here goes through. Light travel
+     * time and planetary aberration are ignored (tens of arcseconds).
+     */
+    public static double[] planetHorizon(int planet, double n, double lat, double lon) {
+        double[] body = heliocentric(planet, n);
+        double[] earth = heliocentric(EARTH, n);
+        double x = body[0] - earth[0];
+        double y = body[1] - earth[1];
+        double z = body[2] - earth[2];
+        double eclipticLong = Math.toDegrees(Math.atan2(y, x));
+        double eclipticLat = Math.toDegrees(Math.atan2(z, Math.sqrt(x * x + y * y)));
+        double[] eq = eclipticToEquatorial(eclipticLong, eclipticLat, n);
+        return toHorizon(eq[0], eq[1], n, lat, lon);
+    }
+
+    /** Heliocentric ecliptic rectangular coordinates (au) of one body of {@link #PLANET_ELEMENTS}. */
+    private static double[] heliocentric(int planet, double n) {
+        double[] e = PLANET_ELEMENTS[planet];
+        double t = n / 36525.0;
+        double a = e[0] + e[6] * t;
+        double ecc = e[1] + e[7] * t;
+        double inc = Math.toRadians(e[2] + e[8] * t);
+        double meanLong = e[3] + e[9] * t;
+        double longPeri = e[4] + e[10] * t;
+        double longNodeDeg = e[5] + e[11] * t;
+        double longNode = Math.toRadians(longNodeDeg);
+        double argPeri = Math.toRadians(longPeri - longNodeDeg);
+
+        // Mean anomaly, folded into -180..180 as the Kepler iteration below expects.
+        double meanAnom = Math.toRadians(normalizeDegrees(meanLong - longPeri + 180.0) - 180.0);
+        double eccAnom = meanAnom;
+        for (int i = 0; i < 12; i++) {
+            double delta = (eccAnom - ecc * Math.sin(eccAnom) - meanAnom) / (1.0 - ecc * Math.cos(eccAnom));
+            eccAnom -= delta;
+            if (Math.abs(delta) < 1.0E-10) {
+                break;
+            }
+        }
+
+        // In the orbital plane, then rotated by the argument of perihelion, the inclination and the
+        // longitude of the ascending node into the J2000 ecliptic frame.
+        double xOrbit = a * (Math.cos(eccAnom) - ecc);
+        double yOrbit = a * Math.sqrt(1.0 - ecc * ecc) * Math.sin(eccAnom);
+        double cosPeri = Math.cos(argPeri), sinPeri = Math.sin(argPeri);
+        double cosNode = Math.cos(longNode), sinNode = Math.sin(longNode);
+        double cosInc = Math.cos(inc), sinInc = Math.sin(inc);
+        double xPlane = xOrbit * cosPeri - yOrbit * sinPeri;
+        double yPlane = xOrbit * sinPeri + yOrbit * cosPeri;
+        return new double[] {
+            xPlane * cosNode - yPlane * cosInc * sinNode,
+            xPlane * sinNode + yPlane * cosInc * cosNode,
+            yPlane * sinInc,
+        };
+    }
+
+    // =================================================================================================
+    // HELPERS
+    // =================================================================================================
+
+    /** Today's UTC date and fractional hour: { year, month, day, hour }. */
+    public static double[] nowUtc() {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        double hour = calendar.get(Calendar.HOUR_OF_DAY)
+                + calendar.get(Calendar.MINUTE) / 60.0
+                + calendar.get(Calendar.SECOND) / 3600.0;
+        return new double[] { calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH), hour };
+    }
+
+    public static double normalizeDegrees(double degrees) {
+        double result = degrees % 360.0;
+        return result < 0 ? result + 360.0 : result;
+    }
+
+    private static double clamp(double value) {
+        return Math.max(-1.0, Math.min(1.0, value));
+    }
+}

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoCameraPreview.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoCameraPreview.java
@@ -1,0 +1,186 @@
+package com.akylas.cartotest.demo;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.hardware.camera2.CameraAccessException;
+import android.hardware.camera2.CameraCaptureSession;
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.CameraDevice;
+import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.CaptureRequest;
+import android.util.Log;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.constraintlayout.widget.ConstraintLayout;
+
+import java.util.Arrays;
+
+/**
+ * A live camera preview BEHIND the map, which is what makes a transparent map worth having: the
+ * star sky drawn over what the camera sees is an augmented-reality sky.
+ *
+ * The arrangement is the standard one for a GL view over a camera, and it is the whole reason
+ * MapView.setTranslucent also raises the z-order: a SurfaceView is composited BELOW the window, so
+ * the only thing a translucent map can reveal is ANOTHER surface under it. This adds that surface -
+ * a plain SurfaceView, added first so it stays at the bottom - and the map (media overlay) sits on
+ * top of it.
+ *
+ * Camera2 with a single preview target; nothing is captured or stored.
+ */
+public final class DemoCameraPreview {
+
+    private static final String TAG = "DemoCameraPreview";
+    private static final int PERMISSION_REQUEST = 4711;
+
+    private final Context context;
+    private final ConstraintLayout root;
+
+    private SurfaceView surfaceView;
+    private CameraDevice camera;
+    private CameraCaptureSession session;
+
+    public DemoCameraPreview(Context context, ConstraintLayout root) {
+        this.context = context;
+        this.root = root;
+    }
+
+    public boolean isRunning() {
+        return surfaceView != null;
+    }
+
+    /** Adds the preview under the map and starts it. Asks for the permission if it is missing. */
+    public void start() {
+        // The demo builds its map on a worker thread; a view hierarchy may only be touched on the
+        // main one.
+        if (android.os.Looper.myLooper() != android.os.Looper.getMainLooper()) {
+            new android.os.Handler(android.os.Looper.getMainLooper()).post(new Runnable() {
+                public void run() { start(); }
+            });
+            return;
+        }
+        if (surfaceView != null) {
+            return;
+        }
+        if (context.checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            if (context instanceof Activity) {
+                ((Activity) context).requestPermissions(new String[] { Manifest.permission.CAMERA }, PERMISSION_REQUEST);
+            }
+            Log.w(TAG, "no camera permission yet - grant it and switch the mode again");
+            return;
+        }
+
+        surfaceView = new SurfaceView(context);
+        ConstraintLayout.LayoutParams lp = new ConstraintLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        lp.topToTop = ConstraintLayout.LayoutParams.PARENT_ID;
+        lp.bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID;
+        lp.startToStart = ConstraintLayout.LayoutParams.PARENT_ID;
+        lp.endToEnd = ConstraintLayout.LayoutParams.PARENT_ID;
+        // Index 0: below every other view, and - what actually matters here - a plain surface,
+        // which the map's media-overlay surface is composited on top of.
+        root.addView(surfaceView, 0, lp);
+
+        surfaceView.getHolder().addCallback(new SurfaceHolder.Callback() {
+            public void surfaceCreated(SurfaceHolder holder) {
+                openCamera(holder);
+            }
+            public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+            }
+            public void surfaceDestroyed(SurfaceHolder holder) {
+                closeCamera();
+            }
+        });
+    }
+
+    /** Stops the preview and takes the view back out of the layout. */
+    public void stop() {
+        closeCamera();
+        if (surfaceView != null) {
+            final View view = surfaceView;
+            surfaceView = null;
+            view.post(new Runnable() {
+                public void run() {
+                    root.removeView(view);
+                }
+            });
+        }
+    }
+
+    private void openCamera(final SurfaceHolder holder) {
+        CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
+        if (manager == null) {
+            return;
+        }
+        try {
+            String cameraId = null;
+            for (String id : manager.getCameraIdList()) {
+                Integer facing = manager.getCameraCharacteristics(id).get(CameraCharacteristics.LENS_FACING);
+                if (facing != null && facing == CameraCharacteristics.LENS_FACING_BACK) {
+                    cameraId = id;
+                    break;
+                }
+            }
+            if (cameraId == null) {
+                Log.w(TAG, "no back camera on this device");
+                return;
+            }
+            manager.openCamera(cameraId, new CameraDevice.StateCallback() {
+                public void onOpened(CameraDevice device) {
+                    camera = device;
+                    startPreview(holder);
+                }
+                public void onDisconnected(CameraDevice device) {
+                    device.close();
+                    camera = null;
+                }
+                public void onError(CameraDevice device, int error) {
+                    Log.w(TAG, "camera error " + error);
+                    device.close();
+                    camera = null;
+                }
+            }, null);
+        } catch (CameraAccessException e) {
+            Log.w(TAG, "could not open the camera: " + e);
+        } catch (SecurityException e) {
+            Log.w(TAG, "camera permission was revoked: " + e);
+        }
+    }
+
+    private void startPreview(SurfaceHolder holder) {
+        try {
+            final CaptureRequest.Builder request = camera.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
+            request.addTarget(holder.getSurface());
+            camera.createCaptureSession(Arrays.asList(holder.getSurface()), new CameraCaptureSession.StateCallback() {
+                public void onConfigured(CameraCaptureSession configured) {
+                    session = configured;
+                    try {
+                        session.setRepeatingRequest(request.build(), null, null);
+                    } catch (CameraAccessException e) {
+                        Log.w(TAG, "could not start the preview: " + e);
+                    }
+                }
+                public void onConfigureFailed(CameraCaptureSession configured) {
+                    Log.w(TAG, "camera session configuration failed");
+                }
+            }, null);
+        } catch (CameraAccessException e) {
+            Log.w(TAG, "could not build the preview request: " + e);
+        }
+    }
+
+    private void closeCamera() {
+        if (session != null) {
+            session.close();
+            session = null;
+        }
+        if (camera != null) {
+            camera.close();
+            camera = null;
+        }
+    }
+}

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoCelestial.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoCelestial.java
@@ -1,31 +1,50 @@
 package com.akylas.cartotest.demo;
 
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.RectF;
 import android.widget.Toast;
 
 import com.carto.celestial.CelestialArc;
 import com.carto.celestial.CelestialObject;
 import com.carto.celestial.CelestialSprite;
+import com.carto.core.DoubleVector;
+import com.carto.core.MapPos;
+import com.carto.core.Variant;
 import com.carto.graphics.Color;
 import com.carto.layers.CelestialEventListener;
 import com.carto.layers.CelestialLayer;
 import com.carto.ui.ClickInfo;
 import com.carto.ui.MapView;
+import com.carto.utils.BitmapUtils;
 
 /**
- * The sun, the moon and the sun's path across the day, built on the generic celestial API.
+ * The sun, the moon and their paths across the day, built on the generic celestial API.
  *
- * NOTHING here is a sun or a moon as far as the SDK is concerned: they are two sprites and one
- * arc, placed by direction. The astronomy lives in this file, which is the point - the same API
- * carries an aircraft ({@link #addAircraft}) or a star catalogue with no SDK change at all.
+ * NOTHING here is a sun or a moon as far as the SDK is concerned: they are two sprites and two
+ * arcs, placed by direction. The astronomy lives in {@link DemoAstro}, which is the point - the
+ * same API carries an aircraft ({@link #addAircraft}) or a star catalogue ({@link DemoStars}) with
+ * no SDK change at all.
+ *
+ * The positions are the REAL ones for the demo's date, hour and location, and the arcs are sampled
+ * from the same ephemeris over the whole day, so the disc always sits exactly on its own arc. That
+ * is a free correctness check on both: they are computed independently of each other.
  */
 public final class DemoCelestial {
 
     private static final String META_NAME = "name";
+    private static final int MOON_BITMAP_SIZE = 128;
+    /** The sampling step of a daily path, in minutes. 10 is smooth at any field of view. */
+    private static final int PATH_STEP_MINUTES = 10;
 
     private CelestialLayer layer;
     private CelestialSprite sun;
     private CelestialSprite moon;
     private CelestialArc sunPath;
+    private CelestialArc moonPath;
+    private double lastMoonPhase = -1;
 
     /** Builds the layer and its objects. Added FIRST, so the map and the terrain draw over them. */
     public CelestialLayer createLayer(final MapView mapView) {
@@ -36,30 +55,39 @@ public final class DemoCelestial {
         sun.setColor(new Color((short) 255, (short) 244, (short) 214, (short) 255));
         sun.setSoftness(0.35f);
         sun.setClickRadius(3f);
-        sun.setMetaDataElement(META_NAME, new com.carto.core.Variant("Sun"));
+        sun.setMetaDataElement(META_NAME, new Variant("Sun"));
 
         moon = new CelestialSprite();
         moon.setAngularSize(DemoConfig.CELESTIAL_MOON_SIZE);
-        moon.setColor(new Color((short) 235, (short) 235, (short) 225, (short) 255));
+        moon.setColor(new Color((short) 245, (short) 245, (short) 235, (short) 255));
         moon.setSoftness(0.25f);
         moon.setClickRadius(3f);
-        moon.setMetaDataElement(META_NAME, new com.carto.core.Variant("Moon"));
+        moon.setMetaDataElement(META_NAME, new Variant("Moon"));
 
         sunPath = new CelestialArc();
         sunPath.setColor(new Color((short) 255, (short) 216, (short) 120, (short) 160));
         sunPath.setWidth(DemoConfig.CELESTIAL_ARC_WIDTH);
         sunPath.setBelowHorizonVisible(false);
-        sunPath.setMetaDataElement(META_NAME, new com.carto.core.Variant("Sun path"));
+        sunPath.setClickRadius(2f);
+        sunPath.setMetaDataElement(META_NAME, new Variant("Sun path"));
+
+        moonPath = new CelestialArc();
+        moonPath.setColor(new Color((short) 170, (short) 190, (short) 255, (short) 130));
+        moonPath.setWidth(DemoConfig.CELESTIAL_ARC_WIDTH);
+        moonPath.setBelowHorizonVisible(false);
+        moonPath.setClickRadius(2f);
+        moonPath.setMetaDataElement(META_NAME, new Variant("Moon path"));
 
         layer.add(sun);
         layer.add(moon);
         layer.add(sunPath);
+        layer.add(moonPath);
 
         layer.setCelestialEventListener(new CelestialEventListener() {
             @Override
             public boolean onCelestialObjectClicked(ClickInfo clickInfo, CelestialObject object) {
                 final String message = object.getMetaDataElement(META_NAME).getString()
-                        + "  az " + Math.round(object.getAzimuth()) + "\u00b0  alt " + Math.round(object.getAltitude()) + "\u00b0";
+                        + "  az " + Math.round(object.getAzimuth()) + "°  alt " + Math.round(object.getAltitude()) + "°";
                 // The listener is called on the touch thread; a Toast needs the UI thread.
                 mapView.post(new Runnable() {
                     @Override
@@ -74,38 +102,103 @@ public final class DemoCelestial {
     }
 
     /**
-     * Places the objects for the demo's current date, time and location. The sun's direction is
-     * taken from the SDK's own solar position (LightOptions), so the sprite sits exactly where the
-     * light comes from; the moon and the arc are computed here.
+     * Places the objects for the demo's current date, time and location.
+     *
+     * Both bodies come from {@link DemoAstro} rather than from the light options, because the panel
+     * can drive the sun's azimuth and altitude by hand: what is drawn here is always where the body
+     * really is on that date, which is the only version of it whose daily arc means anything.
      */
-    public void update(DemoMap demoMap) {
-        if (layer == null || demoMap == null || demoMap.lightOptions == null) {
+    public void update() {
+        if (layer == null) {
             return;
         }
-        double hourUtc = DemoConfig.SUN_HOUR_UTC >= 0 ? DemoConfig.SUN_HOUR_UTC : DemoConfig.DAY_CYCLE_HOUR;
+        double hourUtc = DemoConfig.currentHourUtc();
         double lat = DemoConfig.START_LAT;
         double lon = DemoConfig.START_LON;
+        double n = DemoAstro.daysSinceJ2000(DemoConfig.SUN_YEAR, DemoConfig.SUN_MONTH, DemoConfig.SUN_DAY, hourUtc);
 
-        float sunAzimuth = demoMap.lightOptions.getSunAzimuth();
-        float sunAltitude = demoMap.lightOptions.getSunAltitude();
-        sun.setDirection(sunAzimuth, sunAltitude, 0);
+        double[] sunDir = DemoAstro.sunHorizon(n, lat, lon);
+        sun.setDirection((float) sunDir[0], (float) sunDir[1], 0);
 
-        double[] moonDir = moonAzimuthAltitude(DemoConfig.SUN_YEAR, DemoConfig.SUN_MONTH, DemoConfig.SUN_DAY, hourUtc, lat, lon);
+        double[] moonDir = DemoAstro.moonHorizon(n, lat, lon);
         moon.setDirection((float) moonDir[0], (float) moonDir[1], 0);
+        updateMoonPhase(n);
 
-        // The sun's path across the day is the circle of constant declination about the celestial
-        // pole: the axis points north at an altitude equal to the latitude, and the radius is 90
-        // degrees minus the declination. Declination comes back out of the sun's own direction.
-        double altRad = Math.toRadians(sunAltitude);
-        double azRad = Math.toRadians(sunAzimuth);
-        double latRad = Math.toRadians(lat);
-        double sinDecl = Math.sin(altRad) * Math.sin(latRad) + Math.cos(altRad) * Math.cos(latRad) * Math.cos(azRad);
-        double declination = Math.toDegrees(Math.asin(Math.max(-1, Math.min(1, sinDecl))));
-        sunPath.setCircle(lat >= 0 ? 0f : 180f, (float) Math.abs(lat), (float) (90.0 - declination));
+        // The path across the day, sampled from the same ephemeris every PATH_STEP_MINUTES from
+        // midnight to midnight. A circle about the celestial pole would be a good enough sun path
+        // (declination barely moves in a day), but the moon's does move - a quarter of the sky in a
+        // day - so both are sampled and the two arcs are then the same kind of object.
+        sunPath.setDirections(dailyPath(true, lat, lon));
+        moonPath.setDirections(dailyPath(false, lat, lon));
 
         sun.setVisible(DemoConfig.CELESTIAL_SUN);
         moon.setVisible(DemoConfig.CELESTIAL_MOON);
         sunPath.setVisible(DemoConfig.CELESTIAL_ARC);
+        moonPath.setVisible(DemoConfig.CELESTIAL_MOON_ARC);
+        android.util.Log.i("DemoCelestial", "sun az " + Math.round(sunDir[0]) + " alt " + Math.round(sunDir[1])
+                + ", moon az " + Math.round(moonDir[0]) + " alt " + Math.round(moonDir[1])
+                + ", hour " + hourUtc + " UTC " + DemoConfig.SUN_YEAR + "-" + DemoConfig.SUN_MONTH + "-" + DemoConfig.SUN_DAY);
+    }
+
+    /** The body's track over the configured date, as alternating azimuth/altitude degrees. */
+    private static DoubleVector dailyPath(boolean isSun, double lat, double lon) {
+        DoubleVector directions = new DoubleVector();
+        for (int minute = 0; minute <= 24 * 60; minute += PATH_STEP_MINUTES) {
+            double n = DemoAstro.daysSinceJ2000(DemoConfig.SUN_YEAR, DemoConfig.SUN_MONTH, DemoConfig.SUN_DAY, minute / 60.0);
+            double[] horizon = isSun ? DemoAstro.sunHorizon(n, lat, lon) : DemoAstro.moonHorizon(n, lat, lon);
+            directions.add(horizon[0]);
+            directions.add(horizon[1]);
+        }
+        return directions;
+    }
+
+    /**
+     * Draws the moon with the phase it really has: a disc with a bite taken out of it by a second
+     * ellipse, which is what a terminator is - the projection of the circle dividing the lit and
+     * unlit halves. Painting it into the sprite's bitmap keeps this out of the SDK entirely.
+     */
+    private void updateMoonPhase(double n) {
+        double[] phase = DemoAstro.moonPhase(n);
+        if (!DemoConfig.CELESTIAL_MOON_PHASE) {
+            if (lastMoonPhase >= 0) {
+                moon.setBitmap(null);
+                lastMoonPhase = -1;
+            }
+            return;
+        }
+        double illuminated = phase[0];
+        double signedPhase = phase[1] * illuminated;
+        if (Math.abs(signedPhase - lastMoonPhase) < 0.01) {
+            return; // a hundredth of a phase is invisible; do not rebuild the texture for it
+        }
+        lastMoonPhase = signedPhase;
+
+        android.graphics.Bitmap bitmap = android.graphics.Bitmap.createBitmap(MOON_BITMAP_SIZE, MOON_BITMAP_SIZE, android.graphics.Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        float radius = MOON_BITMAP_SIZE * 0.5f;
+        paint.setColor(0xFFF5F5EB);
+        canvas.drawCircle(radius, radius, radius - 1, paint);
+
+        // The terminator: an ellipse whose half-width goes from the full radius at new moon, through
+        // zero at the quarter, to the full radius again at full moon - the same circle seen edge on.
+        float terminator = (float) Math.abs(1.0 - 2.0 * illuminated) * (radius - 1);
+        Paint eraser = new Paint(Paint.ANTI_ALIAS_FLAG);
+        eraser.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
+        boolean waxing = phase[1] > 0;
+        // Waxing: lit on the side towards the sun, the western limb - drawn on the right, so the
+        // dark half is the left one (angles run clockwise from 3 o'clock in Canvas).
+        RectF disc = new RectF(1, 1, MOON_BITMAP_SIZE - 1, MOON_BITMAP_SIZE - 1);
+        canvas.drawArc(disc, waxing ? 90 : -90, 180, true, eraser);
+        RectF terminatorOval = new RectF(radius - terminator, 1, radius + terminator, MOON_BITMAP_SIZE - 1);
+        if (illuminated < 0.5) {
+            // Crescent: the terminator bulges INTO the lit half, so the ellipse erases as well.
+            canvas.drawOval(terminatorOval, eraser);
+        } else {
+            // Gibbous: it bulges into the dark half, so the ellipse paints the moon back in.
+            canvas.drawOval(terminatorOval, paint);
+        }
+        moon.setBitmap(BitmapUtils.createBitmapFromAndroidBitmap(bitmap));
     }
 
     /**
@@ -116,48 +209,9 @@ public final class DemoCelestial {
         CelestialSprite aircraft = new CelestialSprite();
         aircraft.setScreenSize(24f);
         aircraft.setColor(new Color((short) 255, (short) 255, (short) 255, (short) 255));
-        aircraft.setPosition(new com.carto.core.MapPos(lon, lat), altitudeMeters);
-        aircraft.setMetaDataElement(META_NAME, new com.carto.core.Variant("Aircraft"));
+        aircraft.setPosition(new MapPos(lon, lat), altitudeMeters);
+        aircraft.setMetaDataElement(META_NAME, new Variant("Aircraft"));
         layer.add(aircraft);
         return aircraft;
-    }
-
-    /**
-     * Moon position, low-precision (about 0.3 degrees, which is the moon's own diameter): the
-     * standard abbreviated lunar series, then the same equatorial-to-horizon conversion the sun
-     * uses. Good enough to point at the moon in the sky; not an ephemeris.
-     */
-    private static double[] moonAzimuthAltitude(int year, int month, int day, double hourUtc, double lat, double lon) {
-        int a = (14 - month) / 12;
-        int y = year + 4800 - a;
-        int m = month + 12 * a - 3;
-        double jdn = day + (153 * m + 2) / 5 + 365L * y + y / 4 - y / 100 + y / 400 - 32045;
-        double jd = jdn + (hourUtc - 12.0) / 24.0;
-        double n = jd - 2451545.0;
-
-        double meanLong = Math.toRadians(218.316 + 13.176396 * n);
-        double meanAnom = Math.toRadians(134.963 + 13.064993 * n);
-        double argLat = Math.toRadians(93.272 + 13.229350 * n);
-
-        double eclipticLong = meanLong + Math.toRadians(6.289) * Math.sin(meanAnom);
-        double eclipticLat = Math.toRadians(5.128) * Math.sin(argLat);
-        double obliquity = Math.toRadians(23.439 - 0.0000004 * n);
-
-        double rightAsc = Math.atan2(Math.sin(eclipticLong) * Math.cos(obliquity) - Math.tan(eclipticLat) * Math.sin(obliquity),
-                Math.cos(eclipticLong));
-        double decl = Math.asin(Math.sin(eclipticLat) * Math.cos(obliquity)
-                + Math.cos(eclipticLat) * Math.sin(obliquity) * Math.sin(eclipticLong));
-
-        double gmst = (18.697374558 + 24.06570982441908 * n) % 24.0;
-        if (gmst < 0) {
-            gmst += 24.0;
-        }
-        double lmst = Math.toRadians(gmst * 15.0) + Math.toRadians(lon);
-        double hourAngle = lmst - rightAsc;
-
-        double latRad = Math.toRadians(lat);
-        double altitude = Math.asin(Math.sin(latRad) * Math.sin(decl) + Math.cos(latRad) * Math.cos(decl) * Math.cos(hourAngle));
-        double azimuth = Math.atan2(Math.sin(hourAngle), Math.cos(hourAngle) * Math.sin(latRad) - Math.tan(decl) * Math.cos(latRad));
-        return new double[] { Math.toDegrees(azimuth) + 180.0, Math.toDegrees(altitude) };
     }
 }

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoCelestial.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoCelestial.java
@@ -1,0 +1,163 @@
+package com.akylas.cartotest.demo;
+
+import android.widget.Toast;
+
+import com.carto.celestial.CelestialArc;
+import com.carto.celestial.CelestialObject;
+import com.carto.celestial.CelestialSprite;
+import com.carto.graphics.Color;
+import com.carto.layers.CelestialEventListener;
+import com.carto.layers.CelestialLayer;
+import com.carto.ui.ClickInfo;
+import com.carto.ui.MapView;
+
+/**
+ * The sun, the moon and the sun's path across the day, built on the generic celestial API.
+ *
+ * NOTHING here is a sun or a moon as far as the SDK is concerned: they are two sprites and one
+ * arc, placed by direction. The astronomy lives in this file, which is the point - the same API
+ * carries an aircraft ({@link #addAircraft}) or a star catalogue with no SDK change at all.
+ */
+public final class DemoCelestial {
+
+    private static final String META_NAME = "name";
+
+    private CelestialLayer layer;
+    private CelestialSprite sun;
+    private CelestialSprite moon;
+    private CelestialArc sunPath;
+
+    /** Builds the layer and its objects. Added FIRST, so the map and the terrain draw over them. */
+    public CelestialLayer createLayer(final MapView mapView) {
+        layer = new CelestialLayer();
+
+        sun = new CelestialSprite();
+        sun.setAngularSize(DemoConfig.CELESTIAL_SUN_SIZE);
+        sun.setColor(new Color((short) 255, (short) 244, (short) 214, (short) 255));
+        sun.setSoftness(0.35f);
+        sun.setClickRadius(3f);
+        sun.setMetaDataElement(META_NAME, new com.carto.core.Variant("Sun"));
+
+        moon = new CelestialSprite();
+        moon.setAngularSize(DemoConfig.CELESTIAL_MOON_SIZE);
+        moon.setColor(new Color((short) 235, (short) 235, (short) 225, (short) 255));
+        moon.setSoftness(0.25f);
+        moon.setClickRadius(3f);
+        moon.setMetaDataElement(META_NAME, new com.carto.core.Variant("Moon"));
+
+        sunPath = new CelestialArc();
+        sunPath.setColor(new Color((short) 255, (short) 216, (short) 120, (short) 160));
+        sunPath.setWidth(DemoConfig.CELESTIAL_ARC_WIDTH);
+        sunPath.setBelowHorizonVisible(false);
+        sunPath.setMetaDataElement(META_NAME, new com.carto.core.Variant("Sun path"));
+
+        layer.add(sun);
+        layer.add(moon);
+        layer.add(sunPath);
+
+        layer.setCelestialEventListener(new CelestialEventListener() {
+            @Override
+            public boolean onCelestialObjectClicked(ClickInfo clickInfo, CelestialObject object) {
+                final String message = object.getMetaDataElement(META_NAME).getString()
+                        + "  az " + Math.round(object.getAzimuth()) + "\u00b0  alt " + Math.round(object.getAltitude()) + "\u00b0";
+                // The listener is called on the touch thread; a Toast needs the UI thread.
+                mapView.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        Toast.makeText(mapView.getContext(), message, Toast.LENGTH_SHORT).show();
+                    }
+                });
+                return true;
+            }
+        });
+        return layer;
+    }
+
+    /**
+     * Places the objects for the demo's current date, time and location. The sun's direction is
+     * taken from the SDK's own solar position (LightOptions), so the sprite sits exactly where the
+     * light comes from; the moon and the arc are computed here.
+     */
+    public void update(DemoMap demoMap) {
+        if (layer == null || demoMap == null || demoMap.lightOptions == null) {
+            return;
+        }
+        double hourUtc = DemoConfig.SUN_HOUR_UTC >= 0 ? DemoConfig.SUN_HOUR_UTC : DemoConfig.DAY_CYCLE_HOUR;
+        double lat = DemoConfig.START_LAT;
+        double lon = DemoConfig.START_LON;
+
+        float sunAzimuth = demoMap.lightOptions.getSunAzimuth();
+        float sunAltitude = demoMap.lightOptions.getSunAltitude();
+        sun.setDirection(sunAzimuth, sunAltitude, 0);
+
+        double[] moonDir = moonAzimuthAltitude(DemoConfig.SUN_YEAR, DemoConfig.SUN_MONTH, DemoConfig.SUN_DAY, hourUtc, lat, lon);
+        moon.setDirection((float) moonDir[0], (float) moonDir[1], 0);
+
+        // The sun's path across the day is the circle of constant declination about the celestial
+        // pole: the axis points north at an altitude equal to the latitude, and the radius is 90
+        // degrees minus the declination. Declination comes back out of the sun's own direction.
+        double altRad = Math.toRadians(sunAltitude);
+        double azRad = Math.toRadians(sunAzimuth);
+        double latRad = Math.toRadians(lat);
+        double sinDecl = Math.sin(altRad) * Math.sin(latRad) + Math.cos(altRad) * Math.cos(latRad) * Math.cos(azRad);
+        double declination = Math.toDegrees(Math.asin(Math.max(-1, Math.min(1, sinDecl))));
+        sunPath.setCircle(lat >= 0 ? 0f : 180f, (float) Math.abs(lat), (float) (90.0 - declination));
+
+        sun.setVisible(DemoConfig.CELESTIAL_SUN);
+        moon.setVisible(DemoConfig.CELESTIAL_MOON);
+        sunPath.setVisible(DemoConfig.CELESTIAL_ARC);
+    }
+
+    /**
+     * An aircraft or a satellite: the same API, anchored above a real place instead of by
+     * direction, so it parallaxes with the map like anything else that has a location.
+     */
+    public CelestialSprite addAircraft(double lon, double lat, double altitudeMeters) {
+        CelestialSprite aircraft = new CelestialSprite();
+        aircraft.setScreenSize(24f);
+        aircraft.setColor(new Color((short) 255, (short) 255, (short) 255, (short) 255));
+        aircraft.setPosition(new com.carto.core.MapPos(lon, lat), altitudeMeters);
+        aircraft.setMetaDataElement(META_NAME, new com.carto.core.Variant("Aircraft"));
+        layer.add(aircraft);
+        return aircraft;
+    }
+
+    /**
+     * Moon position, low-precision (about 0.3 degrees, which is the moon's own diameter): the
+     * standard abbreviated lunar series, then the same equatorial-to-horizon conversion the sun
+     * uses. Good enough to point at the moon in the sky; not an ephemeris.
+     */
+    private static double[] moonAzimuthAltitude(int year, int month, int day, double hourUtc, double lat, double lon) {
+        int a = (14 - month) / 12;
+        int y = year + 4800 - a;
+        int m = month + 12 * a - 3;
+        double jdn = day + (153 * m + 2) / 5 + 365L * y + y / 4 - y / 100 + y / 400 - 32045;
+        double jd = jdn + (hourUtc - 12.0) / 24.0;
+        double n = jd - 2451545.0;
+
+        double meanLong = Math.toRadians(218.316 + 13.176396 * n);
+        double meanAnom = Math.toRadians(134.963 + 13.064993 * n);
+        double argLat = Math.toRadians(93.272 + 13.229350 * n);
+
+        double eclipticLong = meanLong + Math.toRadians(6.289) * Math.sin(meanAnom);
+        double eclipticLat = Math.toRadians(5.128) * Math.sin(argLat);
+        double obliquity = Math.toRadians(23.439 - 0.0000004 * n);
+
+        double rightAsc = Math.atan2(Math.sin(eclipticLong) * Math.cos(obliquity) - Math.tan(eclipticLat) * Math.sin(obliquity),
+                Math.cos(eclipticLong));
+        double decl = Math.asin(Math.sin(eclipticLat) * Math.cos(obliquity)
+                + Math.cos(eclipticLat) * Math.sin(obliquity) * Math.sin(eclipticLong));
+
+        double gmst = (18.697374558 + 24.06570982441908 * n) % 24.0;
+        if (gmst < 0) {
+            gmst += 24.0;
+        }
+        double lmst = Math.toRadians(gmst * 15.0) + Math.toRadians(lon);
+        double hourAngle = lmst - rightAsc;
+
+        double latRad = Math.toRadians(lat);
+        double altitude = Math.asin(Math.sin(latRad) * Math.sin(decl) + Math.cos(latRad) * Math.cos(decl) * Math.cos(hourAngle));
+        double azimuth = Math.atan2(Math.sin(hourAngle), Math.cos(hourAngle) * Math.sin(latRad) - Math.tan(decl) * Math.cos(latRad));
+        return new double[] { Math.toDegrees(azimuth) + 180.0, Math.toDegrees(altitude) };
+    }
+}

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -233,7 +233,11 @@ public final class DemoConfig {
     public static boolean TERRAIN_LIGHTING = false;
     /** When >= 0 the sun is placed from the date+hour below instead of azimuth/altitude. */
     public static float SUN_HOUR_UTC = -1f;
-    public static int SUN_YEAR = 2026, SUN_MONTH = 7, SUN_DAY = 26;
+    /** The date the sky is drawn for. TODAY by default, which is what makes the sun, the moon, the
+     *  planets and the stars the ones actually up there. '--es sunYear/sunMonth/sunDay' overrides. */
+    public static int SUN_YEAR = (int) DemoAstro.nowUtc()[0];
+    public static int SUN_MONTH = (int) DemoAstro.nowUtc()[1];
+    public static int SUN_DAY = (int) DemoAstro.nowUtc()[2];
     public static float SUN_AZIMUTH = 355f;
     public static float SUN_ALTITUDE = 9f;
     public static float SUN_INTENSITY = 1.0f;
@@ -255,17 +259,55 @@ public final class DemoConfig {
      *  placed by direction, so they stay in the sky while the map pans under them. The demo
      *  builds them in DemoCelestial - the SDK API knows nothing about suns or moons. */
     /** Free roam: one finger looks around (sideways turns, up/down tilts), two fingers pan, pinch
-     *  zooms. Needed to actually look at the sky; the camera still cannot tilt above the horizon. */
+     *  zooms. Needed to actually look at the sky. */
     public static boolean FREE_ROAM = false;
+    /** How far above the horizon free roam may look, in degrees. This is a NEGATIVE tilt: the
+     *  camera stays put and the view pitches up (Options.setTiltRange). 0 stops at the horizon,
+     *  which is what a map does by default. */
+    public static float LOOK_UP_LIMIT = 90f;
     public static boolean CELESTIAL = true;
     public static boolean CELESTIAL_SUN = true;
     public static boolean CELESTIAL_MOON = true;
     public static boolean CELESTIAL_ARC = true;
+    /** The moon's path across the day, the twin of the sun's. */
+    public static boolean CELESTIAL_MOON_ARC = true;
+    /** Draw the moon with the phase it really has (a bitmap the demo paints), rather than a disc. */
+    public static boolean CELESTIAL_MOON_PHASE = true;
     /** Angular diameters in degrees. The real sun and moon are both about 0.5; larger is easier
      *  to see and to hit on a phone. */
     public static float CELESTIAL_SUN_SIZE = 2.5f;
     public static float CELESTIAL_MOON_SIZE = 2.0f;
     public static float CELESTIAL_ARC_WIDTH = 2.0f;
+
+    // --- stars (DemoStars + DemoStarCatalogue) ----------------------------------------------------
+
+    /** The star layer: the bright-star catalogue, the constellation figures and the planets, all
+     *  placed for the date above. Off by default - it is a second CelestialLayer. */
+    public static boolean STARS = false;
+    public static boolean STARS_STARS = true;
+    public static boolean STARS_FIGURES = true;
+    public static boolean STARS_PLANETS = true;
+    public static boolean STARS_EQUATOR = false;
+    /** A magnitude -1.5 star is this big on screen, and each magnitude takes off that much. The
+     *  sizes are in PIXELS, so they are scaled by the screen density in DemoStars. */
+    public static float STARS_BRIGHTEST_SIZE = 5f;
+    public static float STARS_SIZE_PER_MAGNITUDE = 0.55f;
+    public static float STARS_FAINTEST_SIZE = 1.4f;
+    public static float STARS_FIGURE_WIDTH = 1.5f;
+    public static float STARS_FIGURE_CLICK_RADIUS = 2.5f;
+    public static float STARS_PLANET_SIZE = 1.2f;
+
+    /** Star sky: no map at all - the layers are REMOVED, the terrain is off and the background is
+     *  cleared to transparent, so the only thing drawn is the sky. Fades in and out. */
+    public static boolean STAR_SKY = false;
+    public static float STAR_SKY_FADE_MS = 600f;
+    /** Follow the device's orientation in star sky mode: turning the phone turns the view, and
+     *  raising it looks up. Needs LOOK_UP_LIMIT > 0 to reach the zenith. */
+    public static boolean STAR_SKY_ORIENTATION = false;
+    /** Ask for a TRANSLUCENT GL surface in star sky mode, which is what lets whatever is behind the
+     *  view (a camera preview) show through the transparent clear colour. On its own it looks the
+     *  same - black - and it costs a surface recreation, so it can be turned off. */
+    public static boolean STAR_SKY_TRANSLUCENT = true;
 
     /** Day cycle: sun/moon/stars/clouds shader driven by SUN_HOUR_UTC, updated live by the panel. */
     public static boolean DAY_CYCLE = false;
@@ -562,13 +604,28 @@ public final class DemoConfig {
         TERRAIN_LIGHTING = DemoCfg.cfgBool("terrainLight", TERRAIN_LIGHTING);
         SUN_HOUR_UTC = DemoCfg.cfgFloat("sunHour", SUN_HOUR_UTC);
         FREE_ROAM = DemoCfg.cfgBool("freeRoam", FREE_ROAM);
+        LOOK_UP_LIMIT = DemoCfg.cfgFloat("lookUp", LOOK_UP_LIMIT);
         CELESTIAL = DemoCfg.cfgBool("celestial", CELESTIAL);
         CELESTIAL_SUN = DemoCfg.cfgBool("celestialSun", CELESTIAL_SUN);
         CELESTIAL_MOON = DemoCfg.cfgBool("celestialMoon", CELESTIAL_MOON);
         CELESTIAL_ARC = DemoCfg.cfgBool("celestialArc", CELESTIAL_ARC);
+        CELESTIAL_MOON_ARC = DemoCfg.cfgBool("celestialMoonArc", CELESTIAL_MOON_ARC);
+        CELESTIAL_MOON_PHASE = DemoCfg.cfgBool("celestialMoonPhase", CELESTIAL_MOON_PHASE);
         CELESTIAL_SUN_SIZE = DemoCfg.cfgFloat("celestialSunSize", CELESTIAL_SUN_SIZE);
         CELESTIAL_MOON_SIZE = DemoCfg.cfgFloat("celestialMoonSize", CELESTIAL_MOON_SIZE);
         CELESTIAL_ARC_WIDTH = DemoCfg.cfgFloat("celestialArcWidth", CELESTIAL_ARC_WIDTH);
+        STARS = DemoCfg.cfgBool("stars", STARS);
+        STARS_STARS = DemoCfg.cfgBool("starsStars", STARS_STARS);
+        STARS_FIGURES = DemoCfg.cfgBool("starsFigures", STARS_FIGURES);
+        STARS_PLANETS = DemoCfg.cfgBool("starsPlanets", STARS_PLANETS);
+        STARS_EQUATOR = DemoCfg.cfgBool("starsEquator", STARS_EQUATOR);
+        STARS_BRIGHTEST_SIZE = DemoCfg.cfgFloat("starsSize", STARS_BRIGHTEST_SIZE);
+        STARS_FIGURE_WIDTH = DemoCfg.cfgFloat("starsFigureWidth", STARS_FIGURE_WIDTH);
+        STARS_PLANET_SIZE = DemoCfg.cfgFloat("starsPlanetSize", STARS_PLANET_SIZE);
+        STAR_SKY = DemoCfg.cfgBool("starSky", STAR_SKY);
+        STAR_SKY_FADE_MS = DemoCfg.cfgFloat("starSkyFade", STAR_SKY_FADE_MS);
+        STAR_SKY_ORIENTATION = DemoCfg.cfgBool("starSkyOrientation", STAR_SKY_ORIENTATION);
+        STAR_SKY_TRANSLUCENT = DemoCfg.cfgBool("starSkyTranslucent", STAR_SKY_TRANSLUCENT);
         SUN_YEAR = DemoCfg.cfgInt("sunYear", SUN_YEAR);
         SUN_MONTH = DemoCfg.cfgInt("sunMonth", SUN_MONTH);
         SUN_DAY = DemoCfg.cfgInt("sunDay", SUN_DAY);
@@ -661,6 +718,21 @@ public final class DemoConfig {
         ANIM_ROTATION = DemoCfg.cfgFloat("animRotation", ANIM_ROTATION);
         ANIM_ZOOM_OUT = DemoCfg.cfgFloat("animZoomOut", ANIM_ZOOM_OUT);
         ANIM_SETTLE_MS = DemoCfg.cfgFloat("animSettle", ANIM_SETTLE_MS);
+    }
+
+    /**
+     * The UTC hour the sky is drawn for: the explicit sun hour if one is set (the panel's hour
+     * slider writes it), then the day-cycle hour, and otherwise the real clock - so out of the box
+     * the sun, the moon, the planets and the stars are where they are right now.
+     */
+    public static double currentHourUtc() {
+        if (SUN_HOUR_UTC >= 0) {
+            return SUN_HOUR_UTC;
+        }
+        if (DAY_CYCLE) {
+            return DAY_CYCLE_HOUR;
+        }
+        return DemoAstro.nowUtc()[3];
     }
 
     private DemoConfig() {

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -254,6 +254,9 @@ public final class DemoConfig {
     /** Celestial objects: sun, moon and the sun's daily path, drawn by a CelestialLayer and
      *  placed by direction, so they stay in the sky while the map pans under them. The demo
      *  builds them in DemoCelestial - the SDK API knows nothing about suns or moons. */
+    /** Free roam: one finger looks around (sideways turns, up/down tilts), two fingers pan, pinch
+     *  zooms. Needed to actually look at the sky; the camera still cannot tilt above the horizon. */
+    public static boolean FREE_ROAM = false;
     public static boolean CELESTIAL = true;
     public static boolean CELESTIAL_SUN = true;
     public static boolean CELESTIAL_MOON = true;
@@ -558,6 +561,7 @@ public final class DemoConfig {
         // sun / shadows
         TERRAIN_LIGHTING = DemoCfg.cfgBool("terrainLight", TERRAIN_LIGHTING);
         SUN_HOUR_UTC = DemoCfg.cfgFloat("sunHour", SUN_HOUR_UTC);
+        FREE_ROAM = DemoCfg.cfgBool("freeRoam", FREE_ROAM);
         CELESTIAL = DemoCfg.cfgBool("celestial", CELESTIAL);
         CELESTIAL_SUN = DemoCfg.cfgBool("celestialSun", CELESTIAL_SUN);
         CELESTIAL_MOON = DemoCfg.cfgBool("celestialMoon", CELESTIAL_MOON);

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -258,9 +258,14 @@ public final class DemoConfig {
     /** Celestial objects: sun, moon and the sun's daily path, drawn by a CelestialLayer and
      *  placed by direction, so they stay in the sky while the map pans under them. The demo
      *  builds them in DemoCelestial - the SDK API knows nothing about suns or moons. */
-    /** Free roam: one finger looks around (sideways turns, up/down tilts), two fingers pan, pinch
-     *  zooms. Needed to actually look at the sky. */
-    public static boolean FREE_ROAM = false;
+    /** Free roam mode: "off", "look" (one finger looks, two fingers still pan/pinch/rotate the
+     *  map) or "fps" (mouse look - the camera never moves - and two fingers move like the keys
+     *  would, with no pinch and no rotation). '--es freeRoam fps'. */
+    public static String FREE_ROAM_MODE = "off";
+    /** Degrees of turn per inch of drag. */
+    public static float FREE_ROAM_LOOK_SENSITIVITY = 90f;
+    /** How far an inch of two-finger drag moves, as a fraction of the camera to focus distance. */
+    public static float FREE_ROAM_MOVE_SPEED = 0.5f;
     /** How far above the horizon free roam may look, in degrees. This is a NEGATIVE tilt: the
      *  camera stays put and the view pitches up (Options.setTiltRange). 0 stops at the horizon,
      *  which is what a map does by default. */
@@ -606,7 +611,14 @@ public final class DemoConfig {
         // sun / shadows
         TERRAIN_LIGHTING = DemoCfg.cfgBool("terrainLight", TERRAIN_LIGHTING);
         SUN_HOUR_UTC = DemoCfg.cfgFloat("sunHour", SUN_HOUR_UTC);
-        FREE_ROAM = DemoCfg.cfgBool("freeRoam", FREE_ROAM);
+        FREE_ROAM_MODE = DemoCfg.cfgStr("freeRoam", FREE_ROAM_MODE);
+        if ("true".equals(FREE_ROAM_MODE)) {
+            FREE_ROAM_MODE = "look";
+        } else if ("false".equals(FREE_ROAM_MODE)) {
+            FREE_ROAM_MODE = "off";
+        }
+        FREE_ROAM_LOOK_SENSITIVITY = DemoCfg.cfgFloat("lookSensitivity", FREE_ROAM_LOOK_SENSITIVITY);
+        FREE_ROAM_MOVE_SPEED = DemoCfg.cfgFloat("moveSpeed", FREE_ROAM_MOVE_SPEED);
         LOOK_UP_LIMIT = DemoCfg.cfgFloat("lookUp", LOOK_UP_LIMIT);
         CELESTIAL = DemoCfg.cfgBool("celestial", CELESTIAL);
         CELESTIAL_SUN = DemoCfg.cfgBool("celestialSun", CELESTIAL_SUN);

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -304,6 +304,9 @@ public final class DemoConfig {
     /** Follow the device's orientation in star sky mode: turning the phone turns the view, and
      *  raising it looks up. Needs LOOK_UP_LIMIT > 0 to reach the zenith. */
     public static boolean STAR_SKY_ORIENTATION = false;
+    /** Show the live camera BEHIND the transparent map in star sky mode: the sky drawn over what
+     *  the camera sees. Needs the CAMERA permission, and needs STAR_SKY_TRANSLUCENT. */
+    public static boolean STAR_SKY_CAMERA = false;
     /** Ask for a TRANSLUCENT GL surface in star sky mode, which is what lets whatever is behind the
      *  view (a camera preview) show through the transparent clear colour. On its own it looks the
      *  same - black - and it costs a surface recreation, so it can be turned off. */
@@ -626,6 +629,7 @@ public final class DemoConfig {
         STAR_SKY_FADE_MS = DemoCfg.cfgFloat("starSkyFade", STAR_SKY_FADE_MS);
         STAR_SKY_ORIENTATION = DemoCfg.cfgBool("starSkyOrientation", STAR_SKY_ORIENTATION);
         STAR_SKY_TRANSLUCENT = DemoCfg.cfgBool("starSkyTranslucent", STAR_SKY_TRANSLUCENT);
+        STAR_SKY_CAMERA = DemoCfg.cfgBool("starSkyCamera", STAR_SKY_CAMERA);
         SUN_YEAR = DemoCfg.cfgInt("sunYear", SUN_YEAR);
         SUN_MONTH = DemoCfg.cfgInt("sunMonth", SUN_MONTH);
         SUN_DAY = DemoCfg.cfgInt("sunDay", SUN_DAY);

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -262,6 +262,11 @@ public final class DemoConfig {
      *  map) or "fps" (mouse look - the camera never moves - and two fingers move like the keys
      *  would, with no pinch and no rotation). '--es freeRoam fps'. */
     public static String FREE_ROAM_MODE = "off";
+    /** Pan speed on a tilted view: "map" (the point under the finger follows it exactly, so the
+     *  speed changes as the finger moves between near and far parts of the screen), "anchored"
+     *  (the speed a gesture starts with, kept for the whole gesture) or "constant" (always the
+     *  scale at the centre of the screen). '--es panSpeed map|anchored|constant'. */
+    public static String PANNING_SPEED_MODE = "anchored";
     /** Degrees of turn per inch of drag. */
     public static float FREE_ROAM_LOOK_SENSITIVITY = 90f;
     /** How far an inch of two-finger drag moves, as a fraction of the camera to focus distance. */
@@ -301,6 +306,12 @@ public final class DemoConfig {
     public static float STARS_FIGURE_WIDTH = 1.5f;
     public static float STARS_FIGURE_CLICK_RADIUS = 2.5f;
     public static float STARS_PLANET_SIZE = 1.2f;
+    /** Constellation NAMES drawn in the sky, at the middle of each figure. The demo paints them
+     *  into a bitmap, so they are styled entirely by the app. */
+    public static boolean STARS_LABELS = true;
+    public static float STARS_LABEL_TEXT_SIZE = 15f;   // dp of the text inside the bitmap
+    public static float STARS_LABEL_SCALE = 1f;        // 1 = the text at the size it was painted
+    public static float STARS_LABEL_OPACITY = 0.85f;
 
     /** Star sky: no map at all - the layers are REMOVED, the terrain is off and the background is
      *  cleared to transparent, so the only thing drawn is the sky. Fades in and out. */
@@ -617,6 +628,7 @@ public final class DemoConfig {
         } else if ("false".equals(FREE_ROAM_MODE)) {
             FREE_ROAM_MODE = "off";
         }
+        PANNING_SPEED_MODE = DemoCfg.cfgStr("panSpeed", PANNING_SPEED_MODE);
         FREE_ROAM_LOOK_SENSITIVITY = DemoCfg.cfgFloat("lookSensitivity", FREE_ROAM_LOOK_SENSITIVITY);
         FREE_ROAM_MOVE_SPEED = DemoCfg.cfgFloat("moveSpeed", FREE_ROAM_MOVE_SPEED);
         LOOK_UP_LIMIT = DemoCfg.cfgFloat("lookUp", LOOK_UP_LIMIT);
@@ -637,6 +649,8 @@ public final class DemoConfig {
         STARS_BRIGHTEST_SIZE = DemoCfg.cfgFloat("starsSize", STARS_BRIGHTEST_SIZE);
         STARS_FIGURE_WIDTH = DemoCfg.cfgFloat("starsFigureWidth", STARS_FIGURE_WIDTH);
         STARS_PLANET_SIZE = DemoCfg.cfgFloat("starsPlanetSize", STARS_PLANET_SIZE);
+        STARS_LABELS = DemoCfg.cfgBool("starsLabels", STARS_LABELS);
+        STARS_LABEL_SCALE = DemoCfg.cfgFloat("starsLabelScale", STARS_LABEL_SCALE);
         STAR_SKY = DemoCfg.cfgBool("starSky", STAR_SKY);
         STAR_SKY_FADE_MS = DemoCfg.cfgFloat("starSkyFade", STAR_SKY_FADE_MS);
         STAR_SKY_ORIENTATION = DemoCfg.cfgBool("starSkyOrientation", STAR_SKY_ORIENTATION);

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -251,6 +251,19 @@ public final class DemoConfig {
     // =============================================================================================
 
     public static boolean SKY_ENABLED = true;
+    /** Celestial objects: sun, moon and the sun's daily path, drawn by a CelestialLayer and
+     *  placed by direction, so they stay in the sky while the map pans under them. The demo
+     *  builds them in DemoCelestial - the SDK API knows nothing about suns or moons. */
+    public static boolean CELESTIAL = true;
+    public static boolean CELESTIAL_SUN = true;
+    public static boolean CELESTIAL_MOON = true;
+    public static boolean CELESTIAL_ARC = true;
+    /** Angular diameters in degrees. The real sun and moon are both about 0.5; larger is easier
+     *  to see and to hit on a phone. */
+    public static float CELESTIAL_SUN_SIZE = 2.5f;
+    public static float CELESTIAL_MOON_SIZE = 2.0f;
+    public static float CELESTIAL_ARC_WIDTH = 2.0f;
+
     /** Day cycle: sun/moon/stars/clouds shader driven by SUN_HOUR_UTC, updated live by the panel. */
     public static boolean DAY_CYCLE = false;
     public static float DAY_CYCLE_HOUR = 12f;
@@ -545,6 +558,13 @@ public final class DemoConfig {
         // sun / shadows
         TERRAIN_LIGHTING = DemoCfg.cfgBool("terrainLight", TERRAIN_LIGHTING);
         SUN_HOUR_UTC = DemoCfg.cfgFloat("sunHour", SUN_HOUR_UTC);
+        CELESTIAL = DemoCfg.cfgBool("celestial", CELESTIAL);
+        CELESTIAL_SUN = DemoCfg.cfgBool("celestialSun", CELESTIAL_SUN);
+        CELESTIAL_MOON = DemoCfg.cfgBool("celestialMoon", CELESTIAL_MOON);
+        CELESTIAL_ARC = DemoCfg.cfgBool("celestialArc", CELESTIAL_ARC);
+        CELESTIAL_SUN_SIZE = DemoCfg.cfgFloat("celestialSunSize", CELESTIAL_SUN_SIZE);
+        CELESTIAL_MOON_SIZE = DemoCfg.cfgFloat("celestialMoonSize", CELESTIAL_MOON_SIZE);
+        CELESTIAL_ARC_WIDTH = DemoCfg.cfgFloat("celestialArcWidth", CELESTIAL_ARC_WIDTH);
         SUN_YEAR = DemoCfg.cfgInt("sunYear", SUN_YEAR);
         SUN_MONTH = DemoCfg.cfgInt("sunMonth", SUN_MONTH);
         SUN_DAY = DemoCfg.cfgInt("sunDay", SUN_DAY);

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -807,6 +807,7 @@ public class DemoMap {
         Projection proj = mapView.getOptions().getBaseProjection();
         mapView.setFocusPos(proj.fromWgs84(new MapPos(DemoConfig.START_LON, DemoConfig.START_LAT)), 0);
         mapView.setZoom(DemoConfig.START_ZOOM, 0);
+        mapView.getOptions().setFreeRoam(DemoConfig.FREE_ROAM);
         mapView.setTilt(DemoConfig.START_TILT, 0);
         mapView.setMapRotation(DemoConfig.START_ROTATION, 0);
     }

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -848,8 +848,22 @@ public class DemoMap {
      * by default (tilt range 0..90), which is why this has to be asked for.
      */
     public void applyLookRange() {
-        mapView.getOptions().setFreeRoam(DemoConfig.FREE_ROAM);
-        mapView.getOptions().setTiltRange(new com.carto.core.MapRange(-Math.max(0f, DemoConfig.LOOK_UP_LIMIT), 90f));
+        Options options = mapView.getOptions();
+        options.setFreeRoamMode(freeRoamMode(DemoConfig.FREE_ROAM_MODE));
+        options.setFreeRoamLookSensitivity(DemoConfig.FREE_ROAM_LOOK_SENSITIVITY);
+        options.setFreeRoamMoveSpeed(DemoConfig.FREE_ROAM_MOVE_SPEED);
+        options.setTiltRange(new com.carto.core.MapRange(-Math.max(0f, DemoConfig.LOOK_UP_LIMIT), 90f));
+    }
+
+    /** "off" / "look" / "fps" -> the SDK enum. */
+    public static com.carto.components.FreeRoamMode freeRoamMode(String name) {
+        if ("look".equals(name)) {
+            return com.carto.components.FreeRoamMode.FREE_ROAM_MODE_LOOK;
+        }
+        if ("fps".equals(name)) {
+            return com.carto.components.FreeRoamMode.FREE_ROAM_MODE_FIRST_PERSON;
+        }
+        return com.carto.components.FreeRoamMode.FREE_ROAM_MODE_OFF;
     }
 
     // =============================================================================================

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -850,9 +850,21 @@ public class DemoMap {
     public void applyLookRange() {
         Options options = mapView.getOptions();
         options.setFreeRoamMode(freeRoamMode(DemoConfig.FREE_ROAM_MODE));
+        options.setPanningSpeedMode(panningSpeedMode(DemoConfig.PANNING_SPEED_MODE));
         options.setFreeRoamLookSensitivity(DemoConfig.FREE_ROAM_LOOK_SENSITIVITY);
         options.setFreeRoamMoveSpeed(DemoConfig.FREE_ROAM_MOVE_SPEED);
         options.setTiltRange(new com.carto.core.MapRange(-Math.max(0f, DemoConfig.LOOK_UP_LIMIT), 90f));
+    }
+
+    /** "map" / "anchored" / "constant" -> the SDK enum. */
+    public static com.carto.components.PanningSpeedMode panningSpeedMode(String name) {
+        if ("map".equals(name)) {
+            return com.carto.components.PanningSpeedMode.PANNING_SPEED_MODE_MAP;
+        }
+        if ("constant".equals(name)) {
+            return com.carto.components.PanningSpeedMode.PANNING_SPEED_MODE_CONSTANT;
+        }
+        return com.carto.components.PanningSpeedMode.PANNING_SPEED_MODE_ANCHORED;
     }
 
     /** "off" / "look" / "fps" -> the SDK enum. */

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -100,6 +100,8 @@ public class DemoMap {
     public final DemoStars stars = new DemoStars();
     /** Device orientation driving the camera, for the star sky mode. */
     private DemoOrientation orientation;
+    /** Live camera preview behind the transparent map, for the star sky mode. */
+    private DemoCameraPreview cameraPreview;
 
     private final Context context;
     public final MapView mapView;
@@ -914,6 +916,7 @@ public class DemoMap {
             skyOptions.setEnabled(false);
         }
         setSurfaceTranslucent(DemoConfig.STAR_SKY_TRANSLUCENT);
+        setCameraPreviewEnabled(DemoConfig.STAR_SKY_CAMERA);
         rebuildLayers();
         Log.i(TAG, "star sky on: " + mapView.getLayers().count() + " layers, clear "
                 + options.getClearColor().getARGB() + ", background " + options.getBackgroundBitmap());
@@ -925,6 +928,7 @@ public class DemoMap {
 
     private void leaveStarSky() {
         setOrientationFollowing(false);
+        setCameraPreviewEnabled(false);
         DemoConfig.STAR_SKY = false;
         Options options = mapView.getOptions();
         if (starSkySaved) {
@@ -961,17 +965,42 @@ public class DemoMap {
     }
 
     /**
+     * The live camera behind the map: what the transparent clear colour is FOR. Only meaningful
+     * with a translucent surface, and only in star sky mode - there is nothing to see through
+     * otherwise.
+     */
+    public void setCameraPreviewEnabled(boolean enabled) {
+        DemoConfig.STAR_SKY_CAMERA = enabled;
+        if (enabled) {
+            if (!(mapView.getParent() instanceof androidx.constraintlayout.widget.ConstraintLayout)) {
+                Log.w(TAG, "the map is not in a ConstraintLayout: no place to put the preview");
+                return;
+            }
+            if (cameraPreview == null) {
+                cameraPreview = new DemoCameraPreview(context, (androidx.constraintlayout.widget.ConstraintLayout) mapView.getParent());
+            }
+            cameraPreview.start();
+        } else if (cameraPreview != null) {
+            cameraPreview.stop();
+        }
+    }
+
+    /**
      * A translucent GL surface, which is what makes a transparent clear colour visible: the map is
      * then composited over whatever is behind it (with setZOrderMediaOverlay, a camera preview).
      * Without this the transparency is real but the surface is still opaque, so it just looks black.
      */
-    private void setSurfaceTranslucent(boolean translucent) {
-        try {
-            mapView.setZOrderMediaOverlay(translucent);
-            mapView.getHolder().setFormat(translucent ? android.graphics.PixelFormat.TRANSLUCENT : android.graphics.PixelFormat.OPAQUE);
-        } catch (Exception e) {
-            Log.w(TAG, "could not change the surface format: " + e);
-        }
+    private void setSurfaceTranslucent(final boolean translucent) {
+        // Touches the view, and the demo builds on a worker thread.
+        mapView.post(new Runnable() {
+            public void run() {
+                try {
+                    mapView.setTranslucent(translucent);
+                } catch (Exception e) {
+                    Log.w(TAG, "could not change the surface format: " + e);
+                }
+            }
+        });
     }
 
     /** Opacity of every layer that is NOT the sky. */

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -82,20 +82,24 @@ public class DemoMap {
 
     /** One switchable layer of the demo. */
     public enum Feature {
-        CELESTIAL, BASE, SATELLITE, HILLSHADE, HYPSO, CONTOUR, CONTOUR_TILES, ROUTES, ROUTE_TEST, ELEMENTS
+        CELESTIAL, STARS, BASE, SATELLITE, HILLSHADE, HYPSO, CONTOUR, CONTOUR_TILES, ROUTES, ROUTE_TEST, ELEMENTS
     }
 
     /** Bottom -> top draw order. Toggling a layer never reorders the others. */
     private static final Feature[] LAYER_ORDER = {
         // The sky goes FIRST, so the map and the terrain draw over it and a ridge hides what is
         // behind it - which is what a body in the sky should do.
-        Feature.CELESTIAL,
+        Feature.CELESTIAL, Feature.STARS,
         Feature.BASE, Feature.SATELLITE, Feature.HILLSHADE, Feature.HYPSO,
         Feature.CONTOUR, Feature.CONTOUR_TILES, Feature.ROUTES, Feature.ROUTE_TEST, Feature.ELEMENTS
     };
 
-    /** Sun, moon and the sun's daily path - demo content built on the generic celestial API. */
+    /** Sun, moon and their daily paths - demo content built on the generic celestial API. */
     public final DemoCelestial celestial = new DemoCelestial();
+    /** The bright-star catalogue, the constellation figures and the planets - same API. */
+    public final DemoStars stars = new DemoStars();
+    /** Device orientation driving the camera, for the star sky mode. */
+    private DemoOrientation orientation;
 
     private final Context context;
     public final MapView mapView;
@@ -159,6 +163,11 @@ public class DemoMap {
         if (DemoConfig.DAY_CYCLE) {
             applyDayCycle(DemoConfig.DAY_CYCLE_HOUR);
         }
+        if (DemoConfig.STAR_SKY) {
+            // Already built without the map layers (isEnabled), so there is nothing to fade out.
+            saveMapAppearance();
+            enterStarSky();
+        }
         startScriptedAnimation();
     }
 
@@ -168,8 +177,14 @@ public class DemoMap {
 
     /** True if the feature is currently switched on in the config. */
     public boolean isEnabled(Feature feature) {
+        // Star sky mode: every map layer is left OUT of the layer list rather than hidden, so no
+        // tile is fetched, decoded or drawn - the mode costs what an empty map costs.
+        if (DemoConfig.STAR_SKY && feature != Feature.CELESTIAL && feature != Feature.STARS) {
+            return false;
+        }
         switch (feature) {
             case CELESTIAL: return DemoConfig.CELESTIAL;
+            case STARS: return DemoConfig.STARS;
             case BASE: return DemoConfig.LAYER_BASE;
             case SATELLITE: return DemoConfig.LAYER_SATELLITE;
             case HILLSHADE: return DemoConfig.LAYER_HILLSHADE;
@@ -185,6 +200,8 @@ public class DemoMap {
 
     public void setEnabled(Feature feature, boolean enabled) {
         switch (feature) {
+            case CELESTIAL: DemoConfig.CELESTIAL = enabled; break;
+            case STARS: DemoConfig.STARS = enabled; break;
             case BASE: DemoConfig.LAYER_BASE = enabled; break;
             case SATELLITE: DemoConfig.LAYER_SATELLITE = enabled; break;
             case HILLSHADE: DemoConfig.LAYER_HILLSHADE = enabled; break;
@@ -225,15 +242,24 @@ public class DemoMap {
             vector.add(layer);
         }
         mapView.getLayers().setAll(vector);
-        // The celestial objects are built with the layer, which happens here - after
-        // applyLightOptions has run - so place them now that they exist.
-        celestial.update(this);
+        // The sky objects are built with their layer, which happens here, so place them now that
+        // they exist.
+        updateSky();
+        mapView.requestRender();
+    }
+
+    /** Puts every sky object where it really is for the configured date, hour and position. */
+    public void updateSky() {
+        celestial.update();
+        double n = DemoAstro.daysSinceJ2000(DemoConfig.SUN_YEAR, DemoConfig.SUN_MONTH, DemoConfig.SUN_DAY, DemoConfig.currentHourUtc());
+        stars.update(n, DemoConfig.START_LAT, DemoConfig.START_LON);
         mapView.requestRender();
     }
 
     private Layer createLayer(Feature feature) {
         switch (feature) {
             case CELESTIAL: return celestial.createLayer(mapView);
+            case STARS: return stars.createLayer(mapView);
             case BASE: return createBaseLayer();
             case SATELLITE: return new RasterTileLayer(rasterSource());
             case HILLSHADE: return createHillshadeLayer();
@@ -758,8 +784,7 @@ public class DemoMap {
         lightOptions.setShadowBias(DemoConfig.SHADOW_BIAS);
         lightOptions.setShadowDistance(DemoConfig.SHADOW_DISTANCE);
         lightOptions.setShadowCasterMargin(DemoConfig.SHADOW_CASTER_MARGIN);
-        celestial.update(this);
-        mapView.requestRender();
+        updateSky();
     }
 
     /** The sky is always attached so the panel can toggle it live; disabled = no sky at all. */
@@ -782,6 +807,7 @@ public class DemoMap {
      */
     public void applyDayCycle(float hourUtc) {
         DemoConfig.DAY_CYCLE_HOUR = hourUtc;
+        updateSky(); // the hour is also what places the sun, the moon and the stars
         if (!DemoConfig.DAY_CYCLE) {
             if (skyOptions != null) {
                 skyOptions.setShaderSource("");
@@ -807,9 +833,180 @@ public class DemoMap {
         Projection proj = mapView.getOptions().getBaseProjection();
         mapView.setFocusPos(proj.fromWgs84(new MapPos(DemoConfig.START_LON, DemoConfig.START_LAT)), 0);
         mapView.setZoom(DemoConfig.START_ZOOM, 0);
-        mapView.getOptions().setFreeRoam(DemoConfig.FREE_ROAM);
+        applyLookRange();
         mapView.setTilt(DemoConfig.START_TILT, 0);
         mapView.setMapRotation(DemoConfig.START_ROTATION, 0);
+    }
+
+    /**
+     * Free roam and how far above the horizon the view may look.
+     *
+     * A NEGATIVE tilt is the look up: the camera stays where the tilt geometry put it and only the
+     * view pitches, so nothing about zoom or the visible tiles changes. A map stops at the horizon
+     * by default (tilt range 0..90), which is why this has to be asked for.
+     */
+    public void applyLookRange() {
+        mapView.getOptions().setFreeRoam(DemoConfig.FREE_ROAM);
+        mapView.getOptions().setTiltRange(new com.carto.core.MapRange(-Math.max(0f, DemoConfig.LOOK_UP_LIMIT), 90f));
+    }
+
+    // =============================================================================================
+    // STAR SKY: the map removed, the background cleared to nothing, only the sky left
+    // =============================================================================================
+
+    private Color savedClearColor;
+    private Color savedSkyColor;
+    private com.carto.graphics.Bitmap savedBackgroundBitmap;
+    private boolean starSkySaved;
+
+    /**
+     * Switches the whole map off and leaves the sky.
+     *
+     * "Not drawn" here means NOT BUILT: the map layers leave the layer list (see isEnabled), the
+     * terrain is disabled and the background is cleared to a fully transparent black, so the frame
+     * costs an empty map plus the sky objects. The transparency is the point - with a translucent
+     * surface, whatever is behind the view (a camera preview) shows through it.
+     *
+     * The map fades out before it is dropped and fades back in after it returns, so the switch is
+     * not a pop.
+     */
+    public void applyStarSky(final boolean enabled) {
+        if (enabled == DemoConfig.STAR_SKY && starSkySaved == enabled) {
+            return;
+        }
+        long duration = (long) Math.max(0f, DemoConfig.STAR_SKY_FADE_MS);
+        if (enabled) {
+            saveMapAppearance();
+            fadeMapLayers(1f, 0f, duration, new Runnable() {
+                public void run() {
+                    enterStarSky();
+                }
+            });
+        } else {
+            leaveStarSky();
+            fadeMapLayers(0f, 1f, duration, null);
+        }
+    }
+
+    private void saveMapAppearance() {
+        if (starSkySaved) {
+            return;
+        }
+        Options options = mapView.getOptions();
+        savedClearColor = options.getClearColor();
+        savedSkyColor = options.getSkyColor();
+        savedBackgroundBitmap = options.getBackgroundBitmap();
+        starSkySaved = true;
+    }
+
+    private void enterStarSky() {
+        DemoConfig.STAR_SKY = true;
+        Options options = mapView.getOptions();
+        // Transparent, not black: the frame is then a hole that whatever is behind the surface
+        // shows through, and it looks black on its own anyway.
+        options.setClearColor(new Color((short) 0, (short) 0, (short) 0, (short) 0));
+        options.setSkyColor(new Color((short) 0, (short) 0, (short) 0, (short) 0));
+        options.setBackgroundBitmap(null);
+        if (terrainOptions != null) {
+            terrainOptions.setEnabled(false);
+        }
+        if (skyOptions != null) {
+            skyOptions.setEnabled(false);
+        }
+        setSurfaceTranslucent(DemoConfig.STAR_SKY_TRANSLUCENT);
+        rebuildLayers();
+        Log.i(TAG, "star sky on: " + mapView.getLayers().count() + " layers, clear "
+                + options.getClearColor().getARGB() + ", background " + options.getBackgroundBitmap());
+        setMapLayerOpacity(1f); // the layers are out of the list now: leave them ready to come back
+        applyLookRange();
+        setOrientationFollowing(DemoConfig.STAR_SKY_ORIENTATION);
+        mapView.requestRender();
+    }
+
+    private void leaveStarSky() {
+        setOrientationFollowing(false);
+        DemoConfig.STAR_SKY = false;
+        Options options = mapView.getOptions();
+        if (starSkySaved) {
+            options.setClearColor(savedClearColor);
+            options.setSkyColor(savedSkyColor);
+            options.setBackgroundBitmap(savedBackgroundBitmap);
+            starSkySaved = false;
+        }
+        if (terrainOptions != null) {
+            terrainOptions.setEnabled(DemoConfig.TERRAIN_ENABLED);
+        }
+        if (skyOptions != null) {
+            skyOptions.setEnabled(DemoConfig.SKY_ENABLED);
+        }
+        if (DemoConfig.STAR_SKY_TRANSLUCENT) {
+            setSurfaceTranslucent(false);
+        }
+        setMapLayerOpacity(0f);
+        rebuildLayers();
+        mapView.requestRender();
+    }
+
+    /** Turning the device turns the view, raising it looks up - the negative tilt in action. */
+    public void setOrientationFollowing(boolean enabled) {
+        DemoConfig.STAR_SKY_ORIENTATION = enabled;
+        if (enabled) {
+            if (orientation == null) {
+                orientation = new DemoOrientation(context, mapView);
+            }
+            orientation.start();
+        } else if (orientation != null) {
+            orientation.stop();
+        }
+    }
+
+    /**
+     * A translucent GL surface, which is what makes a transparent clear colour visible: the map is
+     * then composited over whatever is behind it (with setZOrderMediaOverlay, a camera preview).
+     * Without this the transparency is real but the surface is still opaque, so it just looks black.
+     */
+    private void setSurfaceTranslucent(boolean translucent) {
+        try {
+            mapView.setZOrderMediaOverlay(translucent);
+            mapView.getHolder().setFormat(translucent ? android.graphics.PixelFormat.TRANSLUCENT : android.graphics.PixelFormat.OPAQUE);
+        } catch (Exception e) {
+            Log.w(TAG, "could not change the surface format: " + e);
+        }
+    }
+
+    /** Opacity of every layer that is NOT the sky. */
+    private void setMapLayerOpacity(float opacity) {
+        for (Map.Entry<Feature, Layer> entry : layers.entrySet()) {
+            if (entry.getKey() != Feature.CELESTIAL && entry.getKey() != Feature.STARS) {
+                entry.getValue().setOpacity(opacity);
+            }
+        }
+        mapView.requestRender();
+    }
+
+    private void fadeMapLayers(final float from, final float to, long durationMs, final Runnable onEnd) {
+        if (durationMs <= 0) {
+            setMapLayerOpacity(to);
+            if (onEnd != null) {
+                onEnd.run();
+            }
+            return;
+        }
+        android.animation.ValueAnimator animator = android.animation.ValueAnimator.ofFloat(from, to);
+        animator.setDuration(durationMs);
+        animator.addUpdateListener(new android.animation.ValueAnimator.AnimatorUpdateListener() {
+            public void onAnimationUpdate(android.animation.ValueAnimator a) {
+                setMapLayerOpacity(((Float) a.getAnimatedValue()).floatValue());
+            }
+        });
+        if (onEnd != null) {
+            animator.addListener(new android.animation.AnimatorListenerAdapter() {
+                public void onAnimationEnd(android.animation.Animator a) {
+                    onEnd.run();
+                }
+            });
+        }
+        animator.start();
     }
 
     /**

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -82,14 +82,20 @@ public class DemoMap {
 
     /** One switchable layer of the demo. */
     public enum Feature {
-        BASE, SATELLITE, HILLSHADE, HYPSO, CONTOUR, CONTOUR_TILES, ROUTES, ROUTE_TEST, ELEMENTS
+        CELESTIAL, BASE, SATELLITE, HILLSHADE, HYPSO, CONTOUR, CONTOUR_TILES, ROUTES, ROUTE_TEST, ELEMENTS
     }
 
     /** Bottom -> top draw order. Toggling a layer never reorders the others. */
     private static final Feature[] LAYER_ORDER = {
+        // The sky goes FIRST, so the map and the terrain draw over it and a ridge hides what is
+        // behind it - which is what a body in the sky should do.
+        Feature.CELESTIAL,
         Feature.BASE, Feature.SATELLITE, Feature.HILLSHADE, Feature.HYPSO,
         Feature.CONTOUR, Feature.CONTOUR_TILES, Feature.ROUTES, Feature.ROUTE_TEST, Feature.ELEMENTS
     };
+
+    /** Sun, moon and the sun's daily path - demo content built on the generic celestial API. */
+    public final DemoCelestial celestial = new DemoCelestial();
 
     private final Context context;
     public final MapView mapView;
@@ -163,6 +169,7 @@ public class DemoMap {
     /** True if the feature is currently switched on in the config. */
     public boolean isEnabled(Feature feature) {
         switch (feature) {
+            case CELESTIAL: return DemoConfig.CELESTIAL;
             case BASE: return DemoConfig.LAYER_BASE;
             case SATELLITE: return DemoConfig.LAYER_SATELLITE;
             case HILLSHADE: return DemoConfig.LAYER_HILLSHADE;
@@ -218,11 +225,15 @@ public class DemoMap {
             vector.add(layer);
         }
         mapView.getLayers().setAll(vector);
+        // The celestial objects are built with the layer, which happens here - after
+        // applyLightOptions has run - so place them now that they exist.
+        celestial.update(this);
         mapView.requestRender();
     }
 
     private Layer createLayer(Feature feature) {
         switch (feature) {
+            case CELESTIAL: return celestial.createLayer(mapView);
             case BASE: return createBaseLayer();
             case SATELLITE: return new RasterTileLayer(rasterSource());
             case HILLSHADE: return createHillshadeLayer();
@@ -747,6 +758,7 @@ public class DemoMap {
         lightOptions.setShadowBias(DemoConfig.SHADOW_BIAS);
         lightOptions.setShadowDistance(DemoConfig.SHADOW_DISTANCE);
         lightOptions.setShadowCasterMargin(DemoConfig.SHADOW_CASTER_MARGIN);
+        celestial.update(this);
         mapView.requestRender();
     }
 

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoOrientation.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoOrientation.java
@@ -1,0 +1,113 @@
+package com.akylas.cartotest.demo;
+
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+import android.util.Log;
+
+import com.carto.ui.MapView;
+
+/**
+ * Points the camera where the device points: turning the phone turns the view, raising it looks up.
+ *
+ * This is the star-sky demo's reason for a negative tilt. The map's rotation is the opposite of the
+ * heading (rotating the map right turns the view left), and the elevation above the horizon IS the
+ * negative tilt the SDK now supports - at tilt -90 the view looks straight at the zenith.
+ *
+ * A rotation-vector sensor is fused and already smooth; the extra low pass here only takes the last
+ * of the jitter out, and an update below the threshold is dropped so a still phone does not
+ * re-render for ever.
+ */
+public final class DemoOrientation implements SensorEventListener {
+
+    private static final String TAG = "DemoOrientation";
+    /** Smoothing of the fused reading: 1 = raw, smaller = calmer and laggier. */
+    private static final float SMOOTHING = 0.2f;
+    /** Below this much movement, in degrees, the camera is left alone. */
+    private static final float DEAD_ZONE_DEGREES = 0.3f;
+
+    private final Context context;
+    private final MapView mapView;
+    private final float[] rotationMatrix = new float[9];
+    private final float[] remapped = new float[9];
+    private final float[] orientation = new float[3];
+
+    private SensorManager sensorManager;
+    private boolean running;
+    private boolean primed;
+    private float heading;
+    private float elevation;
+
+    public DemoOrientation(Context context, MapView mapView) {
+        this.context = context;
+        this.mapView = mapView;
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public void start() {
+        if (running) {
+            return;
+        }
+        sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+        Sensor sensor = sensorManager != null ? sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR) : null;
+        if (sensor == null) {
+            Log.w(TAG, "no rotation vector sensor: orientation following is not available");
+            return;
+        }
+        sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_GAME);
+        running = true;
+        primed = false;
+    }
+
+    public void stop() {
+        if (!running) {
+            return;
+        }
+        sensorManager.unregisterListener(this);
+        running = false;
+    }
+
+    @Override
+    public void onSensorChanged(SensorEvent event) {
+        SensorManager.getRotationMatrixFromVector(rotationMatrix, event.values);
+        // The phone is held up like a window on the sky, so the axis pointing OUT of the back of
+        // the device is what aims the camera: remapping X/Z gives an orientation whose pitch is
+        // measured from the horizon, 0 looking level and -90 looking at the zenith.
+        SensorManager.remapCoordinateSystem(rotationMatrix, SensorManager.AXIS_X, SensorManager.AXIS_Z, remapped);
+        SensorManager.getOrientation(remapped, orientation);
+
+        float newHeading = (float) Math.toDegrees(orientation[0]);
+        // pitch: 0 level, negative looking up. A negative map tilt is exactly the same thing.
+        float newElevation = (float) Math.toDegrees(orientation[1]);
+
+        if (!primed) {
+            heading = newHeading;
+            elevation = newElevation;
+            primed = true;
+        } else {
+            // Headings wrap: smooth the SHORTEST way round, or crossing north swings the view
+            // through a full turn.
+            float delta = ((newHeading - heading + 540f) % 360f) - 180f;
+            heading += SMOOTHING * delta;
+            elevation += SMOOTHING * (newElevation - elevation);
+        }
+
+        float tilt = Math.max(-DemoConfig.LOOK_UP_LIMIT, Math.min(90f, elevation));
+        float rotation = -heading;
+        if (Math.abs(tilt - mapView.getTilt()) < DEAD_ZONE_DEGREES
+                && Math.abs(((rotation - mapView.getMapRotation() + 540f) % 360f) - 180f) < DEAD_ZONE_DEGREES) {
+            return;
+        }
+        mapView.setTilt(tilt, 0);
+        mapView.setMapRotation(rotation, 0);
+    }
+
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {
+    }
+}

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
@@ -447,6 +447,10 @@ public final class DemoPanel {
         check(context, panel, "follow device orientation", DemoConfig.STAR_SKY_ORIENTATION, new BoolSetting() {
             public void set(boolean value) { demo.setOrientationFollowing(value); }
         });
+        // The camera preview goes BEHIND the transparent map: the sky over what the camera sees.
+        check(context, panel, "camera behind (AR sky)", DemoConfig.STAR_SKY_CAMERA, new BoolSetting() {
+            public void set(boolean value) { demo.setCameraPreviewEnabled(value); }
+        });
     }
 
     private static void buildSkyFogSection(Context context, LinearLayout panel, final DemoMap demo) {

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
@@ -70,6 +70,7 @@ public final class DemoPanel {
         buildContourSection(context, panel, demo);
         buildRouteTestSection(context, panel, demo);
         buildSunSection(context, panel, demo);
+        buildCelestialSection(context, panel, demo);
         buildSkyFogSection(context, panel, demo);
         buildDebugSection(context, panel, demo);
         buildActionsSection(context, panel, demo);
@@ -345,7 +346,7 @@ public final class DemoPanel {
                     demo.applyDayCycle(value);
                 } else {
                     DemoConfig.SUN_HOUR_UTC = value;
-                    demo.applyLightOptions();
+                    demo.applyLightOptions(); // which also re-places the sky objects for that hour
                 }
             }
         });
@@ -387,6 +388,64 @@ public final class DemoPanel {
         });
         slider(context, panel, "depth bias (m)", 0f, 5f, DemoConfig.SHADOW_BIAS, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SHADOW_BIAS = value; demo.lightOptions.setShadowBias(value); }
+        });
+    }
+
+    /**
+     * Everything placed in the SKY, and the camera control that makes it reachable.
+     *
+     * The two layers are ordinary layers (LAYERS > celestial / stars); what is here is the demo
+     * content inside them, and the look-around mode - one finger looks instead of panning, and the
+     * tilt may go NEGATIVE, which is the view pitching above the horizon.
+     */
+    private static void buildCelestialSection(Context context, LinearLayout panel, final DemoMap demo) {
+        header(context, panel, "SKY OBJECTS");
+        check(context, panel, "free roam (1 finger looks)", DemoConfig.FREE_ROAM, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.FREE_ROAM = value; demo.applyLookRange(); }
+        });
+        // 0 stops at the horizon, which is what a map does; 90 reaches the zenith.
+        slider(context, panel, "look above horizon (deg)", 0, 90, DemoConfig.LOOK_UP_LIMIT, true, new FloatSetting() {
+            public void set(float value) { DemoConfig.LOOK_UP_LIMIT = value; demo.applyLookRange(); }
+        });
+
+        check(context, panel, "sun", DemoConfig.CELESTIAL_SUN, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.CELESTIAL_SUN = value; demo.updateSky(); }
+        });
+        check(context, panel, "moon", DemoConfig.CELESTIAL_MOON, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.CELESTIAL_MOON = value; demo.updateSky(); }
+        });
+        check(context, panel, "moon phase", DemoConfig.CELESTIAL_MOON_PHASE, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.CELESTIAL_MOON_PHASE = value; demo.updateSky(); }
+        });
+        check(context, panel, "sun path today", DemoConfig.CELESTIAL_ARC, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.CELESTIAL_ARC = value; demo.updateSky(); }
+        });
+        check(context, panel, "moon path today", DemoConfig.CELESTIAL_MOON_ARC, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.CELESTIAL_MOON_ARC = value; demo.updateSky(); }
+        });
+
+        header(context, panel, "STARS");
+        check(context, panel, "star layer", DemoConfig.STARS, new BoolSetting() {
+            public void set(boolean value) { demo.setEnabled(DemoMap.Feature.STARS, value); }
+        });
+        check(context, panel, "stars", DemoConfig.STARS_STARS, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.STARS_STARS = value; demo.updateSky(); }
+        });
+        check(context, panel, "constellations", DemoConfig.STARS_FIGURES, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.STARS_FIGURES = value; demo.updateSky(); }
+        });
+        check(context, panel, "planets", DemoConfig.STARS_PLANETS, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.STARS_PLANETS = value; demo.updateSky(); }
+        });
+        check(context, panel, "celestial equator", DemoConfig.STARS_EQUATOR, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.STARS_EQUATOR = value; demo.updateSky(); }
+        });
+        // No map at all: the layers leave the layer list, so this costs an empty map.
+        check(context, panel, "star sky (no map, transparent)", DemoConfig.STAR_SKY, new BoolSetting() {
+            public void set(boolean value) { demo.applyStarSky(value); }
+        });
+        check(context, panel, "follow device orientation", DemoConfig.STAR_SKY_ORIENTATION, new BoolSetting() {
+            public void set(boolean value) { demo.setOrientationFollowing(value); }
         });
     }
 

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
@@ -400,8 +400,22 @@ public final class DemoPanel {
      */
     private static void buildCelestialSection(Context context, LinearLayout panel, final DemoMap demo) {
         header(context, panel, "SKY OBJECTS");
-        check(context, panel, "free roam (1 finger looks)", DemoConfig.FREE_ROAM, new BoolSetting() {
-            public void set(boolean value) { DemoConfig.FREE_ROAM = value; demo.applyLookRange(); }
+        // off = the map gestures; look = one finger looks; fps = mouse look + two-finger move.
+        final String[] roamModes = { "off", "look", "fps" };
+        int currentRoam = 0;
+        for (int i = 0; i < roamModes.length; i++) {
+            if (roamModes[i].equals(DemoConfig.FREE_ROAM_MODE)) {
+                currentRoam = i;
+            }
+        }
+        choice(context, panel, "free roam", roamModes, currentRoam, new IntSetting() {
+            public void set(int index) { DemoConfig.FREE_ROAM_MODE = roamModes[index]; demo.applyLookRange(); }
+        });
+        slider(context, panel, "look sensitivity (deg/inch)", 20, 200, DemoConfig.FREE_ROAM_LOOK_SENSITIVITY, false, new FloatSetting() {
+            public void set(float value) { DemoConfig.FREE_ROAM_LOOK_SENSITIVITY = value; demo.applyLookRange(); }
+        });
+        slider(context, panel, "move speed (x distance/inch)", 0.05f, 2f, DemoConfig.FREE_ROAM_MOVE_SPEED, false, new FloatSetting() {
+            public void set(float value) { DemoConfig.FREE_ROAM_MOVE_SPEED = value; demo.applyLookRange(); }
         });
         // 0 stops at the horizon, which is what a map does; 90 reaches the zenith.
         slider(context, panel, "look above horizon (deg)", 0, 90, DemoConfig.LOOK_UP_LIMIT, true, new FloatSetting() {
@@ -514,6 +528,14 @@ public final class DemoPanel {
         header(context, panel, "ACTIONS");
         check(context, panel, "relief outline effect", DemoConfig.RELIEF_OUTLINE, new BoolSetting() {
             public void set(boolean value) { demo.setReliefOutlineEnabled(value); }
+        });
+        // The only way to trigger a two-finger gesture without fingers: in free roam 'fps' this
+        // is the move, everywhere else the pan.
+        button(context, panel, "two-finger drag: forward", new Action() {
+            public void run() { DemoTests.runTwoFingerDrag(demo, 0, -500); }
+        });
+        button(context, panel, "two-finger drag: strafe", new Action() {
+            public void run() { DemoTests.runTwoFingerDrag(demo, 400, 0); }
         });
         button(context, panel, "offline routing test", new Action() {
             public void run() { DemoTests.runOfflineRouting(demo); }

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
@@ -1,35 +1,61 @@
 package com.akylas.cartotest.demo;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.Typeface;
+import android.graphics.drawable.GradientDrawable;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
 import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * The on-screen debug panel: every {@link DemoConfig} knob, live.
+ * The on-screen settings panel: every {@link DemoConfig} knob, live.
  *
  * The panel NEVER touches SDK objects directly. It writes a DemoConfig field and then calls the
  * matching apply/rebuild method on {@link DemoMap}, which is the only place that knows how a
  * config value maps onto the SDK. Adding a knob is therefore: add the field in DemoConfig, apply
  * it in DemoMap.apply*(), add one line here.
  *
- * Panel is hidden behind the small gear button so the map stays unobstructed. '--es ui false'
- * skips it entirely (clean screenshots for automated rendering checks).
+ * LAYOUT. There are far too many knobs to scroll through, so:
+ *  - they live in COLLAPSIBLE sections, and opening one closes the others - the list of section
+ *    titles is short enough to read at a glance, which the flat list never was;
+ *  - a FILTER box at the top matches on the label of every row, across all sections, and shows
+ *    the matches expanded. Typing "shadow" is faster than remembering which section it is in.
+ *
+ * Everything is built in code (no XML): a knob is one line here and nothing else.
+ * '--es ui false' skips the whole thing, for clean screenshots.
  */
 public final class DemoPanel {
 
     private interface BoolSetting { void set(boolean value); }
     private interface FloatSetting { void set(float value); }
     private interface Action { void run(); }
+    private interface IntSetting { void set(int index); }
+
+    // --- looks ------------------------------------------------------------------------------------
+    private static final int COLOR_PANEL = 0xFF10151C;
+    private static final int COLOR_SECTION = 0xFF1E2731;
+    private static final int COLOR_TEXT = 0xFFE6EAF0;
+    private static final int COLOR_DIM = 0xFF97A2B0;
+    private static final int COLOR_ACCENT = 0xFF35D6C0;
 
     /** Live "z=.. tilt=.." readout, updated by the fragment's map listener. */
     public static TextView statusText;
@@ -37,6 +63,39 @@ public final class DemoPanel {
     private static TextView styleText;
     /** Shows, per composite slot, whether the style actually declares it. */
     private static TextView slotText;
+
+    private static float density = 1f;
+    private static TextView gearButton;
+    private static LinearLayout sections;      // the column every section is added to
+    private static LinearLayout currentContent; // the section rows are currently going into
+    private static final List<Row> rows = new ArrayList<Row>();
+    private static final List<Section> sectionList = new ArrayList<Section>();
+
+    /** One filterable row: the view to hide, and the text a filter matches against. */
+    private static final class Row {
+        final View view;
+        final String text;
+        final Section section;
+        Row(View view, String text, Section section) {
+            this.view = view;
+            this.text = text;
+            this.section = section;
+        }
+    }
+
+    private static final class Section {
+        final LinearLayout container;
+        final TextView title;
+        final LinearLayout content;
+        final String name;
+        boolean expanded;
+        Section(LinearLayout container, TextView title, LinearLayout content, String name) {
+            this.container = container;
+            this.title = title;
+            this.content = content;
+            this.name = name;
+        }
+    }
 
     /** Re-runs the slot check and updates both status lines. */
     private static void refreshStatus(DemoMap demo) {
@@ -50,57 +109,213 @@ public final class DemoPanel {
     }
 
     public static void build(final Context context, View root, final DemoMap demo) {
+        final ConstraintLayout parent = (ConstraintLayout) root;
+        density = context.getResources().getDisplayMetrics().density;
+
+        // The readout: bottom left, clear of the navigation bar. It is the view the layout already
+        // holds (the fragment writes to it), moved and restyled.
+        final TextView readout = (TextView) parent.findViewById(com.akylas.cartotest.R.id.zoomText);
+        if (readout != null) {
+            readout.setTextColor(COLOR_TEXT);
+            readout.setTextSize(12);
+            readout.setTypeface(Typeface.MONOSPACE);
+            readout.setBackground(rounded(0xB3000000, 10));
+            readout.setPadding(dp(10), dp(6), dp(10), dp(6));
+            ConstraintLayout.LayoutParams lp = (ConstraintLayout.LayoutParams) readout.getLayoutParams();
+            lp.topToTop = ConstraintLayout.LayoutParams.UNSET;
+            lp.endToEnd = ConstraintLayout.LayoutParams.UNSET;
+            lp.bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID;
+            lp.startToStart = ConstraintLayout.LayoutParams.PARENT_ID;
+            lp.leftMargin = dp(12);
+            lp.bottomMargin = dp(12);
+            readout.setLayoutParams(lp);
+        }
+
         if (!DemoConfig.UI_ENABLED) {
+            applyInsets(parent, null, readout, null);
             return;
         }
-        LinearLayout panel = new LinearLayout(context);
-        panel.setOrientation(LinearLayout.VERTICAL);
-        panel.setBackgroundColor(0xA0FFFFFF);
-        panel.setPadding(10, 10, 10, 10);
+
+        rows.clear();
+        sectionList.clear();
+
+        // --- the sheet -----------------------------------------------------------------------
+        final LinearLayout sheet = new LinearLayout(context);
+        sheet.setOrientation(LinearLayout.VERTICAL);
+        sheet.setBackground(roundedTop(COLOR_PANEL, 20));
+        sheet.setVisibility(View.GONE);
+        sheet.setClickable(true); // swallow taps so they never reach the map
+
+        LinearLayout titleRow = new LinearLayout(context);
+        titleRow.setOrientation(LinearLayout.HORIZONTAL);
+        titleRow.setGravity(Gravity.CENTER_VERTICAL);
+        titleRow.setPadding(dp(14), dp(10), dp(8), dp(4));
+
+        final EditText filter = new EditText(context);
+        filter.setHint("filter settings");
+        filter.setHintTextColor(COLOR_DIM);
+        filter.setTextColor(COLOR_TEXT);
+        filter.setTextSize(14);
+        filter.setSingleLine(true);
+        filter.setBackground(rounded(0x33FFFFFF, 10));
+        filter.setPadding(dp(12), dp(8), dp(12), dp(8));
+        titleRow.addView(filter, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+
+        TextView close = new TextView(context);
+        close.setText("\u2715");
+        close.setTextColor(COLOR_DIM);
+        close.setTextSize(18);
+        close.setPadding(dp(14), dp(6), dp(14), dp(6));
+        close.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) { showSheet(sheet, false); }
+        });
+        titleRow.addView(close);
+        sheet.addView(titleRow);
 
         statusText = new TextView(context);
         statusText.setText("zoom -");
-        panel.addView(statusText);
-        styleText = label(context, panel, "style: " + DemoStyles.lastLoadedDescription);
+        statusText.setTextColor(COLOR_DIM);
+        statusText.setTextSize(11);
+        statusText.setPadding(dp(16), 0, dp(16), dp(2));
+        sheet.addView(statusText);
 
-        buildLayerSection(context, panel, demo);
-        buildCompositeSection(context, panel, demo);
-        buildTerrainSection(context, panel, demo);
-        buildHillshadeSection(context, panel, demo);
-        buildContourSection(context, panel, demo);
-        buildRouteTestSection(context, panel, demo);
-        buildSunSection(context, panel, demo);
-        buildCelestialSection(context, panel, demo);
-        buildSkyFogSection(context, panel, demo);
-        buildDebugSection(context, panel, demo);
-        buildActionsSection(context, panel, demo);
+        // Which style actually loaded: a status line of the sheet itself, not a filterable row.
+        styleText = new TextView(context);
+        styleText.setText("style: " + DemoStyles.lastLoadedDescription);
+        styleText.setTextColor(COLOR_DIM);
+        styleText.setTextSize(11);
+        styleText.setPadding(dp(16), 0, dp(16), dp(6));
+        sheet.addView(styleText);
 
-        // The panel is taller than the screen: scroll it, and keep it behind a small toggle.
-        final ScrollView scroll = new ScrollView(context);
-        scroll.addView(panel);
-        scroll.setVisibility(View.GONE);
+        ScrollView scroll = new ScrollView(context);
+        scroll.setFillViewport(true);
+        sections = new LinearLayout(context);
+        sections.setOrientation(LinearLayout.VERTICAL);
+        sections.setPadding(dp(10), dp(4), dp(10), dp(16));
+        scroll.addView(sections);
+        sheet.addView(scroll, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f));
 
-        ConstraintLayout parent = (ConstraintLayout) root;
-        ConstraintLayout.LayoutParams lp = new ConstraintLayout.LayoutParams(820, 1500);
-        lp.bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID;
-        lp.startToStart = ConstraintLayout.LayoutParams.PARENT_ID;
-        lp.bottomMargin = 320;
-        lp.leftMargin = 10;
-        parent.addView(scroll, lp);
+        buildLayerSection(context, demo);
+        buildCompositeSection(context, demo);
+        buildTerrainSection(context, demo);
+        buildHillshadeSection(context, demo);
+        buildContourSection(context, demo);
+        buildRouteTestSection(context, demo);
+        buildSunSection(context, demo);
+        buildCelestialSection(context, demo);
+        buildSkyFogSection(context, demo);
+        buildDebugSection(context, demo);
+        buildActionsSection(context, demo);
 
-        final Button toggle = new Button(context);
-        toggle.setText("⚙");
-        toggle.setOnClickListener(new View.OnClickListener() {
+        filter.addTextChangedListener(new TextWatcher() {
+            public void beforeTextChanged(CharSequence s, int a, int b, int c) { }
+            public void onTextChanged(CharSequence s, int a, int b, int c) { applyFilter(s.toString()); }
+            public void afterTextChanged(Editable s) { }
+        });
+
+        ConstraintLayout.LayoutParams sheetParams = new ConstraintLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, 0);
+        sheetParams.bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID;
+        sheetParams.startToStart = ConstraintLayout.LayoutParams.PARENT_ID;
+        sheetParams.endToEnd = ConstraintLayout.LayoutParams.PARENT_ID;
+        sheetParams.matchConstraintPercentHeight = 0.68f;
+        sheetParams.topToTop = ConstraintLayout.LayoutParams.PARENT_ID;
+        sheetParams.verticalBias = 1f;
+        parent.addView(sheet, sheetParams);
+
+        // --- the button that opens it ---------------------------------------------------------
+        gearButton = new TextView(context);
+        final TextView gear = gearButton;
+        gear.setText("\u2699");
+        gear.setTextSize(22);
+        gear.setTextColor(COLOR_TEXT);
+        gear.setGravity(Gravity.CENTER);
+        gear.setBackground(rounded(0xCC1E2731, 28));
+        gear.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                scroll.setVisibility(scroll.getVisibility() == View.GONE ? View.VISIBLE : View.GONE);
+                showSheet(sheet, sheet.getVisibility() != View.VISIBLE);
             }
         });
-        ConstraintLayout.LayoutParams tlp = new ConstraintLayout.LayoutParams(150, ViewGroup.LayoutParams.WRAP_CONTENT);
-        tlp.bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID;
-        tlp.startToStart = ConstraintLayout.LayoutParams.PARENT_ID;
-        tlp.bottomMargin = 100; // clear of the system navigation bar
-        tlp.leftMargin = 10;
-        parent.addView(toggle, tlp);
+        ConstraintLayout.LayoutParams gearParams = new ConstraintLayout.LayoutParams(dp(48), dp(48));
+        gearParams.bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID;
+        gearParams.endToEnd = ConstraintLayout.LayoutParams.PARENT_ID;
+        gearParams.rightMargin = dp(12);
+        gearParams.bottomMargin = dp(12);
+        parent.addView(gear, gearParams);
+
+        applyInsets(parent, sheet, readout, gear);
+    }
+
+    /** The sheet and the button that opens it are the same control: only one shows at a time. */
+    private static void showSheet(View sheet, boolean show) {
+        sheet.setVisibility(show ? View.VISIBLE : View.GONE);
+        if (gearButton != null) {
+            gearButton.setVisibility(show ? View.GONE : View.VISIBLE);
+        }
+        if (show) {
+            sheet.setAlpha(0f);
+            sheet.setTranslationY(dp(24));
+            sheet.animate().alpha(1f).translationY(0f).setDuration(160).start();
+        }
+    }
+
+    /**
+     * Keeps the overlay clear of the status and navigation bars. The MAP is deliberately left
+     * edge to edge - it is the content.
+     */
+    private static void applyInsets(final ConstraintLayout parent, final View sheet,
+                                    final View readout, final View gear) {
+        ViewCompat.setOnApplyWindowInsetsListener(parent, new androidx.core.view.OnApplyWindowInsetsListener() {
+            public WindowInsetsCompat onApplyWindowInsets(View v, WindowInsetsCompat windowInsets) {
+                Insets bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+                Insets ime = windowInsets.getInsets(WindowInsetsCompat.Type.ime());
+                if (sheet != null) {
+                    // The keyboard is an inset too: the filter box is at the TOP of the sheet, so
+                    // the rows below it have to move up out of the way rather than under it.
+                    sheet.setPadding(0, 0, 0, Math.max(bars.bottom, ime.bottom));
+                }
+                for (View view : new View[] { readout, gear }) {
+                    if (view != null && view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams) {
+                        ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+                        lp.bottomMargin = bars.bottom + dp(12);
+                        lp.leftMargin = bars.left + dp(12);
+                        lp.rightMargin = bars.right + dp(12);
+                        view.setLayoutParams(lp);
+                    }
+                }
+                return windowInsets;
+            }
+        });
+        ViewCompat.requestApplyInsets(parent);
+    }
+
+    /** Shows only the rows whose label matches, and opens the sections that have any. */
+    private static void applyFilter(String query) {
+        String needle = query.trim().toLowerCase();
+        for (Section section : sectionList) {
+            boolean any = false;
+            for (Row row : rows) {
+                if (row.section != section) {
+                    continue;
+                }
+                boolean match = needle.isEmpty() || row.text.contains(needle)
+                        || section.name.toLowerCase().contains(needle);
+                row.view.setVisibility(match ? View.VISIBLE : View.GONE);
+                any = any || match;
+            }
+            section.container.setVisibility(any ? View.VISIBLE : View.GONE);
+            if (!needle.isEmpty()) {
+                expand(section, any);
+            } else {
+                expand(section, section.expanded);
+            }
+        }
+    }
+
+    private static void expand(Section section, boolean expanded) {
+        section.content.setVisibility(expanded ? View.VISIBLE : View.GONE);
+        section.title.setText((expanded ? "\u25be  " : "\u25b8  ") + section.name);
+        section.title.setTextColor(expanded ? COLOR_ACCENT : COLOR_TEXT);
     }
 
     // =============================================================================================
@@ -108,24 +323,24 @@ public final class DemoPanel {
     // =============================================================================================
 
     /** Add / remove whole layers, and pick what the base map is built from. */
-    private static void buildLayerSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "LAYERS");
+    private static void buildLayerSection(Context context, final DemoMap demo) {
+        header(context, "LAYERS");
         for (final DemoMap.Feature feature : DemoMap.Feature.values()) {
-            check(context, panel, feature.name().toLowerCase(), demo.isEnabled(feature), new BoolSetting() {
+            check(context, feature.name().toLowerCase(), demo.isEnabled(feature), new BoolSetting() {
                 public void set(boolean value) { demo.setEnabled(feature, value); }
             });
         }
 
-        header(context, panel, "BASE MAP");
+        header(context, "BASE MAP");
         // Switching either of these rebuilds the base layer with a new decoder / layer class.
-        choice(context, panel, "mode", enumNames(DemoConfig.BaseMode.values()), DemoConfig.BASE_MODE.ordinal(), new IntSetting() {
+        choice(context, "mode", enumNames(DemoConfig.BaseMode.values()), DemoConfig.BASE_MODE.ordinal(), new IntSetting() {
             public void set(int index) {
                 DemoConfig.BASE_MODE = DemoConfig.BaseMode.values()[index];
                 demo.rebuildBaseLayer();
                 refreshStatus(demo);
             }
         });
-        choice(context, panel, "style", enumNames(DemoConfig.StyleSource.values()), DemoConfig.STYLE_SOURCE.ordinal(), new IntSetting() {
+        choice(context, "style", enumNames(DemoConfig.StyleSource.values()), DemoConfig.STYLE_SOURCE.ordinal(), new IntSetting() {
             public void set(int index) {
                 DemoConfig.STYLE_SOURCE = DemoConfig.StyleSource.values()[index];
                 demo.rebuildBaseLayer();
@@ -135,21 +350,21 @@ public final class DemoPanel {
     }
 
     /** Sources woven INTO the base style (CompositeVectorTileLayer only). */
-    private static void buildCompositeSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "COMPOSITE SLOTS");
+    private static void buildCompositeSection(Context context, final DemoMap demo) {
+        header(context, "COMPOSITE SLOTS");
         // A slot only exists if the STYLE declares a layer with that name; otherwise the source is
         // registered but never drawn. This line says which of the two it is, per slot.
-        slotText = label(context, panel, demo.compositeStatus);
-        check(context, panel, "#hillshade", DemoConfig.COMPOSITE_HILLSHADE, new BoolSetting() {
+        slotText = label(context, demo.compositeStatus);
+        check(context, "#hillshade", DemoConfig.COMPOSITE_HILLSHADE, new BoolSetting() {
             public void set(boolean value) { DemoConfig.COMPOSITE_HILLSHADE = value; demo.syncCompositeSources(); refreshStatus(demo); }
         });
-        check(context, panel, "#satellite", DemoConfig.COMPOSITE_SATELLITE, new BoolSetting() {
+        check(context, "#satellite", DemoConfig.COMPOSITE_SATELLITE, new BoolSetting() {
             public void set(boolean value) { DemoConfig.COMPOSITE_SATELLITE = value; demo.syncCompositeSources(); refreshStatus(demo); }
         });
-        check(context, panel, "#contour", DemoConfig.COMPOSITE_CONTOUR, new BoolSetting() {
+        check(context, "#contour", DemoConfig.COMPOSITE_CONTOUR, new BoolSetting() {
             public void set(boolean value) { DemoConfig.COMPOSITE_CONTOUR = value; demo.syncCompositeSources(); refreshStatus(demo); }
         });
-        check(context, panel, "single-pass rendering", DemoConfig.COMPOSITE_SINGLE_PASS, new BoolSetting() {
+        check(context, "single-pass rendering", DemoConfig.COMPOSITE_SINGLE_PASS, new BoolSetting() {
             public void set(boolean value) {
                 DemoConfig.COMPOSITE_SINGLE_PASS = value;
                 if (demo.compositeLayer != null) {
@@ -158,7 +373,7 @@ public final class DemoPanel {
             }
         });
         // +1 = fetch the DEM one zoom level deeper than the base map.
-        slider(context, panel, "#hillshade zoom bias", -2, 2, DemoConfig.COMPOSITE_HILLSHADE_ZOOM_BIAS, true, new FloatSetting() {
+        slider(context, "#hillshade zoom bias", -2, 2, DemoConfig.COMPOSITE_HILLSHADE_ZOOM_BIAS, true, new FloatSetting() {
             public void set(float value) {
                 DemoConfig.COMPOSITE_HILLSHADE_ZOOM_BIAS = Math.round(value);
                 demo.syncCompositeSources();
@@ -166,57 +381,57 @@ public final class DemoPanel {
         });
     }
 
-    private static void buildTerrainSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "TERRAIN");
-        check(context, panel, "3D terrain", DemoConfig.TERRAIN_ENABLED, new BoolSetting() {
+    private static void buildTerrainSection(Context context, final DemoMap demo) {
+        header(context, "TERRAIN");
+        check(context, "3D terrain", DemoConfig.TERRAIN_ENABLED, new BoolSetting() {
             public void set(boolean value) { DemoConfig.TERRAIN_ENABLED = value; demo.animateTerrain(value); }
         });
-        check(context, panel, "billboard occlusion", DemoConfig.TERRAIN_BILLBOARD_OCCLUSION, new BoolSetting() {
+        check(context, "billboard occlusion", DemoConfig.TERRAIN_BILLBOARD_OCCLUSION, new BoolSetting() {
             public void set(boolean value) { DemoConfig.TERRAIN_BILLBOARD_OCCLUSION = value; demo.terrainOptions.setBillboardOcclusionEnabled(value); }
         });
-        slider(context, panel, "occlusion tolerance", 0f, 0.5f, DemoConfig.TERRAIN_OCCLUSION_TOLERANCE, false, new FloatSetting() {
+        slider(context, "occlusion tolerance", 0f, 0.5f, DemoConfig.TERRAIN_OCCLUSION_TOLERANCE, false, new FloatSetting() {
             public void set(float value) { DemoConfig.TERRAIN_OCCLUSION_TOLERANCE = value; demo.terrainOptions.setBillboardOcclusionTolerance(value); }
         });
         // Exaggeration and the resolutions re-tesselate / drop every cached tile texture, so they
         // are applied on release only - applying them per pixel of drag is a guaranteed stall.
-        slider(context, panel, "exaggeration", 0f, 3f, DemoConfig.TERRAIN_EXAGGERATION, true, new FloatSetting() {
+        slider(context, "exaggeration", 0f, 3f, DemoConfig.TERRAIN_EXAGGERATION, true, new FloatSetting() {
             public void set(float value) { DemoConfig.TERRAIN_EXAGGERATION = value; demo.terrainOptions.setExaggeration(value); }
         });
-        slider(context, panel, "mesh resolution", 16, 192, DemoConfig.TERRAIN_MESH_RESOLUTION, true, new FloatSetting() {
+        slider(context, "mesh resolution", 16, 192, DemoConfig.TERRAIN_MESH_RESOLUTION, true, new FloatSetting() {
             public void set(float value) {
                 DemoConfig.TERRAIN_MESH_RESOLUTION = Math.max(16, ((int) value / 16) * 16);
                 demo.terrainOptions.setMeshResolution(DemoConfig.TERRAIN_MESH_RESOLUTION);
             }
         });
-        check(context, panel, "drape fills (RTT)", DemoConfig.TERRAIN_DRAPE_FILLS, new BoolSetting() {
+        check(context, "drape fills (RTT)", DemoConfig.TERRAIN_DRAPE_FILLS, new BoolSetting() {
             public void set(boolean value) { DemoConfig.TERRAIN_DRAPE_FILLS = value; demo.terrainOptions.setDrapeFillsEnabled(value); }
         });
-        check(context, panel, "drape lines", DemoConfig.TERRAIN_DRAPE_LINES, new BoolSetting() {
+        check(context, "drape lines", DemoConfig.TERRAIN_DRAPE_LINES, new BoolSetting() {
             public void set(boolean value) { DemoConfig.TERRAIN_DRAPE_LINES = value; demo.terrainOptions.setDrapeLinesEnabled(value); }
         });
-        slider(context, panel, "drape resolution", 256, 2048, DemoConfig.TERRAIN_DRAPE_RESOLUTION, true, new FloatSetting() {
+        slider(context, "drape resolution", 256, 2048, DemoConfig.TERRAIN_DRAPE_RESOLUTION, true, new FloatSetting() {
             public void set(float value) {
                 DemoConfig.TERRAIN_DRAPE_RESOLUTION = Math.max(256, ((int) value / 256) * 256);
                 demo.terrainOptions.setDrapeResolution(DemoConfig.TERRAIN_DRAPE_RESOLUTION);
             }
         });
-        check(context, panel, "tile edge stitching", DemoConfig.TERRAIN_TILE_EDGE_STITCHING, new BoolSetting() {
+        check(context, "tile edge stitching", DemoConfig.TERRAIN_TILE_EDGE_STITCHING, new BoolSetting() {
             public void set(boolean value) { DemoConfig.TERRAIN_TILE_EDGE_STITCHING = value; demo.terrainOptions.setTileEdgeStitchingEnabled(value); }
         });
-        check(context, panel, "seamless tile edges", DemoConfig.TERRAIN_SEAMLESS_TILE_EDGES, new BoolSetting() {
+        check(context, "seamless tile edges", DemoConfig.TERRAIN_SEAMLESS_TILE_EDGES, new BoolSetting() {
             public void set(boolean value) { DemoConfig.TERRAIN_SEAMLESS_TILE_EDGES = value; demo.terrainOptions.setSeamlessTileEdgesEnabled(value); }
         });
-        check(context, panel, "elevation prefetch", DemoConfig.TERRAIN_ELEVATION_PREFETCH, new BoolSetting() {
+        check(context, "elevation prefetch", DemoConfig.TERRAIN_ELEVATION_PREFETCH, new BoolSetting() {
             public void set(boolean value) { DemoConfig.TERRAIN_ELEVATION_PREFETCH = value; demo.terrainOptions.setElevationPrefetchEnabled(value); }
         });
-        check(context, panel, "background bitmap", DemoConfig.TERRAIN_BACKGROUND_BITMAP, new BoolSetting() {
+        check(context, "background bitmap", DemoConfig.TERRAIN_BACKGROUND_BITMAP, new BoolSetting() {
             public void set(boolean value) { DemoConfig.TERRAIN_BACKGROUND_BITMAP = value; demo.terrainOptions.setBackgroundBitmapEnabled(value); }
         });
     }
 
     /** Stand-alone hillshade layer (LAYERS > hillshade). */
-    private static void buildHillshadeSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "HILLSHADE LAYER");
+    private static void buildHillshadeSection(Context context, final DemoMap demo) {
+        header(context, "HILLSHADE LAYER");
         final String[] methods = { "STANDARD", "COMBINED", "IGOR", "MULTIDIRECTIONAL", "BASIC" };
         int current = 2;
         for (int i = 0; i < methods.length; i++) {
@@ -224,55 +439,55 @@ public final class DemoPanel {
                 current = i;
             }
         }
-        choice(context, panel, "method", methods, current, new IntSetting() {
+        choice(context, "method", methods, current, new IntSetting() {
             public void set(int index) { DemoConfig.HILLSHADE_METHOD = methods[index]; demo.applyHillshadeConfig(); }
         });
-        slider(context, panel, "contrast", 0f, 1f, DemoConfig.HILLSHADE_CONTRAST, false, new FloatSetting() {
+        slider(context, "contrast", 0f, 1f, DemoConfig.HILLSHADE_CONTRAST, false, new FloatSetting() {
             public void set(float value) { DemoConfig.HILLSHADE_CONTRAST = value; demo.applyHillshadeConfig(); }
         });
-        slider(context, panel, "height scale", 0f, 1f, DemoConfig.HILLSHADE_HEIGHT_SCALE, false, new FloatSetting() {
+        slider(context, "height scale", 0f, 1f, DemoConfig.HILLSHADE_HEIGHT_SCALE, false, new FloatSetting() {
             public void set(float value) { DemoConfig.HILLSHADE_HEIGHT_SCALE = value; demo.applyHillshadeConfig(); }
         });
-        slider(context, panel, "exaggeration", 0f, 3f, DemoConfig.HILLSHADE_EXAGGERATION, false, new FloatSetting() {
+        slider(context, "exaggeration", 0f, 3f, DemoConfig.HILLSHADE_EXAGGERATION, false, new FloatSetting() {
             public void set(float value) { DemoConfig.HILLSHADE_EXAGGERATION = value; demo.applyHillshadeConfig(); }
         });
-        slider(context, panel, "illumination (deg)", 0, 360, DemoConfig.HILLSHADE_ILLUMINATION_DEGREES, false, new FloatSetting() {
+        slider(context, "illumination (deg)", 0, 360, DemoConfig.HILLSHADE_ILLUMINATION_DEGREES, false, new FloatSetting() {
             public void set(float value) { DemoConfig.HILLSHADE_ILLUMINATION_DEGREES = value; demo.applyHillshadeConfig(); }
         });
-        check(context, panel, "illumination follows map", DemoConfig.HILLSHADE_ILLUMINATION_FOLLOWS_MAP, new BoolSetting() {
+        check(context, "illumination follows map", DemoConfig.HILLSHADE_ILLUMINATION_FOLLOWS_MAP, new BoolSetting() {
             public void set(boolean value) { DemoConfig.HILLSHADE_ILLUMINATION_FOLLOWS_MAP = value; demo.applyHillshadeConfig(); }
         });
-        check(context, panel, "slope colouring shader", DemoConfig.HILLSHADE_SLOPES_SHADER, new BoolSetting() {
+        check(context, "slope colouring shader", DemoConfig.HILLSHADE_SLOPES_SHADER, new BoolSetting() {
             public void set(boolean value) { DemoConfig.HILLSHADE_SLOPES_SHADER = value; demo.applyHillshadeConfig(); }
         });
-        check(context, panel, "shader contour lines", DemoConfig.HILLSHADE_CONTOUR_LINES, new BoolSetting() {
+        check(context, "shader contour lines", DemoConfig.HILLSHADE_CONTOUR_LINES, new BoolSetting() {
             public void set(boolean value) { DemoConfig.HILLSHADE_CONTOUR_LINES = value; demo.applyHillshadeConfig(); }
         });
-        slider(context, panel, "shader contour interval (m)", 10, 500, DemoConfig.HILLSHADE_CONTOUR_INTERVAL, true, new FloatSetting() {
+        slider(context, "shader contour interval (m)", 10, 500, DemoConfig.HILLSHADE_CONTOUR_INTERVAL, true, new FloatSetting() {
             public void set(float value) { DemoConfig.HILLSHADE_CONTOUR_INTERVAL = value; demo.applyHillshadeConfig(); }
         });
-        slider(context, panel, "shader contour width", 0.2f, 3f, DemoConfig.HILLSHADE_CONTOUR_WIDTH, true, new FloatSetting() {
+        slider(context, "shader contour width", 0.2f, 3f, DemoConfig.HILLSHADE_CONTOUR_WIDTH, true, new FloatSetting() {
             public void set(float value) { DemoConfig.HILLSHADE_CONTOUR_WIDTH = value; demo.applyHillshadeConfig(); }
         });
     }
 
     /** Geometry contours (ContourTileDataSource): shared by the layer and the composite slot. */
-    private static void buildContourSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "CONTOUR SOURCE");
+    private static void buildContourSection(Context context, final DemoMap demo) {
+        header(context, "CONTOUR SOURCE");
         // All of these re-generate tiles, so they apply on release and then drop the cached tiles.
-        slider(context, panel, "base interval (m)", 1, 100, DemoConfig.CONTOUR_BASE_INTERVAL, true, new FloatSetting() {
+        slider(context, "base interval (m)", 1, 100, DemoConfig.CONTOUR_BASE_INTERVAL, true, new FloatSetting() {
             public void set(float value) { DemoConfig.CONTOUR_BASE_INTERVAL = value; reloadContours(demo); }
         });
-        slider(context, panel, "resolution (samples)", 32, 256, DemoConfig.CONTOUR_RESOLUTION, true, new FloatSetting() {
+        slider(context, "resolution (samples)", 32, 256, DemoConfig.CONTOUR_RESOLUTION, true, new FloatSetting() {
             public void set(float value) { DemoConfig.CONTOUR_RESOLUTION = (int) value; reloadContours(demo); }
         });
-        slider(context, panel, "simplify tolerance (px)", 0, 5, DemoConfig.CONTOUR_SIMPLIFY_TOLERANCE, true, new FloatSetting() {
+        slider(context, "simplify tolerance (px)", 0, 5, DemoConfig.CONTOUR_SIMPLIFY_TOLERANCE, true, new FloatSetting() {
             public void set(float value) { DemoConfig.CONTOUR_SIMPLIFY_TOLERANCE = value; reloadContours(demo); }
         });
-        slider(context, panel, "min visible tile zoom", 0, 16, DemoConfig.CONTOUR_MIN_VISIBLE_ZOOM, true, new FloatSetting() {
+        slider(context, "min visible tile zoom", 0, 16, DemoConfig.CONTOUR_MIN_VISIBLE_ZOOM, true, new FloatSetting() {
             public void set(float value) { DemoConfig.CONTOUR_MIN_VISIBLE_ZOOM = (int) value; reloadContours(demo); }
         });
-        check(context, panel, "seamless edges", DemoConfig.CONTOUR_SEAMLESS_EDGES, new BoolSetting() {
+        check(context, "seamless edges", DemoConfig.CONTOUR_SEAMLESS_EDGES, new BoolSetting() {
             public void set(boolean value) { DemoConfig.CONTOUR_SEAMLESS_EDGES = value; reloadContours(demo); }
         });
     }
@@ -284,33 +499,33 @@ public final class DemoPanel {
     }
 
     /** Join / cap / opacity of the route test layer - the line tesselation bench. */
-    private static void buildRouteTestSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "ROUTE TEST");
+    private static void buildRouteTestSection(Context context, final DemoMap demo) {
+        header(context, "ROUTE TEST");
         final String[] joins = { "miter", "bevel", "round" };
-        choice(context, panel, "join", joins, indexOf(joins, DemoConfig.ROUTE_TEST_JOIN), new IntSetting() {
+        choice(context, "join", joins, indexOf(joins, DemoConfig.ROUTE_TEST_JOIN), new IntSetting() {
             public void set(int index) { DemoConfig.ROUTE_TEST_JOIN = joins[index]; reloadRouteTest(demo); }
         });
         final String[] caps = { "butt", "square", "round" };
-        choice(context, panel, "cap", caps, indexOf(caps, DemoConfig.ROUTE_TEST_CAP), new IntSetting() {
+        choice(context, "cap", caps, indexOf(caps, DemoConfig.ROUTE_TEST_CAP), new IntSetting() {
             public void set(int index) { DemoConfig.ROUTE_TEST_CAP = caps[index]; reloadRouteTest(demo); }
         });
-        slider(context, panel, "width", 1, 30, DemoConfig.ROUTE_TEST_WIDTH, true, new FloatSetting() {
+        slider(context, "width", 1, 30, DemoConfig.ROUTE_TEST_WIDTH, true, new FloatSetting() {
             public void set(float value) { DemoConfig.ROUTE_TEST_WIDTH = value; reloadRouteTest(demo); }
         });
-        slider(context, panel, "casing width", 0, 40, DemoConfig.ROUTE_TEST_CASE_WIDTH, true, new FloatSetting() {
+        slider(context, "casing width", 0, 40, DemoConfig.ROUTE_TEST_CASE_WIDTH, true, new FloatSetting() {
             public void set(float value) { DemoConfig.ROUTE_TEST_CASE_WIDTH = value; reloadRouteTest(demo); }
         });
-        slider(context, panel, "miter limit", 1, 12, DemoConfig.ROUTE_TEST_MITER_LIMIT, true, new FloatSetting() {
+        slider(context, "miter limit", 1, 12, DemoConfig.ROUTE_TEST_MITER_LIMIT, true, new FloatSetting() {
             public void set(float value) { DemoConfig.ROUTE_TEST_MITER_LIMIT = value; reloadRouteTest(demo); }
         });
-        slider(context, panel, "opacity", 0.1f, 1, DemoConfig.ROUTE_TEST_OPACITY, true, new FloatSetting() {
+        slider(context, "opacity", 0.1f, 1, DemoConfig.ROUTE_TEST_OPACITY, true, new FloatSetting() {
             public void set(float value) { DemoConfig.ROUTE_TEST_OPACITY = value; reloadRouteTest(demo); }
         });
         final String[] opacityModes = { "geom", "layer" };
-        choice(context, panel, "opacity mode", opacityModes, indexOf(opacityModes, DemoConfig.ROUTE_TEST_OPACITY_MODE), new IntSetting() {
+        choice(context, "opacity mode", opacityModes, indexOf(opacityModes, DemoConfig.ROUTE_TEST_OPACITY_MODE), new IntSetting() {
             public void set(int index) { DemoConfig.ROUTE_TEST_OPACITY_MODE = opacityModes[index]; reloadRouteTest(demo); }
         });
-        slider(context, panel, "simplify", 0, 16, DemoConfig.ROUTE_TEST_SIMPLIFY, true, new FloatSetting() {
+        slider(context, "simplify", 0, 16, DemoConfig.ROUTE_TEST_SIMPLIFY, true, new FloatSetting() {
             public void set(float value) { DemoConfig.ROUTE_TEST_SIMPLIFY = value; reloadRouteTest(demo); }
         });
     }
@@ -330,16 +545,16 @@ public final class DemoPanel {
         return 0;
     }
 
-    private static void buildSunSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "SUN");
-        check(context, panel, "terrain lighting", DemoConfig.TERRAIN_LIGHTING, new BoolSetting() {
+    private static void buildSunSection(Context context, final DemoMap demo) {
+        header(context, "SUN");
+        check(context, "terrain lighting", DemoConfig.TERRAIN_LIGHTING, new BoolSetting() {
             public void set(boolean value) { DemoConfig.TERRAIN_LIGHTING = value; demo.lightOptions.setTerrainLightingEnabled(value); }
         });
-        check(context, panel, "day cycle (sun/moon/sky)", DemoConfig.DAY_CYCLE, new BoolSetting() {
+        check(context, "day cycle (sun/moon/sky)", DemoConfig.DAY_CYCLE, new BoolSetting() {
             public void set(boolean value) { DemoConfig.DAY_CYCLE = value; demo.applyDayCycle(DemoConfig.DAY_CYCLE_HOUR); }
         });
         // With the day cycle on, the hour drives everything; otherwise it only moves the sun.
-        slider(context, panel, "hour (UTC)", 0, 24, DemoConfig.DAY_CYCLE_HOUR, false, new FloatSetting() {
+        slider(context, "hour (UTC)", 0, 24, DemoConfig.DAY_CYCLE_HOUR, false, new FloatSetting() {
             public void set(float value) {
                 DemoConfig.DAY_CYCLE_HOUR = value;
                 if (DemoConfig.DAY_CYCLE) {
@@ -350,43 +565,43 @@ public final class DemoPanel {
                 }
             }
         });
-        slider(context, panel, "azimuth", 0, 360, DemoConfig.SUN_AZIMUTH, false, new FloatSetting() {
+        slider(context, "azimuth", 0, 360, DemoConfig.SUN_AZIMUTH, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SUN_AZIMUTH = value; DemoConfig.SUN_HOUR_UTC = -1; demo.lightOptions.setSunAzimuth(value); }
         });
-        slider(context, panel, "altitude", -10, 90, DemoConfig.SUN_ALTITUDE, false, new FloatSetting() {
+        slider(context, "altitude", -10, 90, DemoConfig.SUN_ALTITUDE, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SUN_ALTITUDE = value; DemoConfig.SUN_HOUR_UTC = -1; demo.lightOptions.setSunAltitude(value); }
         });
-        slider(context, panel, "sun intensity", 0, 2, DemoConfig.SUN_INTENSITY, false, new FloatSetting() {
+        slider(context, "sun intensity", 0, 2, DemoConfig.SUN_INTENSITY, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SUN_INTENSITY = value; demo.lightOptions.setSunIntensity(value); }
         });
-        slider(context, panel, "ambient", 0, 1, DemoConfig.AMBIENT_INTENSITY, false, new FloatSetting() {
+        slider(context, "ambient", 0, 1, DemoConfig.AMBIENT_INTENSITY, false, new FloatSetting() {
             public void set(float value) { DemoConfig.AMBIENT_INTENSITY = value; demo.lightOptions.setAmbientIntensity(value); }
         });
 
-        header(context, panel, "SHADOWS");
-        slider(context, panel, "strength", 0, 1, DemoConfig.SHADOW_STRENGTH, false, new FloatSetting() {
+        header(context, "SHADOWS");
+        slider(context, "strength", 0, 1, DemoConfig.SHADOW_STRENGTH, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SHADOW_STRENGTH = value; demo.lightOptions.setShadowStrength(value); }
         });
-        slider(context, panel, "softness (texels)", 0, 4, DemoConfig.SHADOW_SOFTNESS, false, new FloatSetting() {
+        slider(context, "softness (texels)", 0, 4, DemoConfig.SHADOW_SOFTNESS, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SHADOW_SOFTNESS = value; demo.lightOptions.setShadowSoftness(value); }
         });
         // Reallocates the shadow map atlas, so apply on release only.
-        slider(context, panel, "map size", 512, 4096, DemoConfig.SHADOW_MAP_SIZE, true, new FloatSetting() {
+        slider(context, "map size", 512, 4096, DemoConfig.SHADOW_MAP_SIZE, true, new FloatSetting() {
             public void set(float value) {
                 DemoConfig.SHADOW_MAP_SIZE = Math.max(512, ((int) value / 512) * 512);
                 demo.lightOptions.setShadowMapSize(DemoConfig.SHADOW_MAP_SIZE);
             }
         });
-        slider(context, panel, "cascades", 1, 4, DemoConfig.SHADOW_CASCADES, true, new FloatSetting() {
+        slider(context, "cascades", 1, 4, DemoConfig.SHADOW_CASCADES, true, new FloatSetting() {
             public void set(float value) { DemoConfig.SHADOW_CASCADES = Math.round(value); demo.lightOptions.setShadowCascades(DemoConfig.SHADOW_CASCADES); }
         });
-        slider(context, panel, "distance (m, 0=all)", 0, 20000, DemoConfig.SHADOW_DISTANCE, false, new FloatSetting() {
+        slider(context, "distance (m, 0=all)", 0, 20000, DemoConfig.SHADOW_DISTANCE, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SHADOW_DISTANCE = value < 200 ? 0 : value; demo.lightOptions.setShadowDistance(DemoConfig.SHADOW_DISTANCE); }
         });
-        slider(context, panel, "caster margin (tiles)", 0, 6, DemoConfig.SHADOW_CASTER_MARGIN, true, new FloatSetting() {
+        slider(context, "caster margin (tiles)", 0, 6, DemoConfig.SHADOW_CASTER_MARGIN, true, new FloatSetting() {
             public void set(float value) { DemoConfig.SHADOW_CASTER_MARGIN = Math.round(value); demo.lightOptions.setShadowCasterMargin(DemoConfig.SHADOW_CASTER_MARGIN); }
         });
-        slider(context, panel, "depth bias (m)", 0f, 5f, DemoConfig.SHADOW_BIAS, false, new FloatSetting() {
+        slider(context, "depth bias (m)", 0f, 5f, DemoConfig.SHADOW_BIAS, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SHADOW_BIAS = value; demo.lightOptions.setShadowBias(value); }
         });
     }
@@ -398,8 +613,8 @@ public final class DemoPanel {
      * content inside them, and the look-around mode - one finger looks instead of panning, and the
      * tilt may go NEGATIVE, which is the view pitching above the horizon.
      */
-    private static void buildCelestialSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "SKY OBJECTS");
+    private static void buildCelestialSection(Context context, final DemoMap demo) {
+        header(context, "SKY OBJECTS");
         // off = the map gestures; look = one finger looks; fps = mouse look + two-finger move.
         final String[] roamModes = { "off", "look", "fps" };
         int currentRoam = 0;
@@ -408,80 +623,83 @@ public final class DemoPanel {
                 currentRoam = i;
             }
         }
-        choice(context, panel, "free roam", roamModes, currentRoam, new IntSetting() {
+        choice(context, "free roam", roamModes, currentRoam, new IntSetting() {
             public void set(int index) { DemoConfig.FREE_ROAM_MODE = roamModes[index]; demo.applyLookRange(); }
         });
-        slider(context, panel, "look sensitivity (deg/inch)", 20, 200, DemoConfig.FREE_ROAM_LOOK_SENSITIVITY, false, new FloatSetting() {
+        slider(context, "look sensitivity (deg/inch)", 20, 200, DemoConfig.FREE_ROAM_LOOK_SENSITIVITY, false, new FloatSetting() {
             public void set(float value) { DemoConfig.FREE_ROAM_LOOK_SENSITIVITY = value; demo.applyLookRange(); }
         });
-        slider(context, panel, "move speed (x distance/inch)", 0.05f, 2f, DemoConfig.FREE_ROAM_MOVE_SPEED, false, new FloatSetting() {
+        slider(context, "move speed (x distance/inch)", 0.05f, 2f, DemoConfig.FREE_ROAM_MOVE_SPEED, false, new FloatSetting() {
             public void set(float value) { DemoConfig.FREE_ROAM_MOVE_SPEED = value; demo.applyLookRange(); }
         });
         // 0 stops at the horizon, which is what a map does; 90 reaches the zenith.
-        slider(context, panel, "look above horizon (deg)", 0, 90, DemoConfig.LOOK_UP_LIMIT, true, new FloatSetting() {
+        slider(context, "look above horizon (deg)", 0, 90, DemoConfig.LOOK_UP_LIMIT, true, new FloatSetting() {
             public void set(float value) { DemoConfig.LOOK_UP_LIMIT = value; demo.applyLookRange(); }
         });
 
-        check(context, panel, "sun", DemoConfig.CELESTIAL_SUN, new BoolSetting() {
+        check(context, "sun", DemoConfig.CELESTIAL_SUN, new BoolSetting() {
             public void set(boolean value) { DemoConfig.CELESTIAL_SUN = value; demo.updateSky(); }
         });
-        check(context, panel, "moon", DemoConfig.CELESTIAL_MOON, new BoolSetting() {
+        check(context, "moon", DemoConfig.CELESTIAL_MOON, new BoolSetting() {
             public void set(boolean value) { DemoConfig.CELESTIAL_MOON = value; demo.updateSky(); }
         });
-        check(context, panel, "moon phase", DemoConfig.CELESTIAL_MOON_PHASE, new BoolSetting() {
+        check(context, "moon phase", DemoConfig.CELESTIAL_MOON_PHASE, new BoolSetting() {
             public void set(boolean value) { DemoConfig.CELESTIAL_MOON_PHASE = value; demo.updateSky(); }
         });
-        check(context, panel, "sun path today", DemoConfig.CELESTIAL_ARC, new BoolSetting() {
+        check(context, "sun path today", DemoConfig.CELESTIAL_ARC, new BoolSetting() {
             public void set(boolean value) { DemoConfig.CELESTIAL_ARC = value; demo.updateSky(); }
         });
-        check(context, panel, "moon path today", DemoConfig.CELESTIAL_MOON_ARC, new BoolSetting() {
+        check(context, "moon path today", DemoConfig.CELESTIAL_MOON_ARC, new BoolSetting() {
             public void set(boolean value) { DemoConfig.CELESTIAL_MOON_ARC = value; demo.updateSky(); }
         });
 
-        header(context, panel, "STARS");
-        check(context, panel, "star layer", DemoConfig.STARS, new BoolSetting() {
+        header(context, "STARS");
+        check(context, "star layer", DemoConfig.STARS, new BoolSetting() {
             public void set(boolean value) { demo.setEnabled(DemoMap.Feature.STARS, value); }
         });
-        check(context, panel, "stars", DemoConfig.STARS_STARS, new BoolSetting() {
+        check(context, "stars", DemoConfig.STARS_STARS, new BoolSetting() {
             public void set(boolean value) { DemoConfig.STARS_STARS = value; demo.updateSky(); }
         });
-        check(context, panel, "constellations", DemoConfig.STARS_FIGURES, new BoolSetting() {
+        check(context, "constellations", DemoConfig.STARS_FIGURES, new BoolSetting() {
             public void set(boolean value) { DemoConfig.STARS_FIGURES = value; demo.updateSky(); }
         });
-        check(context, panel, "planets", DemoConfig.STARS_PLANETS, new BoolSetting() {
+        check(context, "constellation names", DemoConfig.STARS_LABELS, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.STARS_LABELS = value; demo.updateSky(); }
+        });
+        check(context, "planets", DemoConfig.STARS_PLANETS, new BoolSetting() {
             public void set(boolean value) { DemoConfig.STARS_PLANETS = value; demo.updateSky(); }
         });
-        check(context, panel, "celestial equator", DemoConfig.STARS_EQUATOR, new BoolSetting() {
+        check(context, "celestial equator", DemoConfig.STARS_EQUATOR, new BoolSetting() {
             public void set(boolean value) { DemoConfig.STARS_EQUATOR = value; demo.updateSky(); }
         });
         // No map at all: the layers leave the layer list, so this costs an empty map.
-        check(context, panel, "star sky (no map, transparent)", DemoConfig.STAR_SKY, new BoolSetting() {
+        check(context, "star sky (no map, transparent)", DemoConfig.STAR_SKY, new BoolSetting() {
             public void set(boolean value) { demo.applyStarSky(value); }
         });
-        check(context, panel, "follow device orientation", DemoConfig.STAR_SKY_ORIENTATION, new BoolSetting() {
+        check(context, "follow device orientation", DemoConfig.STAR_SKY_ORIENTATION, new BoolSetting() {
             public void set(boolean value) { demo.setOrientationFollowing(value); }
         });
         // The camera preview goes BEHIND the transparent map: the sky over what the camera sees.
-        check(context, panel, "camera behind (AR sky)", DemoConfig.STAR_SKY_CAMERA, new BoolSetting() {
+        check(context, "camera behind (AR sky)", DemoConfig.STAR_SKY_CAMERA, new BoolSetting() {
             public void set(boolean value) { demo.setCameraPreviewEnabled(value); }
         });
     }
 
-    private static void buildSkyFogSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "SKY");
-        check(context, panel, "sky", DemoConfig.SKY_ENABLED, new BoolSetting() {
+    private static void buildSkyFogSection(Context context, final DemoMap demo) {
+        header(context, "SKY");
+        check(context, "sky", DemoConfig.SKY_ENABLED, new BoolSetting() {
             public void set(boolean value) { DemoConfig.SKY_ENABLED = value; demo.skyOptions.setEnabled(value); }
         });
 
         // Buildings come from the STYLE, so the switch rebuilds the base layer. Only the inline
         // style is generated here, so it is the one this can turn on and off; a dir/zip/nuti style
         // draws whatever it was authored with.
-        check(context, panel, "3D buildings (inline style)", DemoConfig.INLINE_BUILDINGS_3D, new BoolSetting() {
+        check(context, "3D buildings (inline style)", DemoConfig.INLINE_BUILDINGS_3D, new BoolSetting() {
             public void set(boolean value) { DemoConfig.INLINE_BUILDINGS_3D = value; demo.rebuildBaseLayer(); }
         });
 
-        header(context, panel, "FOG / DISTANCE");
-        check(context, panel, "fog", DemoConfig.FOG_ENABLED, new BoolSetting() {
+        header(context, "FOG / DISTANCE");
+        check(context, "fog", DemoConfig.FOG_ENABLED, new BoolSetting() {
             public void set(boolean value) {
                 DemoConfig.FOG_ENABLED = value;
                 if (value && DemoConfig.FOG_DISTANCE <= 0) {
@@ -490,100 +708,163 @@ public final class DemoPanel {
                 demo.applyTerrainOptions();
             }
         });
-        slider(context, panel, "fog start (m)", 0, 40000, DemoConfig.FOG_START_DISTANCE, false, new FloatSetting() {
+        slider(context, "fog start (m)", 0, 40000, DemoConfig.FOG_START_DISTANCE, false, new FloatSetting() {
             public void set(float value) { DemoConfig.FOG_START_DISTANCE = value; demo.terrainOptions.setFogStartDistance(value); }
         });
-        slider(context, panel, "fog distance (m, 0=off)", 0, 120000, DemoConfig.FOG_DISTANCE, false, new FloatSetting() {
+        slider(context, "fog distance (m, 0=off)", 0, 120000, DemoConfig.FOG_DISTANCE, false, new FloatSetting() {
             public void set(float value) { DemoConfig.FOG_DISTANCE = value < 500 ? 0 : value; demo.terrainOptions.setFogDistance(DemoConfig.FOG_DISTANCE); }
         });
         // How much of the SKY the same haze takes: the blend is the fade width, the horizon is the
         // angle it is still full at (below 0 on the slider = follow the terrain skyline).
-        slider(context, panel, "sky fog blend (deg)", 0, 45, DemoConfig.SKY_FOG_BLEND, false, new FloatSetting() {
+        slider(context, "sky fog blend (deg)", 0, 45, DemoConfig.SKY_FOG_BLEND, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SKY_FOG_BLEND = value; demo.skyOptions.setFogBlend(value); }
         });
-        slider(context, panel, "sky fog horizon (deg, <0=auto)", -1, 30, DemoConfig.SKY_FOG_HORIZON, false, new FloatSetting() {
+        slider(context, "sky fog horizon (deg, <0=auto)", -1, 30, DemoConfig.SKY_FOG_HORIZON, false, new FloatSetting() {
             public void set(float value) { DemoConfig.SKY_FOG_HORIZON = value; demo.skyOptions.setFogHorizon(value); }
         });
         // Changes the visible tile set, so apply on release only.
-        slider(context, panel, "tile LOD (x tangram, 0=finest)", 0, 4, DemoConfig.TILE_LOD_FACTOR, true, new FloatSetting() {
+        slider(context, "tile LOD (x tangram, 0=finest)", 0, 4, DemoConfig.TILE_LOD_FACTOR, true, new FloatSetting() {
             public void set(float value) { DemoConfig.TILE_LOD_FACTOR = value; demo.mapView.getOptions().setTileLODFactor(value); }
         });
-        slider(context, panel, "tile coarsening (levels)", 0, 6, DemoConfig.TERRAIN_MAX_TILE_ZOOM_COARSENING, true, new FloatSetting() {
+        slider(context, "tile coarsening (levels)", 0, 6, DemoConfig.TERRAIN_MAX_TILE_ZOOM_COARSENING, true, new FloatSetting() {
             public void set(float value) { DemoConfig.TERRAIN_MAX_TILE_ZOOM_COARSENING = (int) value; demo.terrainOptions.setMaxTileZoomCoarsening((int) value); }
         });
-        slider(context, panel, "view distance (x tangram, 0=all)", 0, 4, DemoConfig.VIEW_DISTANCE_FACTOR, true, new FloatSetting() {
+        slider(context, "view distance (x tangram, 0=all)", 0, 4, DemoConfig.VIEW_DISTANCE_FACTOR, true, new FloatSetting() {
             public void set(float value) { DemoConfig.VIEW_DISTANCE_FACTOR = value < 0.05f ? 0 : value; demo.terrainOptions.setViewDistanceFactor(DemoConfig.VIEW_DISTANCE_FACTOR); }
         });
     }
 
     /** One-shot actions: post-process effects and the routing / search / geometry test cases. */
-    private static void buildDebugSection(Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "DEBUG");
-        check(context, panel, "tile borders", DemoConfig.DEBUG_TILE_BORDERS, new BoolSetting() {
+    private static void buildDebugSection(Context context, final DemoMap demo) {
+        header(context, "DEBUG");
+        check(context, "tile borders", DemoConfig.DEBUG_TILE_BORDERS, new BoolSetting() {
             public void set(boolean value) { DemoConfig.DEBUG_TILE_BORDERS = value; demo.applyDebugConfig(); }
         });
     }
 
-    private static void buildActionsSection(final Context context, LinearLayout panel, final DemoMap demo) {
-        header(context, panel, "ACTIONS");
-        check(context, panel, "relief outline effect", DemoConfig.RELIEF_OUTLINE, new BoolSetting() {
+    private static void buildActionsSection(final Context context, final DemoMap demo) {
+        header(context, "ACTIONS");
+        check(context, "relief outline effect", DemoConfig.RELIEF_OUTLINE, new BoolSetting() {
             public void set(boolean value) { demo.setReliefOutlineEnabled(value); }
         });
         // The only way to trigger a two-finger gesture without fingers: in free roam 'fps' this
         // is the move, everywhere else the pan.
-        button(context, panel, "two-finger drag: forward", new Action() {
+        button(context, "two-finger drag: forward", new Action() {
             public void run() { DemoTests.runTwoFingerDrag(demo, 0, -500); }
         });
-        button(context, panel, "two-finger drag: strafe", new Action() {
+        button(context, "two-finger drag: strafe", new Action() {
             public void run() { DemoTests.runTwoFingerDrag(demo, 400, 0); }
         });
-        button(context, panel, "offline routing test", new Action() {
+        button(context, "offline routing test", new Action() {
             public void run() { DemoTests.runOfflineRouting(demo); }
         });
-        button(context, panel, "online routing test", new Action() {
+        button(context, "online routing test", new Action() {
             public void run() { DemoTests.runOnlineRouting(demo); }
         });
-        button(context, panel, "vector tile search test", new Action() {
+        button(context, "vector tile search test", new Action() {
             public void run() { DemoTests.runVectorTileSearch(demo); }
         });
-        button(context, panel, "geojson line test", new Action() {
+        button(context, "geojson line test", new Action() {
             public void run() { DemoTests.addGeoJSONLine(demo); }
         });
     }
 
     // =============================================================================================
     // WIDGET BUILDERS
+    // Every one of them registers a filterable row, and lands in the section the last header
+    // opened - which is what keeps adding a knob a one-line job.
     // =============================================================================================
 
-    private interface IntSetting { void set(int index); }
-
-    private static void header(Context context, LinearLayout panel, String label) {
-        TextView text = new TextView(context);
-        text.setText(label);
-        text.setTextColor(0xFF204060);
-        text.setPadding(0, 18, 0, 2);
-        text.setTypeface(null, Typeface.BOLD);
-        panel.addView(text);
+    private static int dp(float value) {
+        return Math.round(value * density);
     }
 
-    private static TextView label(Context context, LinearLayout panel, String value) {
+    private static GradientDrawable rounded(int color, float radiusDp) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setColor(color);
+        drawable.setCornerRadius(dp(radiusDp));
+        return drawable;
+    }
+
+    private static GradientDrawable roundedTop(int color, float radiusDp) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setColor(color);
+        float r = dp(radiusDp);
+        drawable.setCornerRadii(new float[] { r, r, r, r, 0, 0, 0, 0 });
+        return drawable;
+    }
+
+    /** Starts a new collapsible section. Opening one closes the others. */
+    private static void header(Context context, String name) {
+        LinearLayout container = new LinearLayout(context);
+        container.setOrientation(LinearLayout.VERTICAL);
+        container.setBackground(rounded(COLOR_SECTION, 12));
+
+        final TextView title = new TextView(context);
+        title.setText(name);
+        title.setTextColor(COLOR_TEXT);
+        title.setTextSize(13);
+        title.setTypeface(null, Typeface.BOLD);
+        title.setAllCaps(true);
+        title.setPadding(dp(14), dp(12), dp(14), dp(12));
+        container.addView(title);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(8), 0, dp(8), dp(8));
+        content.setVisibility(View.GONE);
+        container.addView(content);
+
+        final Section section = new Section(container, title, content, name);
+        sectionList.add(section);
+        title.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                boolean open = !section.expanded;
+                for (Section other : sectionList) {
+                    other.expanded = (other == section) && open;
+                    expand(other, other.expanded);
+                }
+            }
+        });
+        expand(section, false);
+
+        LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        lp.bottomMargin = dp(8);
+        sections.addView(container, lp);
+        currentContent = content;
+    }
+
+    private static void addRow(View view, String text) {
+        Section section = sectionList.isEmpty() ? null : sectionList.get(sectionList.size() - 1);
+        rows.add(new Row(view, text.toLowerCase(), section));
+        currentContent.addView(view, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+    }
+
+    private static TextView label(Context context, String value) {
         TextView text = new TextView(context);
         text.setText(value);
-        text.setTextSize(10);
-        panel.addView(text);
+        text.setTextSize(11);
+        text.setTextColor(COLOR_DIM);
+        text.setPadding(dp(6), dp(4), dp(6), dp(4));
+        addRow(text, value);
         return text;
     }
 
-    private static CheckBox check(Context context, LinearLayout panel, String label, boolean initial, final BoolSetting setting) {
+    private static CheckBox check(Context context, String label, boolean initial, final BoolSetting setting) {
         CheckBox box = new CheckBox(context);
         box.setText(label);
+        box.setTextColor(COLOR_TEXT);
+        box.setTextSize(14);
+        box.setPadding(dp(8), dp(6), dp(6), dp(6));
         box.setChecked(initial);
         box.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 setting.set(isChecked);
             }
         });
-        panel.addView(box);
+        addRow(box, label);
         return box;
     }
 
@@ -592,20 +873,27 @@ public final class DemoPanel {
      * contour generation) throw away every cached tile when they change, so applying them per
      * pixel of drag is a guaranteed stall.
      */
-    private static void slider(Context context, LinearLayout panel, final String label,
+    private static void slider(Context context, final String label,
                                float min, float max, float initial,
                                final boolean applyOnRelease, final FloatSetting setting) {
         final float lo = min, span = max - min;
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.VERTICAL);
+        row.setPadding(dp(8), dp(4), dp(8), dp(2));
+
         final TextView text = new TextView(context);
-        text.setText(String.format("%s %.2f%s", label, initial, applyOnRelease ? " (release)" : ""));
-        panel.addView(text);
+        text.setTextColor(COLOR_DIM);
+        text.setTextSize(12);
+        text.setText(String.format("%s  %.2f%s", label, initial, applyOnRelease ? "  (release)" : ""));
+        row.addView(text);
+
         SeekBar seek = new SeekBar(context);
         seek.setMax(1000);
         seek.setProgress((int) ((initial - lo) / span * 1000));
         seek.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             private float valueOf(SeekBar bar) { return lo + span * bar.getProgress() / 1000.0f; }
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-                text.setText(String.format("%s %.2f%s", label, valueOf(seekBar), applyOnRelease ? " (release)" : ""));
+                text.setText(String.format("%s  %.2f%s", label, valueOf(seekBar), applyOnRelease ? "  (release)" : ""));
                 if (!applyOnRelease) {
                     setting.set(valueOf(seekBar));
                 }
@@ -615,26 +903,35 @@ public final class DemoPanel {
                 setting.set(valueOf(seekBar));
             }
         });
-        panel.addView(seek, new LinearLayout.LayoutParams(760, ViewGroup.LayoutParams.WRAP_CONTENT));
+        row.addView(seek, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        addRow(row, label);
     }
 
     /** A row of small buttons acting as a radio group (no spinner: less code, easier to read). */
-    private static void choice(Context context, LinearLayout panel, String label,
+    private static void choice(Context context, String label,
                                final String[] options, int initial, final IntSetting setting) {
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.VERTICAL);
+        row.setPadding(dp(8), dp(4), dp(8), dp(4));
+
         TextView text = new TextView(context);
         text.setText(label);
-        panel.addView(text);
+        text.setTextColor(COLOR_DIM);
+        text.setTextSize(12);
+        row.addView(text);
 
-        final LinearLayout row = new LinearLayout(context);
-        row.setOrientation(LinearLayout.HORIZONTAL);
+        final LinearLayout buttonRow = new LinearLayout(context);
+        buttonRow.setOrientation(LinearLayout.HORIZONTAL);
         final Button[] buttons = new Button[options.length];
         for (int i = 0; i < options.length; i++) {
             final int index = i;
             Button button = new Button(context);
             button.setText(options[i]);
-            button.setTextSize(9);
-            button.setPadding(2, 2, 2, 2);
+            button.setTextSize(11);
             button.setAllCaps(false);
+            button.setPadding(dp(2), 0, dp(2), 0);
+            button.setBackground(rounded(0x33FFFFFF, 8));
+            button.setTextColor(COLOR_TEXT);
             button.setOnClickListener(new View.OnClickListener() {
                 public void onClick(View v) {
                     setting.set(index);
@@ -642,27 +939,49 @@ public final class DemoPanel {
                 }
             });
             buttons[i] = button;
-            row.addView(button, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+            LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(0, dp(36), 1f);
+            lp.rightMargin = dp(4);
+            buttonRow.addView(button, lp);
         }
         highlight(buttons, initial);
-        panel.addView(row);
+        row.addView(buttonRow);
+        addRow(row, label + " " + join(options));
+    }
+
+    private static String join(String[] values) {
+        StringBuilder builder = new StringBuilder();
+        for (String value : values) {
+            builder.append(value).append(' ');
+        }
+        return builder.toString();
     }
 
     private static void highlight(Button[] buttons, int selected) {
         for (int i = 0; i < buttons.length; i++) {
             buttons[i].setTypeface(null, i == selected ? Typeface.BOLD : Typeface.NORMAL);
-            buttons[i].setAlpha(i == selected ? 1f : 0.55f);
+            buttons[i].setAlpha(i == selected ? 1f : 0.5f);
+            buttons[i].setBackground(rounded(i == selected ? 0x5535D6C0 : 0x33FFFFFF, 8));
         }
     }
 
-    private static void button(Context context, LinearLayout panel, String label, final Action action) {
+    private static void button(Context context, String label, final Action action) {
         Button button = new Button(context);
         button.setText(label);
         button.setAllCaps(false);
+        button.setTextSize(13);
+        button.setTextColor(COLOR_TEXT);
+        button.setBackground(rounded(0x33FFFFFF, 10));
+        LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, dp(42));
+        lp.topMargin = dp(4);
+        lp.leftMargin = dp(8);
+        lp.rightMargin = dp(8);
         button.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) { action.run(); }
         });
-        panel.addView(button);
+        Section section = sectionList.isEmpty() ? null : sectionList.get(sectionList.size() - 1);
+        rows.add(new Row(button, label.toLowerCase(), section));
+        currentContent.addView(button, lp);
     }
 
     private static String[] enumNames(Enum<?>[] values) {

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStarCatalogue.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStarCatalogue.java
@@ -1,0 +1,313 @@
+package com.akylas.cartotest.demo;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The bright-star catalogue and the constellation figures the star demo draws.
+ *
+ * DATA, not code. Positions are J2000 right ascension (hours) and declination (degrees) with the
+ * visual magnitude, for every star down to about magnitude 3 plus the fainter ones a figure needs.
+ * Precession from J2000 to today is about a third of a degree and is not applied - a star is drawn
+ * a few pixels across, so it does not show.
+ *
+ * A figure is a list of segments between star NAMES: a typo is then a missing line and a log
+ * warning rather than a silently wrong sky.
+ */
+public final class DemoStarCatalogue {
+
+    private DemoStarCatalogue() {
+    }
+
+    /** name | right ascension (hours) | declination (degrees) | visual magnitude */
+    public static final String[] STARS = {
+        // --- brightest, all sky -----------------------------------------------------------------
+        "Sirius|6.7525|-16.7161|-1.46",
+        "Canopus|6.3992|-52.6957|-0.72",
+        "Rigil Kentaurus|14.6600|-60.8339|-0.27",
+        "Arcturus|14.2610|19.1825|-0.05",
+        "Vega|18.6156|38.7837|0.03",
+        "Capella|5.2782|45.9980|0.08",
+        "Rigel|5.2423|-8.2016|0.13",
+        "Procyon|7.6551|5.2250|0.34",
+        "Achernar|1.6286|-57.2367|0.46",
+        "Betelgeuse|5.9195|7.4071|0.50",
+        "Hadar|14.0637|-60.3730|0.61",
+        "Altair|19.8464|8.8683|0.77",
+        "Acrux|12.4433|-63.0991|0.77",
+        "Aldebaran|4.5987|16.5093|0.85",
+        "Spica|13.4199|-11.1613|1.04",
+        "Antares|16.4901|-26.4320|1.09",
+        "Pollux|7.7553|28.0262|1.14",
+        "Fomalhaut|22.9608|-29.6222|1.16",
+        "Deneb|20.6905|45.2803|1.25",
+        "Mimosa|12.7952|-59.6888|1.25",
+        "Regulus|10.1395|11.9672|1.35",
+        "Adhara|6.9771|-28.9720|1.50",
+        "Castor|7.5766|31.8883|1.58",
+        "Shaula|17.5601|-37.1038|1.62",
+        "Gacrux|12.5194|-57.1133|1.63",
+        "Bellatrix|5.4185|6.3497|1.64",
+        "Elnath|5.4381|28.6075|1.65",
+        "Miaplacidus|9.2200|-69.7172|1.67",
+        "Alnilam|5.6036|-1.2019|1.69",
+        "Alnair|22.1372|-46.9611|1.74",
+        "Alnitak|5.6793|-1.9426|1.77",
+        "Alioth|12.9005|55.9598|1.77",
+        "Dubhe|11.0622|61.7510|1.79",
+        "Mirfak|3.4054|49.8612|1.79",
+        "Wezen|7.1399|-26.3932|1.83",
+        "Regor|8.1589|-47.3367|1.83",
+        "Kaus Australis|18.4029|-34.3846|1.85",
+        "Alkaid|13.7923|49.3133|1.86",
+        "Sargas|17.6220|-42.9978|1.86",
+        "Avior|8.3752|-59.5095|1.86",
+        "Menkalinan|5.9922|44.9474|1.90",
+        "Atria|16.8111|-69.0277|1.91",
+        "Alhena|6.6285|16.3993|1.93",
+        "Peacock|20.4275|-56.7351|1.94",
+        "Alsephina|8.7451|-54.7085|1.96",
+        "Mirzam|6.3783|-17.9559|1.98",
+        "Polaris|2.5303|89.2641|1.98",
+        "Alphard|9.4597|-8.6586|1.99",
+        "Hamal|2.1195|23.4624|2.00",
+        "Deneb Kaitos|0.7265|-17.9866|2.04",
+        "Nunki|18.9211|-26.2967|2.05",
+        "Mirach|1.1622|35.6206|2.05",
+        "Alpheratz|0.1398|29.0904|2.06",
+        "Menkent|14.1114|-36.3697|2.06",
+        "Saiph|5.7959|-9.6697|2.09",
+        "Kochab|14.8451|74.1555|2.08",
+        "Rasalhague|17.5822|12.5600|2.08",
+        "Algieba|10.3329|19.8415|2.08",
+        "Algol|3.1361|40.9556|2.09",
+        "Almach|2.0650|42.3297|2.10",
+        "Denebola|11.8177|14.5720|2.14",
+        "Muhlifain|12.6919|-48.9597|2.20",
+        "Naos|8.0597|-40.0033|2.21",
+        "Aspidiske|9.2848|-59.2753|2.21",
+        "Alphecca|15.5781|26.7147|2.22",
+        "Suhail|9.1333|-43.4326|2.23",
+        "Sadr|20.3705|40.2567|2.23",
+        "Mizar|13.3987|54.9254|2.23",
+        "Eltanin|17.9435|51.4889|2.23",
+        "Schedar|0.6751|56.5375|2.24",
+        "Mintaka|5.5334|-0.2991|2.25",
+        "Caph|0.1530|59.1498|2.28",
+        "Larawag|16.8361|-34.2933|2.29",
+        "Dschubba|16.0056|-22.6217|2.29",
+        "Epsilon Centauri|13.6648|-53.4664|2.30",
+        "Eta Centauri|14.5918|-42.1578|2.31",
+        "Kakkab|14.6988|-47.3881|2.30",
+        "Merak|11.0307|56.3824|2.37",
+        "Izar|14.7498|27.0742|2.37",
+        "Enif|21.7364|9.8750|2.39",
+        "Ankaa|0.4381|-42.3061|2.40",
+        "Girtab|17.7081|-39.0300|2.41",
+        "Scheat|23.0629|28.0828|2.42",
+        "Sabik|17.1730|-15.7250|2.43",
+        "Phecda|11.8972|53.6948|2.44",
+        "Alderamin|21.3096|62.5856|2.45",
+        "Aludra|7.4016|-29.3031|2.45",
+        "Navi|0.9451|60.7167|2.47",
+        "Markeb|9.3685|-55.0108|2.47",
+        "Aljanah|20.7702|33.9703|2.48",
+        "Markab|23.0793|15.2053|2.49",
+        "Menkar|3.0380|4.0897|2.53",
+        "Zosma|11.2351|20.5237|2.56",
+        "Zeta Ophiuchi|16.6193|-10.5672|2.56",
+        "Acrab|16.0906|-19.8056|2.56",
+        "Arneb|5.5455|-17.8222|2.58",
+        "Ascella|19.0435|-29.8803|2.60",
+        "Zubeneschamali|15.2834|-9.3829|2.61",
+        "Theta Aurigae|5.9954|37.2125|2.62",
+        "Unukalhai|15.7378|6.4256|2.63",
+        "Sheratan|1.9107|20.8081|2.64",
+        "Muphrid|13.9114|18.3978|2.68",
+        "Hassaleh|4.9499|33.1661|2.69",
+        "Lesath|17.5127|-37.2958|2.69",
+        "Delta Crucis|12.2524|-58.7489|2.79",
+        "Tarazed|19.7710|10.6133|2.72",
+        "Yed Prior|16.2391|-3.6942|2.73",
+        "Porrima|12.6944|-1.4494|2.74",
+        "Zubenelgenubi|14.8480|-16.0417|2.75",
+        "Cebalrai|17.7246|4.5672|2.76",
+        "Hatysa|5.5906|-5.9100|2.77",
+        "Rastaban|17.5072|52.3014|2.79",
+        "Nihal|5.4707|-20.7594|2.81",
+        "Kaus Borealis|18.4662|-25.4217|2.81",
+        "Tau Scorpii|16.5981|-28.2161|2.82",
+        "Vindemiatrix|13.0363|10.9592|2.83",
+        "Algenib|0.2206|15.1836|2.83",
+        "Zeta Persei|3.9022|31.8836|2.85",
+        "Tejat|6.3827|22.5136|2.87",
+        "Alcyone|3.7914|24.1053|2.87",
+        "Delta Cygni|19.7496|45.1308|2.87",
+        "Pi Scorpii|15.9809|-26.1142|2.89",
+        "Gomeisa|7.4525|8.2894|2.89",
+        "Epsilon Persei|3.9642|40.0103|2.90",
+        "Gamma Persei|3.0799|53.5064|2.93",
+        "Matar|22.7167|30.2214|2.94",
+        "Mebsuta|6.7322|25.1311|2.98",
+        "Epsilon Leonis|9.7642|23.7742|2.98",
+        "Alnasl|18.0968|-30.4242|2.99",
+        "Zeta Aquilae|19.0902|13.8633|2.99",
+        "Mu Scorpii|16.8644|-38.0475|3.00",
+        "Zeta Tauri|5.6274|21.1425|3.00",
+        "Gamma Hydrae|13.3153|-23.1714|3.00",
+        "Delta Persei|3.7154|47.7875|3.01",
+        "Epsilon Aurigae|5.0328|43.8233|3.03",
+        "Seginus|14.5346|38.3083|3.03",
+        "Iota Scorpii|17.7931|-40.1269|3.03",
+        "Pherkad|15.3455|71.8339|3.05",
+        "Albireo|19.5121|27.9597|3.05",
+        "Delta Draconis|19.2093|67.6617|3.07",
+        "Ruchbah|1.4304|60.2353|2.68",
+        "Zeta Draconis|17.1465|65.7147|3.17",
+        "Phi Sagittarii|18.7609|-26.9908|3.17",
+        "Pi3 Orionis|4.8307|6.9614|3.19",
+        "Errai|23.6558|77.6325|3.21",
+        "Alfirk|21.4777|70.5608|3.23",
+        "Sulafat|18.9824|32.6894|3.24",
+        "Yed Posterior|16.3054|-4.6925|3.24",
+        "Kaus Media|18.3499|-29.8281|2.70",
+        "Theta Aquilae|20.1884|-0.8214|3.24",
+        "Eta Geminorum|6.2480|22.5067|3.28",
+        "Sigma Librae|15.0678|-25.2819|3.29",
+        "Megrez|12.2571|57.0326|3.31",
+        "Chertan|11.2373|15.4297|3.32",
+        "Tau Sagittarii|19.1157|-27.6706|3.32",
+        "Delta Aquilae|19.4250|3.1147|3.36",
+        "Xi Geminorum|6.7548|12.8956|3.36",
+        "Epsilon Cassiopeiae|1.9066|63.6700|3.37",
+        "Zeta Virginis|13.5782|-0.5958|3.38",
+        "Delta Virginis|12.9267|3.3975|3.38",
+        "Meissa|5.5856|9.9342|3.39",
+        "Theta2 Tauri|4.4777|15.8708|3.40",
+        "Homam|22.6910|10.8314|3.40",
+        "Adhafera|10.2782|23.4172|3.44",
+        "Delta Bootis|15.2584|33.3147|3.47",
+        "Gamma Ceti|2.7217|3.2358|3.47",
+        "Nekkar|15.0324|40.3906|3.49",
+        "Eta Leonis|10.1222|16.7628|3.51",
+        "Sheliak|18.8347|33.3628|3.52",
+        "Wasat|7.3354|21.9822|3.53",
+        "Ain|4.4769|19.1806|3.53",
+        "Hyadum I|4.3299|15.6278|3.65",
+        "Thuban|14.0732|64.3758|3.65",
+        "Nusakan|15.4638|29.1058|3.66",
+        "Alshain|19.9219|6.4067|3.71",
+        "Delta Tauri|4.3822|17.5425|3.76",
+        "Mekbuda|7.0685|20.5703|3.79",
+        "Delta Andromedae|0.6555|30.8611|3.27",
+        "Rasalas|9.8794|26.0069|3.88",
+        "Epsilon Ursae Minoris|16.7661|82.0372|4.21",
+        "Zeta Ursae Minoris|15.7343|77.7944|4.32",
+        "Delta Ursae Minoris|17.5369|86.5864|4.36",
+        "Eta Ursae Minoris|16.2918|75.7553|4.95",
+        "Pi Puppis|7.2857|-37.0975|2.71",
+    };
+
+    /**
+     * The figures, as segments between star names. These are the common stick figures, kept to the
+     * stars above - a few well known ones (Ursa Major's plough, Orion, the Southern Cross) rather
+     * than all 88 boundaries, which is what makes a sky readable at a glance.
+     */
+    public static Map<String, String[][]> figures() {
+        Map<String, String[][]> figures = new LinkedHashMap<String, String[][]>();
+        figures.put("Orion", segments(
+            "Betelgeuse", "Bellatrix", "Bellatrix", "Mintaka", "Mintaka", "Alnilam", "Alnilam", "Alnitak",
+            "Alnitak", "Betelgeuse", "Mintaka", "Rigel", "Alnitak", "Saiph", "Rigel", "Saiph",
+            "Betelgeuse", "Meissa", "Meissa", "Bellatrix", "Alnilam", "Hatysa"));
+        figures.put("Ursa Major", segments(
+            "Alkaid", "Mizar", "Mizar", "Alioth", "Alioth", "Megrez", "Megrez", "Phecda",
+            "Phecda", "Merak", "Merak", "Dubhe", "Dubhe", "Megrez"));
+        figures.put("Ursa Minor", segments(
+            "Polaris", "Delta Ursae Minoris", "Delta Ursae Minoris", "Epsilon Ursae Minoris",
+            "Epsilon Ursae Minoris", "Zeta Ursae Minoris", "Zeta Ursae Minoris", "Kochab",
+            "Kochab", "Pherkad", "Pherkad", "Eta Ursae Minoris", "Eta Ursae Minoris", "Zeta Ursae Minoris"));
+        figures.put("Cassiopeia", segments(
+            "Caph", "Schedar", "Schedar", "Navi", "Navi", "Ruchbah", "Ruchbah", "Epsilon Cassiopeiae"));
+        figures.put("Cygnus", segments(
+            "Deneb", "Sadr", "Sadr", "Albireo", "Aljanah", "Sadr", "Sadr", "Delta Cygni"));
+        figures.put("Lyra", segments(
+            "Vega", "Sheliak", "Sheliak", "Sulafat", "Sulafat", "Vega"));
+        figures.put("Aquila", segments(
+            "Tarazed", "Altair", "Altair", "Alshain", "Tarazed", "Zeta Aquilae",
+            "Altair", "Delta Aquilae", "Delta Aquilae", "Theta Aquilae"));
+        figures.put("Scorpius", segments(
+            "Dschubba", "Acrab", "Dschubba", "Pi Scorpii", "Dschubba", "Antares", "Antares", "Tau Scorpii",
+            "Tau Scorpii", "Larawag", "Larawag", "Mu Scorpii", "Mu Scorpii", "Sargas", "Sargas", "Iota Scorpii",
+            "Iota Scorpii", "Girtab", "Girtab", "Shaula", "Shaula", "Lesath"));
+        figures.put("Sagittarius", segments(
+            "Alnasl", "Kaus Media", "Kaus Australis", "Kaus Media", "Kaus Media", "Kaus Borealis",
+            "Kaus Borealis", "Nunki", "Nunki", "Ascella", "Ascella", "Kaus Australis",
+            "Nunki", "Tau Sagittarii", "Tau Sagittarii", "Phi Sagittarii", "Phi Sagittarii", "Kaus Borealis"));
+        figures.put("Leo", segments(
+            "Regulus", "Eta Leonis", "Eta Leonis", "Algieba", "Algieba", "Adhafera", "Adhafera", "Rasalas",
+            "Rasalas", "Epsilon Leonis", "Algieba", "Zosma", "Zosma", "Denebola", "Denebola", "Chertan",
+            "Chertan", "Regulus"));
+        figures.put("Taurus", segments(
+            "Elnath", "Ain", "Ain", "Aldebaran", "Aldebaran", "Theta2 Tauri", "Theta2 Tauri", "Hyadum I",
+            "Aldebaran", "Delta Tauri", "Zeta Tauri", "Aldebaran"));
+        figures.put("Gemini", segments(
+            "Castor", "Pollux", "Castor", "Mebsuta", "Mebsuta", "Tejat", "Tejat", "Eta Geminorum",
+            "Pollux", "Wasat", "Wasat", "Mekbuda", "Mekbuda", "Alhena", "Wasat", "Xi Geminorum"));
+        figures.put("Canis Major", segments(
+            "Mirzam", "Sirius", "Sirius", "Wezen", "Wezen", "Adhara", "Adhara", "Mirzam",
+            "Wezen", "Aludra"));
+        figures.put("Bootes", segments(
+            "Arcturus", "Izar", "Izar", "Seginus", "Seginus", "Nekkar", "Nekkar", "Delta Bootis",
+            "Delta Bootis", "Izar", "Arcturus", "Muphrid"));
+        figures.put("Crux", segments(
+            "Acrux", "Gacrux", "Mimosa", "Delta Crucis"));
+        figures.put("Centaurus", segments(
+            "Rigil Kentaurus", "Hadar", "Hadar", "Epsilon Centauri", "Epsilon Centauri", "Muhlifain",
+            "Muhlifain", "Menkent", "Menkent", "Eta Centauri", "Eta Centauri", "Hadar"));
+        figures.put("Pegasus", segments(
+            "Markab", "Scheat", "Scheat", "Alpheratz", "Alpheratz", "Algenib", "Algenib", "Markab",
+            "Markab", "Homam", "Scheat", "Matar", "Homam", "Enif"));
+        figures.put("Andromeda", segments(
+            "Alpheratz", "Delta Andromedae", "Delta Andromedae", "Mirach", "Mirach", "Almach"));
+        figures.put("Auriga", segments(
+            "Capella", "Menkalinan", "Menkalinan", "Theta Aurigae", "Theta Aurigae", "Elnath",
+            "Elnath", "Hassaleh", "Hassaleh", "Epsilon Aurigae", "Epsilon Aurigae", "Capella"));
+        figures.put("Perseus", segments(
+            "Mirfak", "Algol", "Algol", "Zeta Persei", "Mirfak", "Delta Persei", "Delta Persei", "Epsilon Persei",
+            "Mirfak", "Gamma Persei"));
+        figures.put("Virgo", segments(
+            "Spica", "Zeta Virginis", "Zeta Virginis", "Porrima", "Porrima", "Delta Virginis",
+            "Delta Virginis", "Vindemiatrix"));
+        figures.put("Aries", segments(
+            "Hamal", "Sheratan"));
+        figures.put("Cepheus", segments(
+            "Alderamin", "Alfirk", "Alfirk", "Errai", "Errai", "Alderamin"));
+        figures.put("Draco", segments(
+            "Eltanin", "Rastaban", "Rastaban", "Zeta Draconis", "Zeta Draconis", "Delta Draconis",
+            "Delta Draconis", "Thuban"));
+        figures.put("Corona Borealis", segments(
+            "Alphecca", "Nusakan"));
+        figures.put("Canis Minor", segments(
+            "Procyon", "Gomeisa"));
+        figures.put("Ophiuchus", segments(
+            "Rasalhague", "Cebalrai", "Cebalrai", "Sabik", "Sabik", "Zeta Ophiuchi",
+            "Zeta Ophiuchi", "Yed Prior", "Yed Prior", "Yed Posterior", "Yed Prior", "Rasalhague"));
+        figures.put("Libra", segments(
+            "Zubeneschamali", "Zubenelgenubi", "Zubenelgenubi", "Sigma Librae", "Sigma Librae", "Zubeneschamali"));
+        figures.put("Carina", segments(
+            "Canopus", "Avior", "Avior", "Aspidiske", "Aspidiske", "Miaplacidus"));
+        figures.put("Vela", segments(
+            "Regor", "Markeb", "Markeb", "Alsephina", "Alsephina", "Suhail", "Suhail", "Regor"));
+        return figures;
+    }
+
+    /** Pairs of names, in order, into a segment list. */
+    private static String[][] segments(String... names) {
+        String[][] result = new String[names.length / 2][2];
+        for (int i = 0; i + 1 < names.length; i += 2) {
+            result[i / 2][0] = names[i];
+            result[i / 2][1] = names[i + 1];
+        }
+        return result;
+    }
+}

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStars.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStars.java
@@ -1,5 +1,9 @@
 package com.akylas.cartotest.demo;
 
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.Typeface;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -39,6 +43,7 @@ public final class DemoStars {
     private final List<CelestialSprite> stars = new ArrayList<CelestialSprite>();
     private final List<double[]> starEquatorial = new ArrayList<double[]>();   // { ra degrees, dec }
     private final List<CelestialArc> figures = new ArrayList<CelestialArc>();
+    private final List<CelestialSprite> figureLabels = new ArrayList<CelestialSprite>();
     private final List<double[][]> figureEquatorial = new ArrayList<double[][]>(); // per segment { ra, dec, ra, dec }
     private final List<CelestialSprite> planets = new ArrayList<CelestialSprite>();
     private CelestialArc equator;
@@ -100,6 +105,24 @@ public final class DemoStars {
             layer.add(arc);
             figures.add(arc);
             figureEquatorial.add(segments.toArray(new double[segments.size()][]));
+
+            // The name, IN THE SKY, at the middle of the figure. It is a plain sprite with a
+            // bitmap the demo paints - the SDK has no text of its own here, which is exactly what
+            // makes it themeable from the app: change the paint, change the label.
+            CelestialSprite label = new CelestialSprite();
+            com.carto.graphics.Bitmap labelBitmap = textBitmap(figure.getKey(), density);
+            label.setBitmap(labelBitmap);
+            // The bitmap is square and the text fills its width, so drawing the quad at the
+            // bitmap's own pixel size renders the text at the size it was painted - the same for
+            // every name. A fixed quad size would shrink the long ones instead.
+            label.setScreenSize(labelBitmap.getWidth() * DemoConfig.STARS_LABEL_SCALE);
+            label.setColor(new Color((short) 255, (short) 255, (short) 255,
+                    (short) Math.round(255 * DemoConfig.STARS_LABEL_OPACITY)));
+            label.setClickRadius(0f); // the figure itself is the clickable thing
+            label.setMetaDataElement(META_NAME, new Variant(figure.getKey()));
+            label.setMetaDataElement(META_INFO, new Variant(""));
+            layer.add(label);
+            figureLabels.add(label);
         }
 
         for (String name : DemoAstro.PLANET_NAMES) {
@@ -181,6 +204,26 @@ public final class DemoStars {
             }
             figures.get(i).setSegments(directions);
             figures.get(i).setVisible(DemoConfig.STARS_FIGURES);
+
+            // The label goes at the MEAN DIRECTION of the figure, averaged as vectors: averaging
+            // azimuths would put a figure straddling north somewhere near south.
+            double x = 0, y = 0, z = 0;
+            for (int k = 0; k + 1 < directions.size(); k += 2) {
+                double az = Math.toRadians(directions.get(k)), alt = Math.toRadians(directions.get(k + 1));
+                x += Math.cos(alt) * Math.sin(az);
+                y += Math.cos(alt) * Math.cos(az);
+                z += Math.sin(alt);
+            }
+            CelestialSprite label = figureLabels.get(i);
+            double length = Math.sqrt(x * x + y * y + z * z);
+            if (length > 0) {
+                double altitude = Math.toDegrees(Math.asin(z / length));
+                double azimuth = DemoAstro.normalizeDegrees(Math.toDegrees(Math.atan2(x, y)));
+                label.setDirection((float) azimuth, (float) altitude, 0);
+                label.setVisible(DemoConfig.STARS_FIGURES && DemoConfig.STARS_LABELS && altitude > 0);
+            } else {
+                label.setVisible(false);
+            }
         }
 
         for (int i = 0; i < planets.size(); i++) {
@@ -194,6 +237,33 @@ public final class DemoStars {
         // equator) at an altitude equal to the latitude.
         equator.setCircle(lat >= 0 ? 0f : 180f, (float) Math.abs(lat), 90f);
         equator.setVisible(DemoConfig.STARS_EQUATOR);
+    }
+
+    /**
+     * The name painted into a square bitmap, which is what a celestial sprite draws. Square
+     * because the sprite quad is: the text is centred in it and the transparent margin costs
+     * nothing but texture.
+     */
+    private static com.carto.graphics.Bitmap textBitmap(String text, float density) {
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        paint.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD));
+        paint.setTextSize(DemoConfig.STARS_LABEL_TEXT_SIZE * density);
+        paint.setColor(0xFFFFFFFF);
+        Rect bounds = new Rect();
+        paint.getTextBounds(text, 0, text.length(), bounds);
+        int side = Math.max(16, Math.max(bounds.width(), bounds.height()) + Math.round(8 * density));
+        android.graphics.Bitmap bitmap = android.graphics.Bitmap.createBitmap(side, side, android.graphics.Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        // A dark outline, so a name stays readable over a bright sky as well as over black.
+        Paint outline = new Paint(paint);
+        outline.setStyle(Paint.Style.STROKE);
+        outline.setStrokeWidth(3 * density);
+        outline.setColor(0xC0000000);
+        float x = side * 0.5f - bounds.exactCenterX();
+        float y = side * 0.5f - bounds.exactCenterY();
+        canvas.drawText(text, x, y, outline);
+        canvas.drawText(text, x, y, paint);
+        return com.carto.utils.BitmapUtils.createBitmapFromAndroidBitmap(bitmap);
     }
 
     /** A star of this magnitude, in screen pixels. */

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStars.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStars.java
@@ -1,0 +1,220 @@
+package com.akylas.cartotest.demo;
+
+import android.util.Log;
+import android.widget.Toast;
+
+import com.carto.celestial.CelestialArc;
+import com.carto.celestial.CelestialObject;
+import com.carto.celestial.CelestialSprite;
+import com.carto.core.DoubleVector;
+import com.carto.core.Variant;
+import com.carto.graphics.Color;
+import com.carto.layers.CelestialEventListener;
+import com.carto.layers.CelestialLayer;
+import com.carto.ui.ClickInfo;
+import com.carto.ui.MapView;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The star demo: the real sky over the demo's position, right now.
+ *
+ * Every star is a {@link CelestialSprite} and every constellation figure is one {@link CelestialArc}
+ * in segment mode, so the whole catalogue is ONE draw call for the stars plus one per figure, and
+ * both are clickable. The planets are sprites too - the API does not know what any of them are.
+ *
+ * The astronomy is in {@link DemoAstro} and the data in {@link DemoStarCatalogue}; this file is the
+ * mapping onto the SDK.
+ */
+public final class DemoStars {
+
+    private static final String TAG = "DemoStars";
+    private static final String META_NAME = "name";
+    private static final String META_INFO = "info";
+
+    private CelestialLayer layer;
+    private final List<CelestialSprite> stars = new ArrayList<CelestialSprite>();
+    private final List<double[]> starEquatorial = new ArrayList<double[]>();   // { ra degrees, dec }
+    private final List<CelestialArc> figures = new ArrayList<CelestialArc>();
+    private final List<double[][]> figureEquatorial = new ArrayList<double[][]>(); // per segment { ra, dec, ra, dec }
+    private final List<CelestialSprite> planets = new ArrayList<CelestialSprite>();
+    private CelestialArc equator;
+
+    /** Builds the layer: stars, constellation figures, planets. Positions come from {@link #update}. */
+    public CelestialLayer createLayer(final MapView mapView) {
+        layer = new CelestialLayer();
+        // The catalogue sizes are in pixels at 160 dpi, the unit the rest of the demo uses.
+        final float density = mapView.getContext().getResources().getDisplayMetrics().density;
+
+        Map<String, double[]> byName = new HashMap<String, double[]>();
+        for (String entry : DemoStarCatalogue.STARS) {
+            String[] parts = entry.split("\\|");
+            if (parts.length != 4) {
+                Log.w(TAG, "bad catalogue entry: " + entry);
+                continue;
+            }
+            String name = parts[0];
+            double raDegrees = Double.parseDouble(parts[1]) * 15.0;
+            double declination = Double.parseDouble(parts[2]);
+            double magnitude = Double.parseDouble(parts[3]);
+            byName.put(name, new double[] { raDegrees, declination });
+
+            CelestialSprite star = new CelestialSprite();
+            // Brighter is bigger, the way a star chart draws them: a magnitude step is a factor of
+            // 2.5 in brightness, but on screen a linear size ramp reads better than the real one.
+            star.setScreenSize((float) magnitudeToPixels(magnitude) * density);
+            star.setColor(new Color((short) 255, (short) 255, (short) 250, (short) 255));
+            star.setSoftness(0.45f);
+            star.setClickRadius(1.5f);
+            star.setMetaDataElement(META_NAME, new Variant(name));
+            star.setMetaDataElement(META_INFO, new Variant("mag " + magnitude));
+            layer.add(star);
+            stars.add(star);
+            starEquatorial.add(new double[] { raDegrees, declination });
+        }
+
+        for (Map.Entry<String, String[][]> figure : DemoStarCatalogue.figures().entrySet()) {
+            List<double[]> segments = new ArrayList<double[]>();
+            for (String[] segment : figure.getValue()) {
+                double[] from = byName.get(segment[0]);
+                double[] to = byName.get(segment[1]);
+                if (from == null || to == null) {
+                    Log.w(TAG, figure.getKey() + ": no such star " + (from == null ? segment[0] : segment[1]));
+                    continue;
+                }
+                segments.add(new double[] { from[0], from[1], to[0], to[1] });
+            }
+            if (segments.isEmpty()) {
+                continue;
+            }
+            CelestialArc arc = new CelestialArc();
+            arc.setColor(new Color((short) 120, (short) 170, (short) 255, (short) 110));
+            arc.setWidth(DemoConfig.STARS_FIGURE_WIDTH * density);
+            arc.setBelowHorizonVisible(false);
+            arc.setClickRadius(DemoConfig.STARS_FIGURE_CLICK_RADIUS);
+            arc.setMetaDataElement(META_NAME, new Variant(figure.getKey()));
+            arc.setMetaDataElement(META_INFO, new Variant(segments.size() + " lines"));
+            layer.add(arc);
+            figures.add(arc);
+            figureEquatorial.add(segments.toArray(new double[segments.size()][]));
+        }
+
+        for (String name : DemoAstro.PLANET_NAMES) {
+            CelestialSprite planet = new CelestialSprite();
+            planet.setAngularSize(DemoConfig.STARS_PLANET_SIZE);
+            planet.setColor(planetColor(name));
+            planet.setSoftness(0.4f);
+            planet.setClickRadius(2.5f);
+            planet.setMetaDataElement(META_NAME, new Variant(name));
+            planet.setMetaDataElement(META_INFO, new Variant("planet"));
+            layer.add(planet);
+            planets.add(planet);
+        }
+
+        // The celestial equator: the one line that makes the sky's rotation readable, and a circle
+        // about the pole like the sun's daily path - the same object, radius 90 degrees.
+        equator = new CelestialArc();
+        equator.setColor(new Color((short) 90, (short) 200, (short) 190, (short) 90));
+        equator.setWidth(1.5f);
+        equator.setBelowHorizonVisible(false);
+        equator.setClickRadius(1.5f);
+        equator.setMetaDataElement(META_NAME, new Variant("Celestial equator"));
+        equator.setMetaDataElement(META_INFO, new Variant("declination 0"));
+        layer.add(equator);
+
+        layer.setCelestialEventListener(new CelestialEventListener() {
+            @Override
+            public boolean onCelestialObjectClicked(ClickInfo clickInfo, CelestialObject object) {
+                StringBuilder message = new StringBuilder(object.getMetaDataElement(META_NAME).getString());
+                String info = object.getMetaDataElement(META_INFO).getString();
+                if (info != null && info.length() > 0) {
+                    message.append("  ").append(info);
+                }
+                if (object instanceof CelestialSprite) {
+                    // Only a sprite HAS one direction - a curve is a set of them.
+                    message.append("   az ").append(Math.round(object.getAzimuth()))
+                           .append("° alt ").append(Math.round(object.getAltitude())).append("°");
+                }
+                final String text = message.toString();
+                Log.i(TAG, "clicked " + text);
+                mapView.post(new Runnable() {
+                    public void run() {
+                        Toast.makeText(mapView.getContext(), text, Toast.LENGTH_SHORT).show();
+                    }
+                });
+                return true;
+            }
+        });
+        return layer;
+    }
+
+    /**
+     * Places everything for a date and a position: the whole catalogue turned into the horizon
+     * frame. This is what the sky really looks like from there at that moment.
+     */
+    public void update(double n, double lat, double lon) {
+        if (layer == null) {
+            return;
+        }
+        for (int i = 0; i < stars.size(); i++) {
+            double[] eq = starEquatorial.get(i);
+            double[] horizon = DemoAstro.toHorizon(eq[0], eq[1], n, lat, lon);
+            CelestialSprite star = stars.get(i);
+            star.setDirection((float) horizon[0], (float) horizon[1], 0);
+            // A star below the horizon is under the ground: not drawn, not clickable, not paid for.
+            star.setVisible(DemoConfig.STARS_STARS && horizon[1] > -2.0);
+        }
+
+        for (int i = 0; i < figures.size(); i++) {
+            double[][] segments = figureEquatorial.get(i);
+            DoubleVector directions = new DoubleVector();
+            for (double[] segment : segments) {
+                double[] from = DemoAstro.toHorizon(segment[0], segment[1], n, lat, lon);
+                double[] to = DemoAstro.toHorizon(segment[2], segment[3], n, lat, lon);
+                directions.add(from[0]);
+                directions.add(from[1]);
+                directions.add(to[0]);
+                directions.add(to[1]);
+            }
+            figures.get(i).setSegments(directions);
+            figures.get(i).setVisible(DemoConfig.STARS_FIGURES);
+        }
+
+        for (int i = 0; i < planets.size(); i++) {
+            double[] horizon = DemoAstro.planetHorizon(i, n, lat, lon);
+            CelestialSprite planet = planets.get(i);
+            planet.setDirection((float) horizon[0], (float) horizon[1], 0);
+            planet.setVisible(DemoConfig.STARS_PLANETS && horizon[1] > -2.0);
+        }
+
+        // Declination 0 is 90 degrees from the pole, and the pole sits due north (south below the
+        // equator) at an altitude equal to the latitude.
+        equator.setCircle(lat >= 0 ? 0f : 180f, (float) Math.abs(lat), 90f);
+        equator.setVisible(DemoConfig.STARS_EQUATOR);
+    }
+
+    /** A star of this magnitude, in screen pixels. */
+    private static double magnitudeToPixels(double magnitude) {
+        double size = DemoConfig.STARS_BRIGHTEST_SIZE - DemoConfig.STARS_SIZE_PER_MAGNITUDE * (magnitude + 1.5);
+        return Math.max(DemoConfig.STARS_FAINTEST_SIZE, size);
+    }
+
+    private static Color planetColor(String name) {
+        if ("Mars".equals(name)) {
+            return new Color((short) 255, (short) 130, (short) 90, (short) 255);
+        }
+        if ("Venus".equals(name)) {
+            return new Color((short) 255, (short) 250, (short) 220, (short) 255);
+        }
+        if ("Jupiter".equals(name)) {
+            return new Color((short) 255, (short) 235, (short) 180, (short) 255);
+        }
+        if ("Saturn".equals(name)) {
+            return new Color((short) 240, (short) 220, (short) 160, (short) 255);
+        }
+        return new Color((short) 220, (short) 220, (short) 230, (short) 255);
+    }
+}

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoTests.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoTests.java
@@ -44,6 +44,76 @@ public final class DemoTests {
 
     private static LocalVectorDataSource resultSource;
 
+    /**
+     * Drives a TWO-FINGER drag over the map, as a real gesture would.
+     *
+     * The only way to exercise it: adb can synthesize one pointer, not two, and the emulator's
+     * touch devices are not writable from the shell. The MotionEvent goes through
+     * MapView.onTouchEvent, which is the same entry point a finger uses, so what it tests is the
+     * gesture path and not a shortcut around it.
+     *
+     * @param dx horizontal travel in pixels, @param dy vertical travel (negative = upwards)
+     */
+    public static void runTwoFingerDrag(final DemoMap demo, final float dx, final float dy) {
+        final com.carto.ui.MapView mapView = demo.mapView;
+        final Handler handler = new Handler(Looper.getMainLooper());
+        final MapPos before = mapView.getFocusPos();
+        final float x1 = 400, x2 = 700, y = 1600;
+        final long downTime = android.os.SystemClock.uptimeMillis();
+        final int steps = 12;
+        // Real delays between the events, not a tight loop: the gesture is only recognised once
+        // the click handler THREAD has seen the movement, so a burst of events with fake
+        // timestamps is dropped as a two-finger tap.
+        send(mapView, downTime, downTime, android.view.MotionEvent.ACTION_DOWN, 1, x1, y, x2, y);
+        handler.postDelayed(new Runnable() {
+            public void run() {
+                send(mapView, downTime, android.os.SystemClock.uptimeMillis(),
+                        android.view.MotionEvent.ACTION_POINTER_DOWN | (1 << android.view.MotionEvent.ACTION_POINTER_INDEX_SHIFT),
+                        2, x1, y, x2, y);
+            }
+        }, 30);
+        for (int step = 1; step <= steps; step++) {
+            final float fx = dx * step / steps, fy = dy * step / steps;
+            handler.postDelayed(new Runnable() {
+                public void run() {
+                    send(mapView, downTime, android.os.SystemClock.uptimeMillis(),
+                            android.view.MotionEvent.ACTION_MOVE, 2, x1 + fx, y + fy, x2 + fx, y + fy);
+                }
+            }, 60 + step * 25L);
+        }
+        handler.postDelayed(new Runnable() {
+            public void run() {
+                send(mapView, downTime, android.os.SystemClock.uptimeMillis(),
+                        android.view.MotionEvent.ACTION_POINTER_UP | (1 << android.view.MotionEvent.ACTION_POINTER_INDEX_SHIFT),
+                        2, x1 + dx, y + dy, x2 + dx, y + dy);
+                send(mapView, downTime, android.os.SystemClock.uptimeMillis(),
+                        android.view.MotionEvent.ACTION_UP, 1, x1 + dx, y + dy, x2 + dx, y + dy);
+                Log.i(TAG, "two-finger drag (" + dx + "," + dy + "): focus " + before + " -> " + mapView.getFocusPos());
+            }
+        }, 60 + (steps + 2) * 25L);
+    }
+
+    private static void send(com.carto.ui.MapView mapView, long downTime, long eventTime, int action,
+                             int count, float x1, float y1, float x2, float y2) {
+        android.view.MotionEvent.PointerProperties[] properties = new android.view.MotionEvent.PointerProperties[count];
+        android.view.MotionEvent.PointerCoords[] coords = new android.view.MotionEvent.PointerCoords[count];
+        for (int i = 0; i < count; i++) {
+            properties[i] = new android.view.MotionEvent.PointerProperties();
+            properties[i].id = i;
+            properties[i].toolType = android.view.MotionEvent.TOOL_TYPE_FINGER;
+            coords[i] = new android.view.MotionEvent.PointerCoords();
+            coords[i].x = (i == 0 ? x1 : x2);
+            coords[i].y = (i == 0 ? y1 : y2);
+            coords[i].pressure = 1;
+            coords[i].size = 1;
+        }
+        android.view.MotionEvent event = android.view.MotionEvent.obtain(downTime, eventTime, action, count,
+                properties, coords, 0, 0, 1, 1, 0, 0, android.view.InputDevice.SOURCE_TOUCHSCREEN, 0);
+        mapView.onTouchEvent(event);
+        event.recycle();
+    }
+
+
     /** Lazily creates (and adds) the layer every test draws its result into. */
     private static LocalVectorDataSource results(DemoMap demo) {
         if (resultSource == null) {

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/ui/main/SecondFragment.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/ui/main/SecondFragment.java
@@ -171,7 +171,9 @@ public class SecondFragment extends Fragment {
                 }
                 getActivity().runOnUiThread(new Runnable() {
                     public void run() {
-                        String text = String.format("z=%.2f tilt=%.0f", mapView.getZoom(), mapView.getTilt());
+                        MapPos focus = mapView.getFocusPos();
+                        String text = String.format("z=%.2f  tilt=%.0f  %.5f, %.5f",
+                                mapView.getZoom(), mapView.getTilt(), focus.getY(), focus.getX());
                         if (zoomText != null) {
                             zoomText.setText(text);
                         }

--- a/scripts/android-dev/app/src/main/res/values-v23/styles.xml
+++ b/scripts/android-dev/app/src/main/res/values-v23/styles.xml
@@ -1,8 +1,6 @@
 <resources>
 
-    <!-- No action bar: the map IS the screen, and the bar only ate 56dp of it. The system bars
-         are transparent because the app draws edge to edge and insets the overlay itself
-         (DemoPanel.applyInsets). -->
+    <!-- The map is light, so the status bar icons have to be dark to be legible over it. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
@@ -10,6 +8,7 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Summary

**A layer for things that are not on the map.** `CelestialLayer` places objects by DIRECTION
(azimuth/altitude, distance 0 = infinitely far, so no parallax) or by geographic position +
altitude. `CelestialSprite` is a camera-facing quad sized by angle or by pixels, batched per
bitmap so a catalogue of thousands costs one draw call; `CelestialArc` is a circle about an axis,
a path, or a set of disjoint segments. Both are clickable, angularly, which needed a fix in the
click path itself: a touch was dropped entirely unless its ray met the GROUND, so nothing above
the horizon was clickable by any layer. The SDK has no notion of a sun, a moon or a star - that is
all demo content.

**A camera that can look up.** The tilt may now go below 0. The obvious version does not work
(rotating the camera on about the focus puts it under the ground and the view comes back
inverted), so a negative tilt keeps the camera where it is and pitches the VIEW about it.
`dist(camera, focus)` is preserved, so zoom, culling and the depth budget still mean what they
meant. Opt-in: the default tilt range is still `(0, 90)`.

**Free roam is a mode**, `Options::FreeRoamMode` = `OFF` / `LOOK` / `FIRST_PERSON`.
`FIRST_PERSON` is a camera MODEL rather than a gesture mapping: tilt and rotation pivot about the
camera for every caller, so `setTilt`/`setMapRotation` driven by an orientation sensor behave
exactly like a one-finger drag. Two fingers then MOVE (forward/back and strafe) instead of
panning, and pinch, two-finger rotation and the kinetic handlers are off - they are map gestures.

**A map view can be translucent.** `setTranslucent(boolean)` on `MapView`, `TextureMapView` and
`NTMapView`. Combined with a transparent clear colour the frame is empty wherever the map does not
paint; the renderer already works in premultiplied alpha, so nothing else changes. What each view
can REVEAL differs and is documented: a `MapView` is a SurfaceView composited below the window and
can only show another surface (a camera preview), while a `TextureMapView` blends with the layout.

**Three bugs the above uncovered**, each with a mechanism worth reading in the commit:
the terrain clearance bound goes unsatisfiable near the horizon and walked the zoom from z16 to
z-33 (map gone, silently); an all-sky frame hits no ground and collapsed the depth range onto the
near plane; and a pitched view took its NEAR plane from where the rays meet the ground, so looking
up clipped away everything close to the camera.

**Panning speed is configurable** (`Options::PanningSpeedMode`, default `ANCHORED`). On a tilted
view the exact grab-the-world pan re-derives its scale from where the finger is NOW, so a drag
that starts close to the camera and travels up the screen accelerates while the finger is down -
measured at z15 tilt 65, the same 1300 px drag moved 2160 m that way against 1186 m at the speed
it started with.

**The demo** (`scripts/android-dev`) is where the sky lives: real sun, moon with its phase,
planets, the bright-star catalogue with clickable named constellations and their names drawn in
the sky, all for today and the current position, each disc landing on its own daily arc. Plus a
star sky mode (no map at all - the layers leave the layer list), the live camera behind it, and a
rebuilt UI: a filterable settings sheet with collapsible sections, no action bar, edge to edge
with insets handled, and the readout moved to the bottom.

## Breaking changes

`Options.setFreeRoam(bool)` is replaced by `Options.setFreeRoamMode(FreeRoamMode)` -
`setFreeRoam(true)` becomes `setFreeRoamMode(FREE_ROAM_MODE_LOOK)`. Breaking for every app
binding, as any `all/modules/*.i` change is.

## Testing

`clang++ -fsyntax-only -std=c++17` clean on all 12 touched translation units; SWIG wrappers
regenerated with `swigpp-java.py`.

Emulator-verified (Android, Grenoble): free roam takes the tilt to -90 at the zenith with the
camera position unchanged to the metre; the sun disc lands on its own arc over map + terrain and
in star sky mode; constellation and star clicks report their names; the star sky toggles both ways
without a crash; the sky draws over the live camera preview; a default launch is unchanged
(z16.22 tilt 26).

**An on-device check is still required** - none of the above is proof on real hardware, and the
depth/near-plane work is exactly the kind that has behaved differently on a device before. Worth
running:

```sh
adb shell am start -n com.akylas.cartotest/.MainActivity --es freeRoam fps --es lookUp 90 \
  --es celestial true --es stars true --es tilt 30
```

then dragging up past the horizon (nothing near the camera should disappear), and

```sh
adb shell am start -n com.akylas.cartotest/.MainActivity --es starSky true --es starSkyCamera true \
  --es starSkyOrientation true --es lookUp 90
```

for the sky over the camera, following the phone.

**iOS is code-reviewed only** - `NTMapView::setTranslucent` could not be built or run here.