### PR TITLE
fix(layers): stop a long view distance paving the horizon in fine tiles

### DIFF
--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -672,6 +672,29 @@ namespace carto {
             }
         }
 
+        // SAFEGUARD: a coarsening floor and a view distance are set independently, and multiplied
+        // they decide how much ground has to be paved in tiles no coarser than that floor. The two
+        // that look reasonable apart can be ruinous together - a 170 km view with a floor 3 levels
+        // under the camera measured 550 tiles against 50, every one of them fetched, decoded,
+        // draped and re-baked, which reads as a map that loads for minutes and blinks a tile at a
+        // time. The floor exists to keep far tiles usable as depth occluders, so it is relaxed
+        // rather than the view shortened: whatever the app asked for, allow enough coarsening that
+        // the covered ground fits in TERRAIN_COVER_TILE_BUDGET tiles. The screen-area rule below
+        // then coarsens the horizon on its own; this only stops the floor from forbidding it.
+        if (_terrainMinTileZoom > 0 && _maxVisibleDistance > 0) {
+            // Tiles across the covered ground, worst case (a square of side 2 * distance):
+            //     (2 * distance / tileWidth)^2 <= budget,   tileWidth = WORLD_SIZE / 2^zoom
+            double maxTileZoom = std::log2(Const::WORLD_SIZE * std::sqrt(static_cast<double>(TERRAIN_COVER_TILE_BUDGET)) / (2 * _maxVisibleDistance));
+            int budgetMinTileZoom = static_cast<int>(std::floor(maxTileZoom));
+            if (budgetMinTileZoom < _terrainMinTileZoom) {
+                if (_terrainMinTileZoom - budgetMinTileZoom > 1) {
+                    Log::Infof("TileLayer::calculateVisibleTiles: the view distance needs %d more levels of terrain tile coarsening than allowed; coarsening to zoom %d to stay inside %d tiles",
+                               _terrainMinTileZoom - budgetMinTileZoom, budgetMinTileZoom, TERRAIN_COVER_TILE_BUDGET);
+                }
+                _terrainMinTileZoom = std::max(0, budgetMinTileZoom);
+            }
+        }
+
         // Tangram's LOD threshold (TileManager::updateTileSets): a tile is refined while its
         // projected SCREEN AREA is at least that of a 2x2 block of nominal tiles - so refinement
         // stops when a tile covers between one and two tile sizes on screen, which is the same
@@ -1264,6 +1287,10 @@ namespace carto {
     }
 
     const float TileLayer::DISCRETE_ZOOM_LEVEL_BIAS = 0.001f;
+
+    // Measured at the demo's mountain camera: a sane cover is ~50 tiles and the pathological
+    // one was 550, so this only engages on a configuration that is already unaffordable.
+    const int TileLayer::TERRAIN_COVER_TILE_BUDGET = 256;
 
     const int TileLayer::MAX_PARENT_SEARCH_DEPTH = 6;
     // As deep as the parent search: a stand-in must be able to cover a zoom-in of several levels,

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -478,6 +478,10 @@ namespace carto {
 
         static const float DISCRETE_ZOOM_LEVEL_BIAS;
 
+        // Ceiling on the terrain tile cover, used to relax the coarsening floor when the
+        // view distance would otherwise demand more tiles than a frame can carry.
+        static const int TERRAIN_COVER_TILE_BUDGET;
+
         static const int MAX_PARENT_SEARCH_DEPTH;
         static const int MAX_STAND_IN_DEPTH;
         static const int MAX_CHILD_SEARCH_DEPTH;

--- a/docs/rendering/02-tiles.md
+++ b/docs/rendering/02-tiles.md
@@ -70,6 +70,31 @@ Three terrain-specific details, each of which was a bug once:
   distance in metres with `terrain-max-visible-distance`. Pair a short one with fog
   ([08-lighting-sky-fog.md](08-lighting-sky-fog.md)) or the ground simply ends.
 
+### The coarsening floor times the view distance
+
+`TerrainOptions::MaxTileZoomCoarsening` floors how coarse a far tile may get (default: 3 levels
+under the camera), so that far surfaces stay usable as depth occluders. It **overrides the
+screen-area rule**, which would happily coarsen the horizon on its own — and that is fine until it
+is multiplied by a long view distance. The cost of a long view is not the distance, it is the
+distance paved in tiles no coarser than the floor.
+
+Measured at the demo's default camera, a 170 km pinned view distance:
+
+| coarsening floor | tiles fetched | deepest zoom |
+|---|---|---|
+| 3 | **550** (all z13) | z13 |
+| 8 | 50 | z15 |
+
+The 550-tile case is a map that loads for minutes and blinks one tile at a time as each arrives,
+because every tile is fetched, decoded, draped and re-baked. Note the near field gets *finer* with
+more coarsening allowed (z15 against z13): the budget goes where it is visible instead of paving
+the horizon.
+
+`TileLayer::calculateVisibleTiles` therefore **relaxes the floor rather than shortening the view**:
+whatever the app configured, it allows enough coarsening for the covered ground to fit in
+`TERRAIN_COVER_TILE_BUDGET` (256) tiles, and logs when it does. Two settings that each look
+reasonable can be ruinous multiplied together, and an app has no way to see that coming.
+
 ## Substitution, preloading, caching
 
 - `TileSubstitutionPolicy` decides whether a missing tile is stood in for by a parent/child.

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -226,12 +226,20 @@ public final class DemoConfig {
     public static float SKY_FOG_HORIZON = -1f;
     public static float VIEW_DISTANCE_FACTOR = 1f;
     /** Absolute view distance in METRES, whatever the camera's height or pitch. 0 = the factor
-     *  rule above (tangram's, which shortens the view as the camera comes down to the ground). */
+     *  rule above (tangram's, which shortens the view as the camera comes down to the ground -
+     *  which is why this is pinned instead). What a long view costs is NOT the distance but the
+     *  distance times the finest a far tile is allowed to be: at coarsening 3 this drew 550 tiles
+     *  against 50, all of them z13, which is minutes of loading and a tile blinking as each lands.
+     *  Pair it with enough COARSENING (below) and it costs the same 50 tiles. */
     public static float VIEW_DISTANCE_METERS = 170000f;
     /** Zoom levels below the camera a tile may coarsen to in terrain mode. The tile surface is the
      *  depth occluder and the DEM level follows the tile zoom, so unbounded coarsening means leaky
-     *  ridges and blocky hillshade. '--es coarsening 2'. */
-    public static int TERRAIN_MAX_TILE_ZOOM_COARSENING = 3;
+     *  ridges and blocky hillshade - but too little of it is what makes a long view unaffordable,
+     *  because it overrides the screen-area LOD rule that would coarsen the horizon by itself.
+     *  8 with the 170 km view above: 50 tiles, and the near field gets FINER (z15 against z13),
+     *  because the budget goes where it is visible instead of paving the horizon.
+     *  '--es coarsening 2'. */
+    public static int TERRAIN_MAX_TILE_ZOOM_COARSENING = 8;
 
     // =============================================================================================
     // SUN / LIGHT / SHADOWS (com.carto.components.LightOptions)


### PR DESCRIPTION
## Summary

Fixes the "terrain constantly reloading and blinking" report: a map that loads for minutes and
flashes one tile at a time, with nothing moving.

- **The cause is two settings multiplied.** `TerrainOptions::MaxTileZoomCoarsening` floors how
  coarse a far tile may be (3 levels under the camera), and it **overrides the screen-area LOD
  rule** that would coarsen the horizon by itself. Multiply that floor by a pinned view distance and
  the ground out to that distance has to be paved at that fineness. At the demo camera with the
  170 km view distance: **550 tiles, all z13, against 50** — each fetched, decoded, draped and
  re-baked. It is not the distance that costs, it is the distance times the finest a far tile is
  allowed to be.
- **`calculateVisibleTiles` now relaxes the floor rather than shortening the view**: whatever the
  app configured, allow enough coarsening for the covered ground to fit in
  `TERRAIN_COVER_TILE_BUDGET` (256) tiles, and log when it engages. Neither setting looks wrong on
  its own, so an app has no way to see this coming.
- **Demo keeps its 170 km view** (pinned on purpose — tangram's rule shortens the view as the camera
  comes down to the ground, which kills a panorama) and raises coarsening to 8. Same 50 tiles, and
  the near field comes out *finer*, z15 against z13, because the budget goes where it is visible
  instead of paving the horizon.

## Testing

`clang++ -fsyntax-only` clean on `TileLayer.cpp`. Emulator at the demo camera: 550 → 50 tiles with
the old settings (the safeguard engaging, 3 levels, with its log line), 50 with the new defaults,
and a settled map now draws **no frames at all** where it previously re-baked 1–11 tiles a second
for ever.

**Still needs an on-device check** — coarser far tiles are the terrain depth occluder, so ridges
want a look for see-through at your cameras. Compare `--es viewDistanceMeters 170000 --es coarsening
3` against the defaults.

Ruled out by measurement while chasing this, in case it resurfaces: the geojson-vt merge (built its
parent — same pathology, worse), leftover `debug.carto.*` props, a drape flag flipping between
frames, and the drape bake itself (it reproduces with `--es drape false`, where nothing is baked).

Cherry-picked into #58, which should be rebased once this merges.