### PR TITLE
fix(ui): stop the pan axes going arbitrary at a vertical tilt

### DIFF
--- a/all/native/ui/TouchHandler.cpp
+++ b/all/native/ui/TouchHandler.cpp
@@ -380,16 +380,23 @@ namespace carto {
                 cglib::vec3<double> focusPos = viewState.getFocusPos();
                 MapPos focusMapPos = projectionSurface->calculateMapPos(focusPos);
                 cglib::vec3<double> normal = projectionSurface->calculateNormal(focusMapPos);
+                // NOT '== 0': looking straight down, this cross product is meant to collapse and
+                // hand over to the up vector - but a tilt REACHED BY GESTURE is vertical only to
+                // within rounding, so it comes out at ~1e-16 instead of 0, the hand-over is missed,
+                // and unit() then turns pure floating point noise into a unit vector pointing
+                // anywhere. That is a pan that goes sideways when the finger goes up. Setting the
+                // tilt to 90 outright happens to build the camera exactly vertical, which is why
+                // only the gesture shows it.
                 cglib::vec3<double> right = cglib::vector_product(viewState.calculateViewDir(), normal);
-                if (cglib::length(right) == 0) {
+                if (cglib::length(right) < VIEW_AXIS_EPSILON) {
                     right = cglib::vector_product(viewState.getUpVec(), normal); // straight up or down
                 }
-                if (cglib::length(right) == 0) {
+                if (cglib::length(right) < VIEW_AXIS_EPSILON) {
                     return;
                 }
                 right = cglib::unit(right);
                 cglib::vec3<double> forward = cglib::vector_product(normal, right);
-                if (cglib::length(forward) == 0) {
+                if (cglib::length(forward) < VIEW_AXIS_EPSILON) {
                     return;
                 }
                 forward = cglib::unit(forward);
@@ -620,16 +627,18 @@ namespace carto {
             MapPos cameraMapPos = projectionSurface->calculateMapPos(cameraPos);
             cglib::vec3<double> normal = projectionSurface->calculateNormal(cameraMapPos);
             cglib::vec3<double> viewDir = viewState.calculateViewDir();
+            // Threshold, not '== 0' - see singlePointerPan: a view that is vertical only to within
+            // rounding leaves a ~1e-16 cross product, and normalising that is normalising noise.
             cglib::vec3<double> right = cglib::vector_product(viewDir, normal);
-            if (cglib::length(right) == 0) {
+            if (cglib::length(right) < VIEW_AXIS_EPSILON) {
                 right = cglib::vector_product(viewState.getUpVec(), normal); // looking straight up or down
             }
-            if (cglib::length(right) == 0) {
+            if (cglib::length(right) < VIEW_AXIS_EPSILON) {
                 return;
             }
             right = cglib::unit(right);
             cglib::vec3<double> forward = cglib::vector_product(normal, right);
-            if (cglib::length(forward) == 0) {
+            if (cglib::length(forward) < VIEW_AXIS_EPSILON) {
                 return;
             }
             forward = cglib::unit(forward);
@@ -1055,6 +1064,8 @@ namespace carto {
     const float TouchHandler::WHEEL_TICK_TO_ZOOM_DELTA = 0.25f;
     
     const float TouchHandler::INCHES_TO_TILT_DELTA = 32.0f;
+
+    const double TouchHandler::VIEW_AXIS_EPSILON = 1.0e-3;
     // A full turn takes about two swipes across a phone, which is what a look control wants.
 
     const float TouchHandler::INCHES_TO_ZOOM_DELTA = 1.0f;

--- a/all/native/ui/TouchHandler.h
+++ b/all/native/ui/TouchHandler.h
@@ -148,6 +148,11 @@ namespace carto {
         // Determines how the finger sliding distance will be converted to tilt angle
         static const float INCHES_TO_TILT_DELTA;
 
+        // Below this, a cross product of two view vectors carries no direction, only
+        // rounding: sin(0.06 degrees), so the fallback axis it selects is indistinguishable
+        // from the one it replaces.
+        static const double VIEW_AXIS_EPSILON;
+
         // Determines how finger sliding distance will be converted to zoom delta
         static const float INCHES_TO_ZOOM_DELTA;
         


### PR DESCRIPTION
## Summary

Tilt to 90 with the two-finger gesture and a drag **up** the screen pans **sideways** — the pan axes
read as swapped.

`singlePointerPan` builds its ground frame from `viewDir × normal`, which collapses when the camera
looks straight down; there is a fallback onto the up vector for exactly that case, guarded by
`length(right) == 0`. A tilt *reached by gesture* is vertical only to within rounding, so the cross
product comes out at ~1e-16 rather than 0, the guard misses it, and `unit()` then normalises pure
floating-point noise into a unit vector pointing in an arbitrary horizontal direction. The axes are
not so much swapped as randomised, and they land sideways.

Compare against an epsilon instead, in both places that derive this frame (the pan and the free-roam
move). Below sin(0.06°) the cross product carries no direction, only rounding, so the fallback axis
it selects is indistinguishable from the one it replaces.

## Testing

`clang++ -fsyntax-only` clean on `TouchHandler.cpp`. Emulator, vertical swipe with the demo's
−15.12° start rotation: the pan direction stays **15.0° at tilt 26 and at tilt 90**, unchanged from
before the fix, so the normal cases do not move.

**The gesture repro is not verifiable here** — `adb` cannot drive two fingers, so the
tilt-by-gesture path could not be exercised on the emulator. Reported fixed on device by @farfromrefug
with the original recipe: launch the demo and immediately tilt to 90 with two fingers, then drag up.

Note the diagnostic value of the *negative* result: `--es tilt 90` at launch pans **correctly**,
because setting the tilt outright builds the camera exactly vertical and the cross product genuinely
is zero. Only the gesture leaves the residue that misses the guard.