### PR TITLE
docs: record where the SDK's binary size and build time go

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,14 @@ cd scripts && python3 swigpp-java.py --profile "standard+valhalla+geocoding+rout
   --swig /Volumes/dev/carto/mobile-swig/swig     # 3. regenerate wrappers, else the build fails
 ```
 
-The checked-in `generated/` wrappers reference the newer API and will not compile against older
+The `generated/` wrappers in the tree reference the newer API and will not compile against older
 headers. Restore the same way (`git checkout HEAD -- all/`, submodule back to its branch,
 regenerate). SWIG is never run by gradle — any change to `all/modules/*.i` needs step 3 too.
+
+**`generated/` is gitignored, not tracked.** There is no `git checkout` that brings it back: a
+`swigpp-java.py` run overwrites the tree's wrappers with whatever `--profile` you passed (322 files
+for the full profile, 256 for `standard`, 236 for `lite`), and the only way back is to run it again
+with the profile you develop against. Size per profile is in [`docs/build-size.md`](docs/build-size.md).
 
 `gh pr create` needs `--repo Akylas/mobile-sdk` (or `--repo farfromrefug/mobile-carto-libs`).
 Both repos are forks of the archived CartoDB originals, and without `--repo` gh targets the

--- a/docs/build-size.md
+++ b/docs/build-size.md
@@ -73,11 +73,6 @@ the 5 GB default has the four ABIs evicting each other.
 
 ## Open, roughly by value
 
-- **`RegisterNatives`** instead of 3138 exported symbols. The mangled export names average ~88
-  bytes; a `JNINativeMethod` table needs only the short name and signature, so this trades ~277 KB
-  of `.dynstr` for maybe 60 KB of `.rodata` and drops `.dynsym` (83 KB) and the hash tables (52 KB)
-  outright. Also makes symbol binding at load cheaper. Needs a post-processing step over the 322
-  generated wrapper files; failure mode is a loud `UnsatisfiedLinkError` at startup.
 - **iOS gets no LTO for the static framework** — `-flto=full` sits inside `if(SHARED_LIBRARY)` in
   `scripts/build/CMakeLists.txt`, so the default build misses it while Android gets `-flto=thin`.
   Bitcode is still wired (`ENABLE_BITCODE=YES` for armv7/arm64, dead since Xcode 14) and `i386` and
@@ -88,3 +83,33 @@ the 5 GB default has the four ABIs evicting each other.
   needs the callback paths audited before it can be trusted.
 - Unset and cheap: `-Wl,--exclude-libs,ALL`, `-fmerge-all-constants`, `-fno-math-errno`. No PGO
   anywhere.
+
+## Measured NOT to work — `RegisterNatives`
+
+The obvious-looking win is to stop exporting the 3496 `Java_*` wrappers and register them from
+`JNI_OnLoad` instead. It was built and measured: the generator derives every descriptor from the
+`*ModuleJNI.java` sources, and the emitted symbol set matched the 3496 exports exactly, in both
+directions. **It makes the library 131 KB bigger.**
+
+| section | exported | registered | delta |
+|---|---|---|---|
+| `.dynstr` | 307,725 | 4,202 | −303,523 |
+| `.dynsym` | 92,160 | 8,280 | −83,880 |
+| `.hash` + `.gnu.hash` + `.gnu.version` | 64,096 | 3,490 | −60,606 |
+| `.rela.dyn` | 574,512 | 836,784 | **+262,272** |
+| `.rodata` | 1,112,997 | 1,338,149 | +225,152 |
+| `.data.rel.ro` | 209,168 | 298,352 | +89,184 |
+| **file** | 11,418,904 | 11,547,912 | **+131,055** |
+
+The −448 KB of dynamic symbol machinery is real and lands as predicted. What kills it is that
+`JNINativeMethod` holds **three pointers** — name, signature, function — so 3496 methods put 10,488
+relocated pointers in `.data.rel.ro`, each costing a 24-byte `R_AARCH64_RELATIVE` entry. A string
+table the dynamic linker already packs efficiently gets traded for a relocated pointer table that
+does not.
+
+A version storing string *offsets* into one blob, and materialising the function pointers in code
+rather than data, would remove ~178 KB of relocations and ~84 KB more, landing near **−150 to
+−190 KB (1.3–1.6%)**. That is a hand-rolled offset encoding inside generated code, for less than a
+twentieth of what moving an app to the `standard` profile gives. Not worth it on size alone. The
+one argument not tested is load time: 3496 fewer dynamic symbols should make `dlopen` cheaper, and
+if that turns out to matter the calculus changes.

--- a/docs/build-size.md
+++ b/docs/build-size.md
@@ -1,0 +1,90 @@
+# Binary size and build time
+
+Where the shipped SDK's bytes and build minutes actually go, measured rather than assumed, plus
+the mechanisms that make some of it hard to remove. Render-side performance lives in
+[rendering/10-performance.md](rendering/10-performance.md); this page is about the artifact.
+
+All numbers: Android **arm64-v8a, Release**, one build tree, NDK 27.3.
+
+## What the profiles cost
+
+The profile machinery (`scripts/build/sdk_profiles.json`) is not cosmetic — it is by far the
+largest size lever in the project, and CI already publishes one AAR and one iOS zip per profile
+(`.github/workflows/build.yml` matrix `["full","standard","lite"]`).
+
+| profile | `.so` | vs full | JNI wrapper files |
+|---|---|---|---|
+| `full` (valhalla + geocoding + routing + packagemanager + sqlite) | 11,418,904 | — | 322 |
+| `standard` (sqlite, search, offline, editable) | 7,997,064 | **−3.42 MB, −30.0%** | 256 |
+| `lite` | 7,043,888 | **−4.38 MB, −38.3%** | 236 |
+
+Nothing needs inventing to get those 3.4 MB back — an app that does not route offline should
+consume the `standard` artifact. Measure a profile by regenerating its wrappers first, because
+they are profile-specific:
+
+```sh
+cd scripts && python3 swigpp-java.py --profile standard --swig /Volumes/dev/carto/mobile-swig/swig
+```
+
+`generated/` is **gitignored**, not checked in — that command overwrites whatever profile's
+wrappers are currently in the tree, and there is no `git checkout` to undo it. Regenerate with the
+profile you actually develop against when you are done.
+
+## Where the bytes go (full profile)
+
+Sections, and `.text` ownership by symbol attribution:
+
+| section | size | note |
+|---|---|---|
+| `.text` | 6.7 MB | |
+| unwind metadata | 1.69 MB | `.eh_frame` 1.04 + `.gcc_except_table` 0.36 + `.eh_frame_hdr` 0.28 — **16% of the file** |
+| `.rodata` | 1.01 MB | |
+| `.dynsym`+`.dynstr`+hashes | 0.41 MB | **3138 exported `Java_*` symbols** |
+| `.bss` | 1.9 MB | RAM, not file; demand-zero |
+
+`.text` ownership: valhalla ~22%, libc++/unwind ~16%, `all/native` ~15%, generated JNI wrappers
+~5%, boost ~4%, freetype/sqlite/harfbuzz ~2% each. **vt + mapnikvt + cartocss together are 3.2%** —
+the renderer is not where the size is.
+
+## Two mechanisms worth knowing
+
+**`--gc-sections` cannot drop a translation unit that has a namespace-scope static.** `.init_array`
+references its initializer, which roots the whole TU no matter what else the linker strips. This is
+why unreachable Valhalla service actions stayed linked despite `-Oz`, `--gc-sections` and
+`--icf=all`, and why the fix was to keep the sources out of the build list rather than to lean
+harder on the linker. The full-profile library ran **309 static initializers at every `dlopen`**
+before that prune, 291 after.
+
+**`.bss` is not RAM until it is touched.** `baldr::BucketCosTable` is 1.5 MB of `.bss`, which reads
+alarming, but the symbol is a function-local static (`_ZZ…E8instance` with a `_ZGV…` guard) reached
+only from `graphtile.h` behind `has_predicted_speed()`. Demand-zero pages cost nothing until the
+first predicted-speed decode. Check the symbol type and the guard before "fixing" a large `.bss`
+entry.
+
+## Build time
+
+45.6 min of CPU per ABI, four ABIs, each recompiling the same headers. By module: mapnikvt 24%,
+valhalla 19%, generated JNI wrappers 14%, cartocss 8%. The individual hogs are all Boost.Spirit
+grammars — `ParserUtils.cpp` 24 s, `CartoCSSParser.cpp` 22 s, `GeneratorUtils.cpp` 21 s,
+`QueryExpressionParser.cpp` 12 s — roughly 15% of a full build between them, and they essentially
+never change, so they are pure ccache fodder. With ninja + ccache one ABI goes 70.9 s cold to
+13.8 s warm; raise the cache first (`ccache --max-size 30G`), since one ABI writes about 1 GB and
+the 5 GB default has the four ABIs evicting each other.
+
+## Open, roughly by value
+
+- **`RegisterNatives`** instead of 3138 exported symbols. The mangled export names average ~88
+  bytes; a `JNINativeMethod` table needs only the short name and signature, so this trades ~277 KB
+  of `.dynstr` for maybe 60 KB of `.rodata` and drops `.dynsym` (83 KB) and the hash tables (52 KB)
+  outright. Also makes symbol binding at load cheaper. Needs a post-processing step over the 322
+  generated wrapper files; failure mode is a loud `UnsatisfiedLinkError` at startup.
+- **iOS gets no LTO for the static framework** — `-flto=full` sits inside `if(SHARED_LIBRARY)` in
+  `scripts/build/CMakeLists.txt`, so the default build misses it while Android gets `-flto=thin`.
+  Bitcode is still wired (`ENABLE_BITCODE=YES` for armv7/arm64, dead since Xcode 14) and `i386` and
+  `armv7` are still in `IOS_ARCHS`.
+- **Unwind tables on the C-only dependencies** (sqlite, libpng, libjpeg, libwebp, freetype, brotli,
+  zstd, miniz) against that 1.69 MB. Risky rather than free: a C++ exception thrown from a callback
+  has to unwind back through those C frames, and without tables that is a `std::terminate`, so it
+  needs the callback paths audited before it can be trusted.
+- Unset and cheap: `-Wl,--exclude-libs,ALL`, `-fmerge-all-constants`, `-fno-math-errno`. No PGO
+  anywhere.


### PR DESCRIPTION
## Summary

Documentation only — `docs/build-size.md`, plus one factual fix in `CLAUDE.md`.

The headline is that **the profile machinery is the largest size lever in the project and had never been quantified**, and CI already publishes an AAR and an iOS zip per profile (`build.yml` matrix `["full","standard","lite"]`). An app that does not route offline can drop 3.4 MB today with no code change:

| profile | arm64 Release `.so` | vs full |
|---|---|---|
| `full` | 11,418,904 | — |
| `standard` | 7,997,064 | **−3.42 MB, −30.0%** |
| `lite` | 7,043,888 | **−4.38 MB, −38.3%** |

It also records where effort should *not* go: the renderer is 3.2% of `.text`, against valhalla at ~22% and libc++/unwind at ~16%.

And two mechanisms that each cost a round to work out:

- **`--gc-sections` cannot drop a translation unit that has a namespace-scope static** — `.init_array` roots it. That is why unreachable Valhalla actions stayed linked under `-Oz` + `--gc-sections` + `--icf=all`, and the full profile ran **309 static initializers at every `dlopen`**.
- **A large `.bss` entry is not RAM until touched.** `baldr::BucketCosTable` is 1.5 MB of `.bss` but is a function-local static behind a `_ZGV` guard, reached only behind `has_predicted_speed()` — demand-zero, so it costs nothing. I had claimed otherwise earlier; the symbol table says no.

`CLAUDE.md` fix: `generated/` is **gitignored, not checked in**. A `swigpp-java.py` run overwrites the tree's wrappers (322 files full, 256 standard, 236 lite) and there is no `git checkout` to undo it — worth knowing before measuring a profile, which is how I hit it.

## Testing

Every number came from a real build in one tree with only the profile changing: wrappers regenerated per profile with `swigpp-java.py`, then configured and built for arm64 Release. The `full` figure is measured with mobile-sdk#64's Valhalla prune in the tree, so it is the size that PR lands on, not current master's 11,522,232.

No code, no build files touched.