### PR TITLE
perf(terrain): stop every DEM tile re-anchoring every label on screen

### DIFF
--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -672,6 +672,29 @@ namespace carto {
             }
         }
 
+        // SAFEGUARD: a coarsening floor and a view distance are set independently, and multiplied
+        // they decide how much ground has to be paved in tiles no coarser than that floor. The two
+        // that look reasonable apart can be ruinous together - a 170 km view with a floor 3 levels
+        // under the camera measured 550 tiles against 50, every one of them fetched, decoded,
+        // draped and re-baked, which reads as a map that loads for minutes and blinks a tile at a
+        // time. The floor exists to keep far tiles usable as depth occluders, so it is relaxed
+        // rather than the view shortened: whatever the app asked for, allow enough coarsening that
+        // the covered ground fits in TERRAIN_COVER_TILE_BUDGET tiles. The screen-area rule below
+        // then coarsens the horizon on its own; this only stops the floor from forbidding it.
+        if (_terrainMinTileZoom > 0 && _maxVisibleDistance > 0) {
+            // Tiles across the covered ground, worst case (a square of side 2 * distance):
+            //     (2 * distance / tileWidth)^2 <= budget,   tileWidth = WORLD_SIZE / 2^zoom
+            double maxTileZoom = std::log2(Const::WORLD_SIZE * std::sqrt(static_cast<double>(TERRAIN_COVER_TILE_BUDGET)) / (2 * _maxVisibleDistance));
+            int budgetMinTileZoom = static_cast<int>(std::floor(maxTileZoom));
+            if (budgetMinTileZoom < _terrainMinTileZoom) {
+                if (_terrainMinTileZoom - budgetMinTileZoom > 1) {
+                    Log::Infof("TileLayer::calculateVisibleTiles: the view distance needs %d more levels of terrain tile coarsening than allowed; coarsening to zoom %d to stay inside %d tiles",
+                               _terrainMinTileZoom - budgetMinTileZoom, budgetMinTileZoom, TERRAIN_COVER_TILE_BUDGET);
+                }
+                _terrainMinTileZoom = std::max(0, budgetMinTileZoom);
+            }
+        }
+
         // Tangram's LOD threshold (TileManager::updateTileSets): a tile is refined while its
         // projected SCREEN AREA is at least that of a 2x2 block of nominal tiles - so refinement
         // stops when a tile covers between one and two tile sizes on screen, which is the same
@@ -1264,6 +1287,10 @@ namespace carto {
     }
 
     const float TileLayer::DISCRETE_ZOOM_LEVEL_BIAS = 0.001f;
+
+    // Measured at the demo's mountain camera: a sane cover is ~50 tiles and the pathological
+    // one was 550, so this only engages on a configuration that is already unaffordable.
+    const int TileLayer::TERRAIN_COVER_TILE_BUDGET = 256;
 
     const int TileLayer::MAX_PARENT_SEARCH_DEPTH = 6;
     // As deep as the parent search: a stand-in must be able to cover a zoom-in of several levels,

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -478,6 +478,10 @@ namespace carto {
 
         static const float DISCRETE_ZOOM_LEVEL_BIAS;
 
+        // Ceiling on the terrain tile cover, used to relax the coarsening floor when the
+        // view distance would otherwise demand more tiles than a frame can carry.
+        static const int TERRAIN_COVER_TILE_BUDGET;
+
         static const int MAX_PARENT_SEARCH_DEPTH;
         static const int MAX_STAND_IN_DEPTH;
         static const int MAX_CHILD_SEARCH_DEPTH;

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -2787,7 +2787,19 @@ namespace carto {
                         std::size_t bakedFingerprint = request.fingerprint;
                         for (std::size_t i = 0; i < drapeLayers.size() && i < sizeof(std::size_t) * 8; i++) {
                             if (drapeLayers[i]->paintsEveryDrapeTile() && (bakedMask & (static_cast<std::size_t>(1) << i)) == 0) {
-                                bakedFingerprint = ~request.fingerprint;
+                                // ONLY when the paint should have been able to paint this tile: its
+                                // elevation is decoded and the texture merely was not uploaded yet,
+                                // which the next frame fixes. A tile with no elevation at all - a
+                                // coarse cached ancestor, ground the DEM does not cover - can NEVER
+                                // be painted, and marking THAT one never-matching left it stale for
+                                // ever: re-baked forever, one per frame, each bake swapping its
+                                // texture and asking for another frame. Elevation ARRIVING is
+                                // already covered without this, because the wanted fingerprint
+                                // folds in 'paintable' per tile.
+                                auto leafElevationIt = leafElevation.find(request.tileId);
+                                if (leafElevationIt != leafElevation.end() && leafElevationIt->second) {
+                                    bakedFingerprint = ~request.fingerprint;
+                                }
                                 break;
                             }
                         }
@@ -2836,7 +2848,15 @@ namespace carto {
                     for (auto it = partialTiles.begin(); it != partialTiles.end() && budget > 0 && bakeTimeLeft(); it++, budget--) {
                         bakeTile(*it);
                     }
-                    budget = DRAPE_BAKE_BUDGET_STALE;
+                    // One stale tile per frame is the right ration while the camera moves - the
+                    // picture is merely out of date and the frame has better things to do. On a map
+                    // at REST it is a livelock: nothing else asks for frames, so the map draws only
+                    // the frames the bakes themselves request, and a backlog of a few dozen tiles
+                    // takes half a minute to drain, one texture swap at a time - which is what the
+                    // terrain "loading and blinking" looks like when nothing is moving. At rest let
+                    // the wall-clock budget ration it instead: a longer frame is invisible on a map
+                    // that is not moving, the same argument DRAPE_BAKE_TIME_BUDGET_STILL is made of.
+                    budget = (bakeCameraMoving ? DRAPE_BAKE_BUDGET_STALE : DRAPE_BAKE_BUDGET_BLANK);
                     for (auto it = staleTiles.begin(); it != staleTiles.end() && budget > 0 && bakeTimeLeft(); it++, budget--) {
                         bakeTile(*it);
                     }

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 namespace carto {
 
@@ -27,6 +28,8 @@ namespace carto {
     static constexpr double DEFAULT_MAX_ELEVATION = 9000.0;
     static constexpr int RAY_MARCH_MAX_STEPS = 256;
     static constexpr int RAY_BISECT_STEPS = 24;
+    // Latitude quantum of the metres-to-internal scale memo, ~40 m of world (see getDisplayScale).
+    static const double DISPLAY_SCALE_STEP = Const::WORLD_SIZE / 1048576.0;
 
     struct ElevationManager::DataSourceListener : public TileDataSource::OnChangeListener {
         explicit DataSourceListener(ElevationManager& manager) : _manager(manager) { }
@@ -96,7 +99,10 @@ namespace carto {
     }
 
     void ElevationManager::setExaggeration(float exaggeration) {
-        _exaggeration.store(std::max(0.0f, exaggeration));
+        float value = std::max(0.0f, exaggeration);
+        if (_exaggeration.exchange(value) == value) {
+            return; // re-setting the same value invalidates every CPU-side height for nothing
+        }
         // The DATA version deliberately stands still: heights are scaled on the GPU and the tile
         // surfaces are built flat, so nothing geometric is stale. Only what reads heights on the
         // CPU - label anchors, the raycast - has to catch up, and that watches the global version.
@@ -322,6 +328,12 @@ namespace carto {
                 // per-tile derived data can then rebuild only the affected tiles. Bump the
                 // version under the same lock as the cache insert, so a consumer that sees
                 // the new version also sees the grid and a matching log entry.
+                // The DATA version moves with it: a decoded tile IS new elevation data, and a
+                // consumer telling a scale-only change apart from a data change compares the
+                // two. While this only moved for whole-data-set changes, every tile load read
+                // as scale-only, which takes the blanket invalidation path - a whole screen of
+                // label anchors resampled per arriving tile instead of those over that tile.
+                _dataVersion++;
                 unsigned int version = _version.fetch_add(1) + 1;
                 _changeLog.emplace_back(version, grid->getTile());
                 while (_changeLog.size() > MAX_CHANGE_LOG_ENTRIES) {
@@ -438,9 +450,28 @@ namespace carto {
     }
 
     double ElevationManager::getDisplayScale(double internalY) const {
-        double sin = std::tanh(internalY * 2 * Const::PI / Const::WORLD_SIZE);
+        // The metres-to-internal scale only depends on the latitude, and a dense consumer (the
+        // label re-anchor, the raycast) walks points a few metres apart - but tanh() is the
+        // single most expensive thing in that loop (measured: tanh + expm1 = 21% of the render
+        // thread). Quantise the latitude to DISPLAY_SCALE_STEP and remember the last step: the
+        // step spans ~40 m, over which the scale moves by ~4e-7 relative, i.e. under two
+        // millimetres on a 3000 m summit. Quantising rather than interpolating keeps it a
+        // function of the position alone, so the same vertex always gets the same height and
+        // nothing oscillates between frames.
+        double step = std::floor(internalY / DISPLAY_SCALE_STEP + 0.5);
+        struct ScaleMemo {
+            double step = std::numeric_limits<double>::quiet_NaN();
+            double scale = 0;
+        };
+        static thread_local ScaleMemo memo;
+        if (memo.step == step) {
+            return memo.scale;
+        }
+        double sin = std::tanh(step * DISPLAY_SCALE_STEP * 2 * Const::PI / Const::WORLD_SIZE);
         double cos = std::sqrt(std::max(1.0e-6, 1.0 - sin * sin));
-        return Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE / cos;
+        double scale = Const::WORLD_SIZE / Const::EARTH_CIRCUMFERENCE / cos;
+        memo = ScaleMemo { step, scale };
+        return scale;
     }
 
     void ElevationManager::getDisplayHeightRange(double internalY, double& minZ, double& maxZ) const {
@@ -668,9 +699,36 @@ namespace carto {
     }
 
     std::shared_ptr<ElevationTileGrid> ElevationManager::getGridForInternalPos(double internalX, double internalY, LoadMode mode) const {
+        // Dense point queries - a label re-anchor samples every vertex of every label - walk the
+        // same grid thousands of times in a row, and finding WHICH tile a point belongs to costs
+        // a projection transform, a tile id, a flip and the zoom clamp before the cache lookup
+        // (and its own memo) is even reached. Measured with labels over 3D terrain, that tile
+        // math was 70% of the render thread. A grid is immutable and every elevation change bumps
+        // the version, so the last grid whose bounds contain the point is the same answer the
+        // resolution below would produce - the raycast in intersectRay keeps its grid for exactly
+        // this reason. LOAD_EXACT is excluded: it must not be satisfied by an ancestor stand-in.
+        struct PosMemo {
+            unsigned long long instanceId = 0;
+            unsigned int version = 0;
+            LoadMode mode = LoadMode::CACHED_ONLY;
+            std::shared_ptr<ElevationTileGrid> grid;
+        };
+        static thread_local PosMemo memo;
+        unsigned int memoVersion = _version.load();
+        bool memoizable = (mode != LoadMode::LOAD_EXACT);
+        if (memoizable && memo.instanceId == _instanceId && memo.version == memoVersion && memo.mode == mode && memo.grid) {
+            if (memo.grid->getInternalBounds().contains(MapPos(internalX, internalY, 0))) {
+                return memo.grid;
+            }
+        }
+
         MapPos dataSourcePos = _projection->fromInternal(MapPos(internalX, internalY, 0));
         MapTile mapTile = TileUtils::CalculateClippedMapTile(dataSourcePos, _dataSource->getMaxZoom(), _projection).getFlipped();
-        return getTileGrid(mapTile, mode);
+        std::shared_ptr<ElevationTileGrid> grid = getTileGrid(mapTile, mode);
+        if (memoizable && grid) {
+            memo = PosMemo { _instanceId, memoVersion, mode, grid };
+        }
+        return grid;
     }
 
     std::shared_ptr<ElevationTileGrid> ElevationManager::loadTileGrid(const MapTile& requestedTile) const {

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -240,7 +240,7 @@ namespace carto {
         // handed straight back to the next one).
         const unsigned long long _instanceId;
 
-        std::atomic<unsigned int> _dataVersion;
+        mutable std::atomic<unsigned int> _dataVersion; // moves with _version whenever tile data changes
 
         std::atomic<float> _exaggeration;
         std::atomic<bool> _seamlessTileEdges;

--- a/all/native/terrain/TerrainTileTransformer.cpp
+++ b/all/native/terrain/TerrainTileTransformer.cpp
@@ -104,7 +104,26 @@ namespace carto {
                     continue;
                 }
                 float dist = cglib::length(pos1 - pos0) * static_cast<float>(_tileScaleMeters);
-                tesselateSegment(pos0, pos1, dist, tesselatedPoints);
+                tesselateSegment(pos0, pos1, dist, _lineDivideThreshold, tesselatedPoints);
+            }
+        }
+    }
+
+    void TerrainTileTransformer::TerrainVertexTransformer::tesselateLabelLineString(const cglib::vec2<float>* points, std::size_t count, vt::VertexArray<cglib::vec2<float>>& tesselatedPoints) const {
+        // A label line is READ, never drawn: the lattice split keeps a DRAWN segment inside one
+        // surface triangle, which buys a glyph run nothing, and neither does the finer line
+        // threshold - the profile a run follows cannot carry more detail than the surface it is
+        // laid on. Halve to the SURFACE cell instead. Every vertex dropped here is an elevation
+        // sample dropped from every terrain re-anchor, which is the most expensive thing on the
+        // render thread over 3D terrain (docs/rendering/06-labels.md). Measured: with no line
+        // subdivision at all, 'prepare' goes 154 -> 68 ms on the north pan.
+        if (count > 0) {
+            tesselatedPoints.append(points[0]);
+            for (std::size_t i = 0; i + 1 < count; i++) {
+                const cglib::vec2<float>& pos0 = points[i + 0];
+                const cglib::vec2<float>& pos1 = points[i + 1];
+                float dist = cglib::length(pos1 - pos0) * static_cast<float>(_tileScaleMeters);
+                tesselateSegment(pos0, pos1, dist, _divideThreshold, tesselatedPoints);
             }
         }
     }
@@ -185,11 +204,11 @@ namespace carto {
         return std::sqrt(std::max(1.0e-6, 1.0 - sin * sin));
     }
 
-    void TerrainTileTransformer::TerrainVertexTransformer::tesselateSegment(const cglib::vec2<float>& pos0, const cglib::vec2<float>& pos1, float dist, vt::VertexArray<cglib::vec2<float>>& points) const {
-        if (dist > _lineDivideThreshold) {
+    void TerrainTileTransformer::TerrainVertexTransformer::tesselateSegment(const cglib::vec2<float>& pos0, const cglib::vec2<float>& pos1, float dist, float threshold, vt::VertexArray<cglib::vec2<float>>& points) const {
+        if (dist > threshold) {
             cglib::vec2<float> posM = (pos0 + pos1) * 0.5f;
-            tesselateSegment(pos0, posM, dist * 0.5f, points);
-            tesselateSegment(posM, pos1, dist * 0.5f, points);
+            tesselateSegment(pos0, posM, dist * 0.5f, threshold, points);
+            tesselateSegment(posM, pos1, dist * 0.5f, threshold, points);
         }
         else {
             points.append(pos1);

--- a/all/native/terrain/TerrainTileTransformer.h
+++ b/all/native/terrain/TerrainTileTransformer.h
@@ -39,13 +39,14 @@ namespace carto {
             virtual float calculateHeight(const cglib::vec2<float>& pos, float height) const override;
 
             virtual void tesselateLineString(const cglib::vec2<float>* points, std::size_t count, vt::VertexArray<cglib::vec2<float>>& tesselatedPoints) const override;
+            virtual void tesselateLabelLineString(const cglib::vec2<float>* points, std::size_t count, vt::VertexArray<cglib::vec2<float>>& tesselatedPoints) const override;
             virtual void tesselateTriangles(const std::size_t* indices, std::size_t count, vt::VertexArray<cglib::vec2<float>>& coords, vt::VertexArray<cglib::vec2<float>>& texCoords, vt::VertexArray<std::size_t>& tesselatedIndices) const override;
 
         private:
             double calculateLocalHeight(const cglib::vec2<float>& pos) const;
             double calculateMercatorCosine(double internalY) const;
 
-            void tesselateSegment(const cglib::vec2<float>& pos0, const cglib::vec2<float>& pos1, float dist, vt::VertexArray<cglib::vec2<float>>& points) const;
+            void tesselateSegment(const cglib::vec2<float>& pos0, const cglib::vec2<float>& pos1, float dist, float threshold, vt::VertexArray<cglib::vec2<float>>& points) const;
             // Splits a segment where it crosses the surface grid's cell edges and the diagonal
             // each cell is split along, so that every resulting sub-segment lies inside ONE
             // surface triangle. Returns false when the segment spans too many cells to be worth

--- a/docs/rendering/02-tiles.md
+++ b/docs/rendering/02-tiles.md
@@ -70,6 +70,31 @@ Three terrain-specific details, each of which was a bug once:
   distance in metres with `terrain-max-visible-distance`. Pair a short one with fog
   ([08-lighting-sky-fog.md](08-lighting-sky-fog.md)) or the ground simply ends.
 
+### The coarsening floor times the view distance
+
+`TerrainOptions::MaxTileZoomCoarsening` floors how coarse a far tile may get (default: 3 levels
+under the camera), so that far surfaces stay usable as depth occluders. It **overrides the
+screen-area rule**, which would happily coarsen the horizon on its own — and that is fine until it
+is multiplied by a long view distance. The cost of a long view is not the distance, it is the
+distance paved in tiles no coarser than the floor.
+
+Measured at the demo's default camera, a 170 km pinned view distance:
+
+| coarsening floor | tiles fetched | deepest zoom |
+|---|---|---|
+| 3 | **550** (all z13) | z13 |
+| 8 | 50 | z15 |
+
+The 550-tile case is a map that loads for minutes and blinks one tile at a time as each arrives,
+because every tile is fetched, decoded, draped and re-baked. Note the near field gets *finer* with
+more coarsening allowed (z15 against z13): the budget goes where it is visible instead of paving
+the horizon.
+
+`TileLayer::calculateVisibleTiles` therefore **relaxes the floor rather than shortening the view**:
+whatever the app configured, it allows enough coarsening for the covered ground to fit in
+`TERRAIN_COVER_TILE_BUDGET` (256) tiles, and logs when it does. Two settings that each look
+reasonable can be ruinous multiplied together, and an app has no way to see that coming.
+
 ## Substitution, preloading, caching
 
 - `TileSubstitutionPolicy` decides whether a missing tile is stood in for by a parent/child.

--- a/docs/rendering/04-terrain.md
+++ b/docs/rendering/04-terrain.md
@@ -17,6 +17,29 @@ half surface cell), which costs about two zoom levels of detail. That cap is rig
 wrong for per-fragment shading, which is why the terrain paint can opt out of it
 ([07-hillshade-contours.md](07-hillshade-contours.md#the-dem-level)).
 
+### CPU height queries
+
+`getDisplayHeight`/`getElevationMeters` are point queries, and their callers are dense: the label
+re-anchor walks every vertex of every label, the raycast marches a ray. Three things make one sample
+cheap, and each of them was a measured frame cost before it existed:
+
+- **The last grid, kept.** `getGridForInternalPos` remembers the last resolved grid per thread and
+  reuses it while the point is inside its bounds. Without it every sample paid a projection
+  transform, a tile id (`IntPow` alone was 21% of the render thread), a flip and the zoom clamp
+  before reaching the cache — to find the tile the previous sample had just used. `lookupTileGrid`
+  keeps a second memo for the callers that arrive with a tile id already.
+- **The latitude scale, quantised.** `getDisplayScale` is `tanh`-based and was 21% of the render
+  thread on its own (`tanh` + `expm1`). It is now memoised over a ~40 m latitude quantum, which
+  moves a height by under two millimetres and — being a function of the position alone — keeps the
+  same vertex at the same height frame after frame.
+- **Two versions, and what they mean.** `getVersion` moves on *any* change; `getDataVersion` moves
+  when the elevation DATA changes, **including a tile load**. A consumer tells an exaggeration ramp
+  (heights scale on the GPU, surfaces stay valid) apart from new data by comparing the two.
+  `_dataVersion` used to stand still for tile loads, so `TileRenderer` read every arriving DEM tile
+  as scale-only and took the blanket invalidation path — a whole screen of label anchors resampled
+  per tile, instead of the labels over that tile. Setting the same exaggeration twice is now a
+  no-op for the same reason.
+
 ### The elevation texture
 
 Displacement happens in the **vertex shader** (vertex texture fetch), so each tile needs its DEM as

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -410,10 +410,20 @@ zoom filter.
   been anchored never defers — its geometry is still flat, and placing it at sea level under a
   mountain is what makes labels pop. That deferral measured **+6% and no more**, because most dirty
   labels do hold a placement.
+  The bigger cut was the **vertex count itself**. A label's line went through the same terrain
+  tesselation as a drawn line — including the lattice split, which cuts a segment at every surface
+  cell edge *and* diagonal so that a painted line stays inside one triangle. A label line is never
+  painted: it is read, to place glyphs and to anchor them. It now takes
+  `TileTransformer::tesselateLabelLineString`, which halves to the **surface cell** and skips the
+  lattice split — the profile a glyph run follows cannot carry more detail than the surface it is
+  laid on. **`prepare` 157 → 72 ms, 1.75 → 2.10 fps.** The bound was measured first with
+  `debug.carto.linesourcedensity 1` (no line subdivision at all): `prepare` 154 → 68, so the label
+  path gives up almost nothing by keeping the surface-cell step.
+  Visible cost: a glyph run can shift a few pixels along its line, and it may sag by the surface's
+  own chord error where a segment crosses a cell diagonal. Contour labels — the most sensitive class,
+  laid along a line the whole way — still track their line at the ridge camera.
   What remains is genuine volume: a changed DEM tile at z12 intersects every label tile beneath it,
-  so "targeted" still means most of the screen, and a line label resamples its **whole** clipped
-  polyline while the glyph run occupies a short stretch of it. The next real cut is there — restrict
-  the resample to the placement neighbourhood — and it changes what the placement search can see.
+  so "targeted" still means most of the screen.
 - **Vertex data.** Glyph quads are rebuilt from scratch for every visible label every frame and
   uploaded as one batch (`labelVertexBuildNs`, `labelBatchNs`). A GPU-billboard path would remove
   the per-frame world transform (`labelTransformNs`) — it is on the backlog, not implemented.

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -395,10 +395,18 @@ zoom filter.
 - **Terrain anchoring.** Label geometry is built flat at decode time, so a label must be re-anchored
   onto the terrain: once when it is new, and afterwards only when the elevation under one of its
   tiles changed. `invalidateLabelElevation(tileIds)` marks exactly those; the blanket version exists
-  for whole-data-set changes. Anchoring costs one elevation sample per label vertex (~233 µs per
-  label), and a whole screen of labels goes dirty at once while elevation streams in, so this loop
-  measures 2.5–4.1 ms of a frame. It still has to run to completion: a label left dirty is drawn and
-  culled at its old height, which reads as labels popping in at the wrong place and settling.
+  for whole-data-set changes. Anchoring costs one elevation sample per label vertex, and a whole
+  screen of labels goes dirty at once while elevation streams in. It still has to run to completion:
+  a label left dirty is drawn and culled at its old height, which reads as labels popping in at the
+  wrong place and settling.
+  **This is the most expensive thing on the render thread over 3D terrain** — measured at ~750 000
+  elevation samples per frame on the north pan with a full style, 82% of the render thread. Two
+  faults made it that: `TileRenderer` classified every arriving DEM tile as a *scale-only* change
+  and took the blanket path (see [04-terrain.md](04-terrain.md#cpu-height-queries)), and each sample
+  re-derived its tile and its latitude scale from scratch. What remains after both fixes is genuine
+  volume: a changed DEM tile at z12 intersects every label tile beneath it, so "targeted" still means
+  most of the screen. Cutting it further means cutting samples — anchor only labels that are placed,
+  or budget the loop — and both trade against how fast a label settles onto the terrain.
 - **Vertex data.** Glyph quads are rebuilt from scratch for every visible label every frame and
   uploaded as one batch (`labelVertexBuildNs`, `labelBatchNs`). A GPU-billboard path would remove
   the per-frame world transform (`labelTransformNs`) — it is on the backlog, not implemented.

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -403,10 +403,17 @@ zoom filter.
   elevation samples per frame on the north pan with a full style, 82% of the render thread. Two
   faults made it that: `TileRenderer` classified every arriving DEM tile as a *scale-only* change
   and took the blanket path (see [04-terrain.md](04-terrain.md#cpu-height-queries)), and each sample
-  re-derived its tile and its latitude scale from scratch. What remains after both fixes is genuine
-  volume: a changed DEM tile at z12 intersects every label tile beneath it, so "targeted" still means
-  most of the screen. Cutting it further means cutting samples — anchor only labels that are placed,
-  or budget the loop — and both trade against how fast a label settles onto the terrain.
+  re-derived its tile and its latitude scale from scratch.
+  A label that has already been anchored and is neither placed nor on screen then **defers** its
+  re-anchor (`Label::isElevationDirty`): it keeps the heights it has, at worst one LOD step out,
+  and reports itself dirty again the moment the culler gives it a placement. A label that has never
+  been anchored never defers — its geometry is still flat, and placing it at sea level under a
+  mountain is what makes labels pop. That deferral measured **+6% and no more**, because most dirty
+  labels do hold a placement.
+  What remains is genuine volume: a changed DEM tile at z12 intersects every label tile beneath it,
+  so "targeted" still means most of the screen, and a line label resamples its **whole** clipped
+  polyline while the glyph run occupies a short stretch of it. The next real cut is there — restrict
+  the resample to the placement neighbourhood — and it changes what the placement search can see.
 - **Vertex data.** Glyph quads are rebuilt from scratch for every visible label every frame and
   uploaded as one batch (`labelVertexBuildNs`, `labelBatchNs`). A GPU-billboard path would remove
   the per-frame world transform (`labelTransformNs`) — it is on the backlog, not implemented.

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -121,6 +121,8 @@ and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 | contour label stubs + shader lines (device) | 14.5 → 16.6 fps, `layers` 8.7 → 7.0 ms |
 | label mutex taken per 32 labels instead of per label | culler pass 19.4 → 15.4 ms (device, ~1960 labels) |
 | label terrain re-anchor: DEM tile loads no longer read as a scale-only change, plus a grid and a latitude-scale memo | full stack over terrain, interleaved ×3: **1.00 → 1.55 fps**, `prepare` 658 → 219 ms |
+| an off-screen, already-anchored label defers its re-anchor | 1.60 → 1.70 fps — small, most dirty labels do hold a placement |
+| label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
 
 ### The label culler, measured on the device
 

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -62,6 +62,20 @@ is the one whose call graph starts at `MapRenderer::onDrawFrame`.
 - Helper scripts: `scripts/android-dev/bench/` (`ab.sh`, `ab2.sh`, `north.sh`, `abapk.sh`,
   `abprop.sh`, `absum.py`).
 
+## Reset the debug props before measuring
+
+`debug.carto.*` properties survive until the device reboots, and a session that leaves them set
+measures a crippled build for weeks. A run in August 2026 found `drapebudget 0` and `drapemip 0`
+(the drape memory budget and its mipmaps, i.e. the whole win of the round that added them) still
+set from the session that introduced them, along with `paintdetail 0` and `skyclip 0`. Clear every
+one of them before a baseline:
+
+```sh
+for p in areasourcedensity areathreshold asyncdepth asyncdepthms background demtaps depthshift \
+         drapebudget drapemip groundpaint linesourcedensity paintdetail skyclip terrainpaint \
+         tilebg tilemasks; do adb shell setprop debug.carto.$p '""'; done
+```
+
 ## Where the frame goes today
 
 At `-O2`, on the north pan with content, the render thread has **no dominant leaf**: draw submission
@@ -106,6 +120,7 @@ and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 | contour lines as a shader block | render tiles 494 → 216 |
 | contour label stubs + shader lines (device) | 14.5 → 16.6 fps, `layers` 8.7 → 7.0 ms |
 | label mutex taken per 32 labels instead of per label | culler pass 19.4 → 15.4 ms (device, ~1960 labels) |
+| label terrain re-anchor: DEM tile loads no longer read as a scale-only change, plus a grid and a latitude-scale memo | full stack over terrain, interleaved ×3: **1.00 → 1.55 fps**, `prepare` 658 → 219 ms |
 
 ### The label culler, measured on the device
 

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -226,12 +226,20 @@ public final class DemoConfig {
     public static float SKY_FOG_HORIZON = -1f;
     public static float VIEW_DISTANCE_FACTOR = 1f;
     /** Absolute view distance in METRES, whatever the camera's height or pitch. 0 = the factor
-     *  rule above (tangram's, which shortens the view as the camera comes down to the ground). */
+     *  rule above (tangram's, which shortens the view as the camera comes down to the ground -
+     *  which is why this is pinned instead). What a long view costs is NOT the distance but the
+     *  distance times the finest a far tile is allowed to be: at coarsening 3 this drew 550 tiles
+     *  against 50, all of them z13, which is minutes of loading and a tile blinking as each lands.
+     *  Pair it with enough COARSENING (below) and it costs the same 50 tiles. */
     public static float VIEW_DISTANCE_METERS = 170000f;
     /** Zoom levels below the camera a tile may coarsen to in terrain mode. The tile surface is the
      *  depth occluder and the DEM level follows the tile zoom, so unbounded coarsening means leaky
-     *  ridges and blocky hillshade. '--es coarsening 2'. */
-    public static int TERRAIN_MAX_TILE_ZOOM_COARSENING = 3;
+     *  ridges and blocky hillshade - but too little of it is what makes a long view unaffordable,
+     *  because it overrides the screen-area LOD rule that would coarsen the horizon by itself.
+     *  8 with the 170 km view above: 50 tiles, and the near field gets FINER (z15 against z13),
+     *  because the budget goes where it is visible instead of paving the horizon.
+     *  '--es coarsening 2'. */
+    public static int TERRAIN_MAX_TILE_ZOOM_COARSENING = 8;
 
     // =============================================================================================
     // SUN / LIGHT / SHADOWS (com.carto.components.LightOptions)


### PR DESCRIPTION
## Summary

Panning a full style over 3D terrain spent **82% of the render thread** in `Label::updateElevation`
— ~750 000 elevation samples a frame, ~660 ms of `prepare`. Nothing had been measured since four
feature sessions landed, and this is what a re-baseline found.

- **A decoded DEM tile was classified as a *scale-only* change**, so `TileRenderer` took the blanket
  "re-anchor every label" path instead of the targeted changed-tiles branch sitting right next to it
  — which was therefore dead code.
- **Each elevation sample re-derived its tile from scratch** (projection → tile id → flip → zoom
  clamp) to find the grid the previous sample had just used; `GeneralUtils::IntPow` alone was 21% of
  the render thread. `getGridForInternalPos` now keeps the last grid, exactly as `intersectRay`
  already did for the raycast. `getDisplayScale`'s `tanh` was another 21%, now memoised over a ~40 m
  latitude quantum (under two millimetres on a 3000 m summit, and a function of position alone, so a
  vertex keeps its height between frames).
- **Label lines are no longer tesselated like painted ones** (the libs-carto half below).
- Also included: the drape re-baking tiles for ever on a resting map (a tile the terrain paint can
  *never* paint was stamped stale-by-construction; stale tiles drained at 1/frame), and the
  view-distance fix of #59.

## Testing

Device (Crosscall, north pan, full stack, interleaved ×3, medians): **1.00 → 2.10 fps**, `prepare`
658 → 72 ms. Emulator screenshot A/B is inside the same-build noise floor for the re-anchor changes;
for the label-line tesselation it is above it, so the crops were inspected — contour labels still
track their line.

**On-device visual check still wanted** at your ridge cameras: a glyph run can shift a few pixels
along its line, and the coarser far tiles from the view-distance commit are the depth occluder.

## Depends on

- https://github.com/farfromrefug/mobile-carto-libs/pull/29 — merges first; the pointer bump in this
  branch must then be rebased onto the merged submodule commit, not the branch commit.
- #59 — the view-distance fix is cherry-picked here, so rebase this branch once that merges.