### PR TITLE
perf(build): compile the render and tile paths at -O2 in Release

### DIFF
--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -18,7 +18,14 @@ adb install -r -t app/build/outputs/apk/debug/app-debug.apk
 - `-PprofileRender` compiles in `FrameProfiler` (`PROF` lines) and `vt/RenderStats.h` (`RenderStats`
   lines). Neither exists in the binary otherwise.
 - Install from `app/build/outputs/apk/debug/`. `app/build/intermediates/apk/debug/` also holds an
-  `app-debug.apk` and it is **stale**.
+  `app-debug.apk` and it is **stale** — *except* when you pass
+  `-Pandroid.injected.build.abi=<abi>` to build a single ABI, which inverts it: AGP then writes the
+  fresh APK to `intermediates/` and leaves `outputs/` untouched. Check the mtimes, not the path.
+- **`RelWithDebInfo` is not what ships.** It is a plain `-O2 -g` build: no LTO, and none of the
+  per-subproject `-O2`/`-Oz` split, which is gated on `CMAKE_BUILD_TYPE MATCHES Release`. The
+  shipped Release build compiles the SDK at `-Oz -flto=thin`. Bench the shipped configuration with
+  `-PnativeConfig=Release` (Release strips, so simpleperf loses its symbols — use it for `PROF`
+  numbers, not for profiles).
 
 ## The three instruments
 
@@ -123,6 +130,13 @@ and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 | label terrain re-anchor: DEM tile loads no longer read as a scale-only change, plus a grid and a latitude-scale memo | full stack over terrain, interleaved ×3: **1.00 → 1.55 fps**, `prepare` 658 → 219 ms |
 | an off-screen, already-anchored label defers its re-anchor | 1.60 → 1.70 fps — small, most dirty labels do hold a placement |
 | label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
+| render and tile paths at `-O2` in Release instead of `-Oz` | device 39.09 → 37.82 ms/frame (3.2%), CPU work minus the swap wait 14.39 → 13.51 ms (6.1%), `prepare` 2.65 → 2.22, `prelude` 0.91 → 0.70; +614 KB on arm64 |
+
+The `-Oz` → `-O2` A/B is a warning about the emulator as much as a result. Three interleaved cycles
+on the emulator put the mean 4.8% apart but reversed the sign on one cycle out of three — no
+conclusion. The same six runs on the device (Adreno 610) favoured `-O2` in **3 of 3 paired runs**.
+Anything worth a few percent needs the device and needs pairing; a single emulator run will happily
+report 10%.
 
 ### The label culler, measured on the device
 

--- a/scripts/android-dev/carto_mobile_sdk/build.gradle
+++ b/scripts/android-dev/carto_mobile_sdk/build.gradle
@@ -104,8 +104,12 @@ android {
                 // RelWithDebInfo keeps -g, so simpleperf still symbolizes the result.
                 // Turn it off to step through native code in a debugger:
                 //   './gradlew :app:assembleDebug -PnativeOpt=false'
+                // RelWithDebInfo is NOT what ships: it is a plain -O2 -g build, while Release
+                // applies -Oz + thin LTO and the per-subproject -O2/-Oz split. Bench the shipped
+                // configuration with './gradlew ... -PnativeConfig=Release' (no symbols left for
+                // simpleperf then, but the PROF/RenderStats lines still work).
                 if (project.findProperty('nativeOpt') != 'false') {
-                    arguments "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+                    arguments "-DCMAKE_BUILD_TYPE=${project.findProperty('nativeConfig') ?: 'RelWithDebInfo'}"
                 }
             }
         }

--- a/scripts/build/CMakeLists.txt
+++ b/scripts/build/CMakeLists.txt
@@ -191,6 +191,25 @@ file(GLOB SDK_SRC_FILES CONFIGURE_DEPENDS
 )
 set_source_files_properties("${SDK_SRC_DIR}/utils/PlatformUtils.cpp" PROPERTIES COMPILE_OPTIONS "-D_CARTO_MOBILE_SDK_PLATFORM=\"${SDK_PLATFORM}\";-D_CARTO_MOBILE_SDK_VERSION=\"${SDK_VERSION}\"")
 
+# Release builds the whole SDK at -Oz, which is right for the API surface but not for the code
+# the frame budget is actually spent in. Build the render and tile paths for speed, same as the
+# vt/mapnikvt/cartocss subprojects above; everything else (routing, geocoding, search, package
+# manager, network, ui) stays at -Oz.
+if(CMAKE_BUILD_TYPE MATCHES "Release|RELEASE")
+  set(SDK_SPEED_DIRS renderers layers terrain graphics geometry projections vectortiles vectorelements rastertiles datasources)
+  foreach(SDK_SPEED_DIR IN ITEMS ${SDK_SPEED_DIRS})
+    file(GLOB SDK_SPEED_SRC_FILES CONFIGURE_DEPENDS
+      "${SDK_SRC_DIR}/${SDK_SPEED_DIR}/*.cpp"
+      "${SDK_SRC_DIR}/${SDK_SPEED_DIR}/*/*.cpp"
+    )
+    if(WIN32)
+      set_source_files_properties(${SDK_SPEED_SRC_FILES} PROPERTIES COMPILE_OPTIONS "/Ox")
+    else()
+      set_source_files_properties(${SDK_SPEED_SRC_FILES} PROPERTIES COMPILE_OPTIONS "-O2")
+    endif()
+  endforeach()
+endif()
+
 if(WIN32 OR APPLE OR ANDROID)
   list(REMOVE_ITEM SDK_SRC_FILES "${SDK_SRC_DIR}/network/HTTPClientPionImpl.cpp")
 endif()


### PR DESCRIPTION
## Summary

- Release built **the whole SDK at `-Oz`**. Only the `vt`/`mapnikvt`/`cartocss`/`freetype`/`tess2`/`zlib`/`brotli`/`zstd` subprojects were exempted, so `MapRenderer.cpp`, `VectorTileLayer.cpp` and the rest of `all/native` shipped optimised for size. This builds `renderers layers terrain graphics geometry projections vectortiles vectorelements rastertiles datasources` for speed; routing, geocoding, search, packagemanager, network and ui stay at `-Oz`.
- **The demo could not measure this before.** `scripts/android-dev` builds `RelWithDebInfo`, which is a plain `-O2 -g` build — no LTO, and none of the per-subproject `-O2`/`-Oz` split, which is gated on `CMAKE_BUILD_TYPE MATCHES Release`. Every perf number ever taken through this demo came from an all-`-O2` binary that is not what ships. Added `-PnativeConfig=Release` so the shipped configuration can be benched.

## Testing

Device, Adreno 610 (`HLTE556N`), demo default camera, 8 pans per run, `PROF` windows over 1600 ms discarded. Three **interleaved paired** cycles from two prebuilt APKs, so no rebuild sits between a pair:

| run | `-Oz` | `-O2` |
|---|---|---|
| 1 | 38.86 ms | 36.84 ms |
| 2 | 37.82 ms | 36.48 ms |
| 3 | 40.58 ms | 40.15 ms |
| **mean** | **39.09 ms** | **37.82 ms** |

`-O2` wins **3 of 3 pairs**: 3.2% of frame time, 25.6 → 26.4 fps.

The frame is GPU-bound at this camera — `sky` is 24.7 of the 39 ms and is the swap wait, not work (GPU `layers` alone reads 22–26 ms). Against the CPU portion only the change is **14.39 → 13.51 ms, -6.1%**, landing where expected: `prepare` 2.65 → 2.22 (-16%), `prelude` 0.91 → 0.70 (-23%), CPU `layers` 5.29 → 5.10. `drape`, `layers3D`, `billboards` flat.

**Size cost: arm64 `.so` 11,538,240 → 12,152,504 bytes, +614 KB (+5.3%).**

The emulator could not resolve this: three cycles there put the means 4.8% apart but **reversed the sign on one cycle of three**. That contrast is written into `docs/rendering/10-performance.md` along with the flag gap, because a single emulator run reports 10% on a change the device puts at 3.2%.

No C++ touched and no `all/modules/*.i` touched, so the `clang++ -fsyntax-only` gate and SWIG regeneration do not apply. Not verified on iOS — the same `-Oz` applies there and the change is platform-neutral, but no iOS build was run.

## Open question for review

The directory list is a judgement call. `datasources` is in because tile fetch/decode sits there; `styles`, `components`, `core` and `utils` are out. Worth a second opinion on whether that split is the right one.