### PR TITLE
perf(routing): build Valhalla without the unused service actions

### DIFF
--- a/routing-lib/native/routing/ValhallaRoutingService.h
+++ b/routing-lib/native/routing/ValhallaRoutingService.h
@@ -122,8 +122,10 @@ namespace routing {
          * already contain that key.
          *
          * @param endpoint  Endpoint name: "route", "trace_attributes",
-         *                  "trace_route", "matrix", "isochrone", "locate",
-         *                  "height", "expansion", "centroid", "status".
+         *                  "trace_route", "centroid". Building with
+         *                  -DVALHALLA_SERVICES=ON adds "matrix", "isochrone",
+         *                  "locate", "height", "expansion" and "status";
+         *                  without it those throw "Unknown Valhalla endpoint".
          * @param jsonBody  Full Valhalla request JSON string.
          * @return          Raw Valhalla JSON response string.
          */

--- a/routing-lib/native/routing/utils/ValhallaRoutingProxy.cpp
+++ b/routing-lib/native/routing/utils/ValhallaRoutingProxy.cpp
@@ -102,20 +102,25 @@ std::string ValhallaRoutingProxy::CallRaw(
         const std::string& jsonBody) {
 
     // Map endpoint string → valhalla action enum
+    // The endpoints under _CARTO_VALHALLA_SERVICES need Valhalla action sources that are left out
+    // of the build unless it is configured with -DVALHALLA_SERVICES=ON. Without it they are not
+    // recognised at all, so a caller gets "Unknown Valhalla endpoint" rather than a silent failure.
     valhalla::Options::Action action;
     if      (endpoint == "route"             ) action = valhalla::Options::route;
+    else if (endpoint == "trace_route"       ) action = valhalla::Options::trace_route;
+    else if (endpoint == "trace_attributes"  ) action = valhalla::Options::trace_attributes;
+    else if (endpoint == "centroid"          ) action = valhalla::Options::centroid;
+#ifdef _CARTO_VALHALLA_SERVICES
     else if (endpoint == "locate"            ) action = valhalla::Options::locate;
     else if (endpoint == "matrix" ||
              endpoint == "sources_to_targets") action = valhalla::Options::sources_to_targets;
     else if (endpoint == "optimized_route"   ) action = valhalla::Options::optimized_route;
     else if (endpoint == "isochrone"         ) action = valhalla::Options::isochrone;
-    else if (endpoint == "trace_route"       ) action = valhalla::Options::trace_route;
-    else if (endpoint == "trace_attributes"  ) action = valhalla::Options::trace_attributes;
     else if (endpoint == "height"            ) action = valhalla::Options::height;
     else if (endpoint == "transit_available" ) action = valhalla::Options::transit_available;
     else if (endpoint == "expansion"         ) action = valhalla::Options::expansion;
-    else if (endpoint == "centroid"          ) action = valhalla::Options::centroid;
     else if (endpoint == "status"            ) action = valhalla::Options::status;
+#endif
     else throw GenericException("Unknown Valhalla endpoint", endpoint);
 
     std::string result;
@@ -150,6 +155,7 @@ std::string ValhallaRoutingProxy::CallRaw(
             result = valhalla::tyr::serializeDirections(api);
             break;
 
+#ifdef _CARTO_VALHALLA_SERVICES
         case valhalla::Options::sources_to_targets:
             lokiWorker.matrix(api);
             result = thorWorker.matrix(api);
@@ -177,14 +183,15 @@ std::string ValhallaRoutingProxy::CallRaw(
             result = thorWorker.expansion(api);
             break;
 
-        case valhalla::Options::centroid:
-            thorWorker.centroid(api);
-            result = valhalla::tyr::serializePbf(api);
-            break;
-
         case valhalla::Options::status:
             lokiWorker.status(api);
             result = valhalla::tyr::serializeStatus(api);
+            break;
+#endif
+
+        case valhalla::Options::centroid:
+            thorWorker.centroid(api);
+            result = valhalla::tyr::serializePbf(api);
             break;
 
         default:

--- a/scripts/build/CMakeLists.txt
+++ b/scripts/build/CMakeLists.txt
@@ -140,6 +140,10 @@ endif(INCLUDE_SQLITE)
 
 if(INCLUDE_VALHALLA)
   list(APPEND SDK_EXTERNAL_SUBPROJECTS "date" "protobuf" "valhalla")
+  # ValhallaRoutingProxy only calls route(), trace_attributes() and narrate(), so the matrix,
+  # isochrone, locate, height, expansion, status and optimized-route actions are dead weight in the
+  # SDK. Declared here so this default wins over the ON default in the valhalla subproject.
+  option(VALHALLA_SERVICES "Build the Valhalla service actions beyond routing and map matching" OFF)
 endif(INCLUDE_VALHALLA)
 
 foreach(SDK_SUBPROJECT IN ITEMS ${SDK_CARTO_SUBPROJECTS})

--- a/scripts/routing/CMakeLists.txt
+++ b/scripts/routing/CMakeLists.txt
@@ -71,6 +71,16 @@ endif(APPLE)
 # (same mechanism as scripts/build/CMakeLists.txt)
 set(ROUTING_EXTERNAL_SUBPROJECTS sqlite sqlite3pp zstd date protobuf valhalla)
 
+# CallRaw currently serves the same endpoints as the SDK - route, trace_route, trace_attributes,
+# centroid - so the matrix, isochrone, locate, height, expansion, status and optimized-route
+# actions are left out of the Valhalla build. Configure with -DVALHALLA_SERVICES=ON to build them
+# back in; the endpoints that need them are compiled in by the same switch. Declared before the
+# subproject is added so this default wins over the ON default there.
+option(VALHALLA_SERVICES "Build the Valhalla service actions beyond routing and map matching" OFF)
+if(VALHALLA_SERVICES)
+  add_definitions("-D_CARTO_VALHALLA_SERVICES")
+endif()
+
 foreach(SDK_SUBPROJECT IN ITEMS ${ROUTING_EXTERNAL_SUBPROJECTS})
   add_subdirectory("${SDK_EXTERNAL_LIBS_DIR}/${SDK_SUBPROJECT}" "${SDK_SUBPROJECT}")
 endforeach()


### PR DESCRIPTION
## Summary

- Turns the new `VALHALLA_SERVICES` option **off** in both consumers. `ValhallaRoutingProxy` only calls `route()`, `trace_attributes()` and `narrate()`, so matrix, isochrone, locate, height, expansion, status and optimized route were 19 translation units of dead weight. `--gc-sections` could not remove them: each is rooted from `.init_array` by a namespace-scope static.
- `routing-lib`'s `callRaw` did serve those endpoints, so it now gates them behind `_CARTO_VALHALLA_SERVICES` and serves the same set as the SDK: `route`, `trace_route`, `trace_attributes`, `centroid`. An endpoint that is not built in is not recognised either, so a caller gets `Unknown Valhalla endpoint` rather than a silent failure.
- Configure with `-DVALHALLA_SERVICES=ON` to build the full `tyr::actor_t` surface back in — one option drives both the Valhalla source list and these endpoints.

## Testing

arm64 Release, same build tree, only the option flipped (reproduced twice in both directions):

| | ON | OFF | delta |
|---|---|---|---|
| file | 11,522,232 | 11,418,904 | **−103,328 B (−0.9%)** |
| `.text` | 7,249,052 | 7,150,112 | −98,940 |
| `.init_array` | 2,472 B = 309 initializers | 2,328 B = 291 | −18 at every `dlopen` |

Both option paths build and link, for `carto_mobile_sdk` and for the `valhalla_routing` module — the touched `.cpp` went through the real Android build in both configurations, which is stronger than the usual `clang++ -fsyntax-only` gate. No `all/modules/*.i` touched, so no SWIG regeneration. Not exercised at runtime: no routing request was issued against a built tile set, so `callRaw("route"/"trace_route")` behaviour is unverified beyond compiling.

## Breaking changes

`ValhallaRoutingService::callRaw` no longer accepts `matrix`/`sources_to_targets`, `isochrone`, `locate`, `height`, `expansion`, `optimized_route`, `transit_available` or `status` in a default build — they throw `Unknown Valhalla endpoint`. Per your call to bring the routing module down to the SDK's API surface for now; rebuild with `-DVALHALLA_SERVICES=ON` to restore them.

## Depends on

https://github.com/Akylas/mobile-external-libs/pull/2 — merges first, then this pointer bump is rebased onto the merged commit.