### PR TITLE
build(android): build with ninja and ccache instead of make

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,18 @@ adb shell am start -n com.akylas.cartotest/.MainActivity --es ui false --es drap
 ## Building / checking
 
 Full builds take 1+ hour (see `BUILDING.md`; requires SWIG fork + boost symlink).
+
+The Android-family build scripts (`build-android.py`, `build-routing-android.py`,
+`build-xamarin.py`) pick **ninja** over make and prefix the compiler with **ccache**, both
+auto-detected and both opt-out (`--ninja none`, `--ccache none`). Ninja is taken from `PATH`,
+otherwise from the newest `$ANDROID_HOME/cmake/*/bin/ninja`. Switching generator clears the
+affected `build/<target>-<abi>` directory — CMake refuses to reconfigure a Makefiles tree as
+Ninja. Measured on one arm64 Release build with a private cache: 70.9 s cold, **13.8 s warm**
+(1128/1134 direct hits), what is left being the thin-LTO link. Raise the cache first —
+`ccache --max-size 30G` — because one ABI writes ~1 GB of objects and the 5 GB default makes the
+four ABIs evict each other; the scripts warn when it is under 20 GB. The `scripts/android-dev`
+gradle build already runs ninja through AGP and now picks up ccache too (`-Pccache=false` off).
+
 For fast iteration on the vt renderer, a syntax/type check is enough:
 
 ```sh

--- a/scripts/android-dev/carto_mobile_sdk/build.gradle
+++ b/scripts/android-dev/carto_mobile_sdk/build.gradle
@@ -4,6 +4,22 @@ apply plugin: 'com.android.library'
 // This variable should normally reflect the value of '--profile' argument when generating wrappers via 'swigpp-java.py' script!
 def profiles = "standard+valhalla+geocoding+routing+packagemanager"
 
+// Compiler launcher, only when ccache is installed. AGP already drives CMake through ninja, so
+// this is the missing half: every ABI recompiles the same headers, and the Boost.Spirit grammars
+// (mapnikvt ParserUtils/GeneratorUtils, CartoCSSParser, QueryExpressionParser) are ~15% of a full
+// build while practically never changing. Turn it off with './gradlew ... -Pccache=false'.
+def ccacheOptions = {
+    if (project.findProperty('ccache') == 'false') {
+        return []
+    }
+    def name = System.getProperty('os.name').toLowerCase().contains('windows') ? 'ccache.exe' : 'ccache'
+    def found = System.getenv('PATH')?.split(File.pathSeparator)?.collect { new File(it, name) }?.find { it.canExecute() }
+    if (found == null) {
+        return []
+    }
+    return ["-DCMAKE_C_COMPILER_LAUNCHER=${found.absolutePath}", "-DCMAKE_CXX_COMPILER_LAUNCHER=${found.absolutePath}"]
+}
+
 def cmakeOptions = {
     def jsonFile = file('$projectDir/../../../build/sdk_profiles.json')
     def parsedJson = new groovy.json.JsonSlurper().parseText(jsonFile.text)
@@ -90,6 +106,7 @@ android {
             cmake {
                 arguments "-DSDK_VERSION=Devel", "-DSDK_PLATFORM='Android'", "-DANDROID_STL=c++_static", '-DANDROID_ARM_NEON:BOOL=ON', '-DSINGLE_LIBRARY:BOOL=ON', '-DHAVE_ZSTD:BOOL=ON', '-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON', "-DWRAPPER_DIR=${projectDir.absolutePath.replaceAll('\\\\', '/')}/../../../generated/android-java/wrappers"
                 cmakeOptions().each {option -> arguments option }
+                ccacheOptions().each {option -> arguments option }
                 // Render profiling, off unless asked for: './gradlew :app:assembleDebug -PprofileRender'
                 // turns on the per-frame section timings (utils/FrameProfiler.h) and the vt
                 // draw/label/tile counters (vt/RenderStats.h), both printed to logcat as 'PROF'

--- a/scripts/build-android.py
+++ b/scripts/build-android.py
@@ -53,14 +53,13 @@ def buildAndroidSO(args, abi):
     print('Failed to detect available platform APIs')
     return False
   print('Using API-%d for 32-bit builds, API-%d for 64-bit builds' % (api32, api64))
+  resetBuildDirOnGeneratorChange(args, buildDir)
 
-  if not cmake(args, buildDir, options + [
-    '-G', 'Unix Makefiles',
+  if not cmake(args, buildDir, options + getGeneratorOptions(args) + getCCacheOptions(args) + [
     "-DCMAKE_TOOLCHAIN_FILE='%s/build/cmake/android.toolchain.cmake'" % args.androidndkpath,
     "-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON",
     "-DCMAKE_SYSTEM_NAME=Android",
     "-DCMAKE_BUILD_TYPE=%s" % args.configuration,
-    "-DCMAKE_MAKE_PROGRAM='%s'" % args.make,
     "-DCMAKE_ANDROID_NDK='%s'" % args.androidndkpath,
     "-DCMAKE_ANDROID_ARCH_ABI='%s'" % abi,
     "-DWRAPPER_DIR=%s" % ('%s/generated/android-java/wrappers' % baseDir),
@@ -217,7 +216,9 @@ parser.add_argument('--defines', dest='defines', default='', help='Defines for c
 parser.add_argument('--javac', dest='javac', default='javac', help='Java compiler executable')
 parser.add_argument('--jar', dest='jar', default='jar', help='Jar executable')
 parser.add_argument('--zip', dest='zip', default='zip', help='Zip executable')
-parser.add_argument('--make', dest='make', default='make', help='Make executable')
+parser.add_argument('--make', dest='make', default='make', help='Make executable, used only when no ninja is available')
+parser.add_argument('--ninja', dest='ninja', default='auto', help="Ninja executable, 'auto' to detect one, 'none' to build with make")
+parser.add_argument('--ccache', dest='ccache', default='auto', help="Ccache executable, 'auto' to detect one, 'none' to compile without a launcher")
 parser.add_argument('--cmake', dest='cmake', default='cmake', help='CMake executable')
 parser.add_argument('--cmake-options', dest='cmakeoptions', default='', help='CMake options')
 parser.add_argument('--gradle', dest='gradle', default='gradle', help='Gradle executable')
@@ -249,8 +250,10 @@ if not checkExecutable(args.cmake, '--help'):
   print('Failed to find CMake executable. Use --cmake to specify its location')
   sys.exit(-1)
 
-if not checkExecutable(args.make, '--help'):
-  print('Failed to find make executable. Use --make to specify its location')
+resolveBuildTools(args)
+
+if not args.ninjapath and not checkExecutable(args.make, '--help'):
+  print('Failed to find ninja or make executable. Use --ninja or --make to specify its location')
   sys.exit(-1)
 
 if not checkExecutable(args.javac, '-help'):

--- a/scripts/build-routing-android.py
+++ b/scripts/build-routing-android.py
@@ -35,14 +35,13 @@ def buildRoutingSO(args, abi):
         print('Failed to detect available platform APIs')
         return False
     print('Using API-%d for 32-bit builds, API-%d for 64-bit builds' % (api32, api64))
+    resetBuildDirOnGeneratorChange(args, buildDir)
 
-    if not cmake(args, buildDir, options + defines + [
-        '-G', 'Unix Makefiles',
+    if not cmake(args, buildDir, options + defines + getGeneratorOptions(args) + getCCacheOptions(args) + [
         "-DCMAKE_TOOLCHAIN_FILE='%s/build/cmake/android.toolchain.cmake'" % args.androidndkpath,
         "-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON",
         "-DCMAKE_SYSTEM_NAME=Android",
         "-DCMAKE_BUILD_TYPE=%s" % args.configuration,
-        "-DCMAKE_MAKE_PROGRAM='%s'" % args.make,
         "-DCMAKE_ANDROID_NDK='%s'" % args.androidndkpath,
         "-DCMAKE_ANDROID_ARCH_ABI='%s'" % abi,
         '-DSINGLE_LIBRARY:BOOL=ON',
@@ -117,7 +116,9 @@ parser.add_argument('--android-ndk-path', dest='androidndkpath', default='auto',
 parser.add_argument('--android-sdk-path', dest='androidsdkpath', default='auto',   help='Android SDK path')
 parser.add_argument('--defines',          dest='defines',        default='',       help='C++ preprocessor defines (semicolon-separated)')
 parser.add_argument('--javac',            dest='javac',          default='javac',  help='Java compiler executable (accepted, not used)')
-parser.add_argument('--make',             dest='make',           default='make',   help='Make executable')
+parser.add_argument('--make',             dest='make',           default='make',   help='Make executable, used only when no ninja is available')
+parser.add_argument('--ninja',            dest='ninja',          default='auto',   help="Ninja executable, 'auto' to detect one, 'none' to build with make")
+parser.add_argument('--ccache',           dest='ccache',         default='auto',   help="Ccache executable, 'auto' to detect one, 'none' to compile without a launcher")
 parser.add_argument('--cmake',            dest='cmake',          default='cmake',  help='CMake executable')
 parser.add_argument('--cmake-options',    dest='cmakeoptions',   default='',       help='CMake options (semicolon-separated)')
 parser.add_argument('--gradle',           dest='gradle',         default='gradle', help='Gradle executable')
@@ -146,8 +147,10 @@ if not checkExecutable(args.cmake, '--help'):
     print('Failed to find CMake executable. Use --cmake to specify its location')
     sys.exit(-1)
 
-if not checkExecutable(args.make, '--help'):
-    print('Failed to find make executable. Use --make to specify its location')
+resolveBuildTools(args)
+
+if not args.ninjapath and not checkExecutable(args.make, '--help'):
+    print('Failed to find ninja or make executable. Use --ninja or --make to specify its location')
     sys.exit(-1)
 
 if not checkExecutable(args.gradle, '--help'):

--- a/scripts/build-xamarin.py
+++ b/scripts/build-xamarin.py
@@ -37,13 +37,12 @@ def buildAndroidSO(args, abi):
     print('Failed to detect available platform APIs')
     return False
   print('Using API-%d for 32-bit builds, API-%d for 64-bit builds' % (api32, api64))
+  resetBuildDirOnGeneratorChange(args, buildDir)
 
-  if not cmake(args, buildDir, options + [
-    '-G', 'Unix Makefiles',
+  if not cmake(args, buildDir, options + getGeneratorOptions(args) + getCCacheOptions(args) + [
     "-DCMAKE_TOOLCHAIN_FILE='%s/build/cmake/android.toolchain.cmake'" % args.androidndkpath,
     "-DCMAKE_SYSTEM_NAME=Android",
     "-DCMAKE_BUILD_TYPE=%s" % args.configuration,
-    "-DCMAKE_MAKE_PROGRAM='%s'" % args.make,
     "-DWRAPPER_DIR=%s" % ('%s/generated/android-csharp/wrappers' % baseDir),
     "-DSINGLE_LIBRARY:BOOL=ON",
     "-DANDROID_STL='c++_static'",
@@ -183,7 +182,9 @@ parser.add_argument('--msbuild', dest='msbuild', default='msbuild', help='Xamari
 parser.add_argument('--nuget', dest='nuget', default='nuget', help='nuget executable')
 parser.add_argument('--android-ndk-path', dest='androidndkpath', default='auto', help='Android NDK path')
 parser.add_argument('--android-sdk-path', dest='androidsdkpath', default='auto', help='Android SDK path')
-parser.add_argument('--make', dest='make', default='make', help='Make executable for Android')
+parser.add_argument('--make', dest='make', default='make', help='Make executable for Android, used only when no ninja is available')
+parser.add_argument('--ninja', dest='ninja', default='auto', help="Ninja executable for Android, 'auto' to detect one, 'none' to build with make")
+parser.add_argument('--ccache', dest='ccache', default='auto', help="Ccache executable, 'auto' to detect one, 'none' to compile without a launcher")
 parser.add_argument('--cmake', dest='cmake', default='cmake', help='CMake executable')
 parser.add_argument('--cmake-options', dest='cmakeoptions', default='', help='CMake options')
 parser.add_argument('--configuration', dest='configuration', default='Release', choices=['Release', 'RelWithDebInfo', 'Debug'], help='Configuration')
@@ -227,8 +228,9 @@ if not checkExecutable(args.cmake, '--help'):
   sys.exit(-1)
 
 if args.target == 'android':
-  if not checkExecutable(args.make, '--help'):
-    print('Failed to find make executable. Use --make to specify its location')
+  resolveBuildTools(args)
+  if not args.ninjapath and not checkExecutable(args.make, '--help'):
+    print('Failed to find ninja or make executable. Use --ninja or --make to specify its location')
     sys.exit(-1)
   for abi in ANDROID_ABIS:
     if not (abi in args.androidabi or os.path.exists('%s/libcarto_mobile_sdk.so' % getBuildDir('xamarin_android', abi))):

--- a/scripts/build/sdk_build_utils.py
+++ b/scripts/build/sdk_build_utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import glob
 import subprocess
 import argparse
 import shutil
@@ -78,6 +79,85 @@ def checkExecutable(cmd, *cmdArgs):
 
 def cmake(args, dir, cmdArgs):
   return execute(args.cmake, dir, *cmdArgs)
+
+def detectNinja(args):
+  # Ninja over Unix Makefiles: better scheduling on the single ~1700 translation unit target,
+  # and it writes .ninja_log, the only per-file build timing this repo has.
+  ninja = getattr(args, 'ninja', 'auto')
+  if ninja == 'none':
+    return None
+  if ninja != 'auto':
+    return ninja if checkExecutable(ninja, '--version') else None
+  found = shutil.which('ninja')
+  if found:
+    return found
+  # A machine that never installed ninja itself still has one per Android SDK cmake package.
+  sdkPath = getattr(args, 'androidsdkpath', None)
+  candidates = glob.glob('%s/cmake/*/bin/ninja' % sdkPath) if sdkPath else []
+  if not candidates:
+    return None
+  versionKey = lambda path: [int(part) if part.isdigit() else 0 for part in path.split('/')[-3].split('.')]
+  return sorted(candidates, key=versionKey)[-1]
+
+def detectCCache(args):
+  ccache = getattr(args, 'ccache', 'auto')
+  if ccache == 'none':
+    return None
+  if ccache != 'auto':
+    return ccache if checkExecutable(ccache, '--version') else None
+  return shutil.which('ccache')
+
+def getCCacheMaxSizeGB(ccachePath):
+  try:
+    output = subprocess.check_output([ccachePath, '--get-config', 'max_size'], stderr=subprocess.STDOUT).decode('utf-8').strip()
+  except:
+    return None
+  match = re.match(r'([0-9.]+)\s*([KMGT]?)i?B?$', output, re.IGNORECASE)
+  if not match:
+    return None
+  scale = { '': 1e-9, 'K': 1e-6, 'M': 1e-3, 'G': 1.0, 'T': 1000.0 }
+  return float(match.group(1)) * scale.get(match.group(2).upper(), 1.0)
+
+def resolveBuildTools(args):
+  # Resolved once, so the per-ABI builds all report and use the same tools.
+  args.ninjapath = detectNinja(args)
+  args.ccachepath = detectCCache(args)
+  print('Using build tool: %s' % (args.ninjapath or '%s (no ninja found)' % args.make))
+  print('Using compiler launcher: %s' % (args.ccachepath or 'none'))
+  if args.ccachepath:
+    # One ABI writes about 1GB of objects, so on the 5GB default the four ABIs evict each
+    # other and every build stays a miss.
+    maxSizeGB = getCCacheMaxSizeGB(args.ccachepath)
+    if maxSizeGB is not None and maxSizeGB < 20:
+      print('Warning: ccache max_size is %.0fGB, too small to keep a full build. Raise it with: %s --max-size 30G' % (maxSizeGB, args.ccachepath))
+
+def getGeneratorOptions(args):
+  if args.ninjapath:
+    return ['-G', 'Ninja', '-DCMAKE_MAKE_PROGRAM=%s' % args.ninjapath]
+  return ['-G', 'Unix Makefiles', "-DCMAKE_MAKE_PROGRAM='%s'" % args.make]
+
+def resetBuildDirOnGeneratorChange(args, buildDir):
+  # CMake refuses to reconfigure an existing build tree with a different generator, so an
+  # existing Unix Makefiles tree has to go before the first Ninja build.
+  cachePath = '%s/CMakeCache.txt' % buildDir
+  if not os.path.exists(cachePath):
+    return
+  generator = 'Ninja' if args.ninjapath else 'Unix Makefiles'
+  with open(cachePath, 'r') as f:
+    match = re.search(r'^CMAKE_GENERATOR:INTERNAL=(.*)$', f.read(), re.MULTILINE)
+  if match and match.group(1).strip() == generator:
+    return
+  print('Generator changed to %s, clearing build directory %s' % (generator, buildDir))
+  shutil.rmtree(buildDir, True)
+  makedirs(buildDir)
+
+def getCCacheOptions(args):
+  # Every ABI recompiles the same headers, and the four Boost.Spirit grammars (mapnikvt
+  # ParserUtils/GeneratorUtils, CartoCSSParser, QueryExpressionParser) are ~15% of a full
+  # build on their own while practically never changing.
+  if not args.ccachepath:
+    return []
+  return ['-DCMAKE_C_COMPILER_LAUNCHER=%s' % args.ccachepath, '-DCMAKE_CXX_COMPILER_LAUNCHER=%s' % args.ccachepath]
 
 def getBaseDir():
   baseDir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))


### PR DESCRIPTION
## Summary

- The Android-family build scripts (`build-android.py`, `build-routing-android.py`, `build-xamarin.py`) configured CMake with the **Unix Makefiles** generator and no compiler launcher, so each of the four ABIs recompiled the same headers from scratch.
- They now pick **ninja** (from `PATH`, else the newest `$ANDROID_HOME/cmake/*/bin/ninja`) and prefix the compiler with **ccache** when one is installed. Both auto-detect, both opt out: `--ninja none`, `--ccache none`.
- Switching generator clears the affected `build/<target>-<abi>` directory first — CMake refuses to reconfigure a Makefiles tree as Ninja, so without this the first run just errors out.
- The scripts warn when ccache `max_size` is under 20 GB. One ABI writes ~1 GB of objects, so on the 5 GB default the four ABIs evict each other and every build stays a miss (reproduced: one build hit, the next missed all 1135 files). Raise it with `ccache --max-size 30G`.
- `scripts/android-dev` already drives CMake through ninja via AGP, so it only gained the ccache launcher (`-Pccache=false` to turn it off).

iOS and UWP are untouched: the Xcode and Visual Studio generators ignore `CMAKE_<LANG>_COMPILER_LAUNCHER`, so they need a different mechanism.

## Testing

Measured on this machine, arm64 Release, one ABI, with a private cache directory:

| | wall | CPU |
|---|---|---|
| cold (empty cache) | 70.9 s | 1136 s |
| warm (`ninja -t clean` + rebuild) | **13.8 s** | 216 s |

1128 of 1134 compiles were direct ccache hits; the remaining wall time is the thin-LTO link, which is not cacheable.

Also run: `python3 -m py_compile` on all four scripts, the detection helpers exercised for both auto-detect and opt-out, gradle configuration evaluated, and two full `build-android.py` runs end to end (exit 0, valid stripped ELF, generator and both launchers confirmed in `CMakeCache.txt`).

No C++ and no `all/modules/*.i` touched, so the `clang++ -fsyntax-only` gate and SWIG regeneration do not apply. Build tooling only — no runtime behaviour change, nothing to check on device.