### PR TITLE
perf(build): run the SWIG passes concurrently

### DIFF
--- a/scripts/swigpp-java.py
+++ b/scripts/swigpp-java.py
@@ -4,6 +4,7 @@ import sys
 import argparse
 import subprocess
 import shutil
+import concurrent.futures
 from build.sdk_build_utils import *
 
 ENUM_TEMPLATE = """
@@ -467,8 +468,8 @@ def findRegexInFile(sourcePath, regexp):
 
   m = re.search(regexp, data)
 
-def buildSwigPackage(args, sourceDir, packageName):
-  for fileName in os.listdir(sourceDir):
+def collectSwigJobs(args, sourceDir, packageName, jobs):
+  for fileName in sorted(os.listdir(sourceDir)):
     if fileName == 'NutiSwig.i':
       continue
     fileNameWithoutExt = fileName.split(".")[0]
@@ -490,11 +491,25 @@ def buildSwigPackage(args, sourceDir, packageName):
       includes += ["-I%s/Lib/java" % swigPath, "-I%s/Lib" % swigPath]
     defines = ["-D%s" % define for define in args.defines.split(';') if define]
     cmd = [args.swig, "-c++", "-java", "-package", "com.carto.%s" % packageName, "-outdir", proxyDir, "-o", outPath, "-doxygen"] + defines + includes + [sourcePath]
-    if subprocess.call(cmd) != 0:
-      print("Error in %s" % fileName)
+    jobs.append({ 'cmd': cmd, 'fileName': fileName, 'sourcePath': sourcePath,
+                  'proxyDir': proxyDir, 'fileNameWithoutExt': fileNameWithoutExt })
+
+def runSwigJobs(jobs):
+  # One SWIG process per module, and no two modules write the same output, so the calls run
+  # concurrently - the whole pass was one core at 96% before. The proxy fix-ups stay serial and
+  # in collection order: two modules can name the same %template proxy, and the rewrite is a
+  # read-modify-write of a shared file.
+  workers = min(len(jobs), (os.cpu_count() or 1))
+  with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+    codes = list(pool.map(lambda job: subprocess.call(job['cmd']), jobs))
+  for job, code in zip(jobs, codes):
+    if code != 0:
+      print("Error in %s" % job['fileName'])
       return False
 
-    for line in [line.rstrip('\n') for line in readUncommentedLines(sourcePath)]:
+  for job in jobs:
+    proxyDir, fileNameWithoutExt = job['proxyDir'], job['fileNameWithoutExt']
+    for line in [line.rstrip('\n') for line in readUncommentedLines(job['sourcePath'])]:
       match = re.search(r'^\s*%template\((.*)\).*$', line)
       if match:
         templateFileNameWithoutExt = match.group(1)
@@ -505,16 +520,17 @@ def buildSwigPackage(args, sourceDir, packageName):
     os.remove(os.path.join(proxyDir, fileNameWithoutExt + "Module.java"))
   return True
 
-def buildSwigPackages(args, sourceDir, basePackageName):
-  for dirName in os.listdir(sourceDir):
+def buildSwigPackages(args, sourceDir, basePackageName, jobs=None):
+  topLevel = jobs is None
+  jobs = [] if topLevel else jobs
+  for dirName in sorted(os.listdir(sourceDir)):
     sourcePath = os.path.join(sourceDir, dirName)
     if not os.path.isdir(sourcePath) or dirName.startswith("."):
       continue
     packageName = (basePackageName + '.' if basePackageName else '') + dirName
-    buildSwigPackages(args, sourcePath, packageName)
-    if not buildSwigPackage(args, sourcePath, packageName):
-      return False
-  return True
+    buildSwigPackages(args, sourcePath, packageName, jobs)
+    collectSwigJobs(args, sourcePath, packageName, jobs)
+  return runSwigJobs(jobs) if topLevel else True
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--profile', dest='profile', default=getDefaultProfileId(), type=validProfile, help='Build profile')


### PR DESCRIPTION
## Summary

`swigpp-java.py` called SWIG once per module in a serial loop, so regenerating the full profile — 228 modules — sat at **96% of a single core for 28.3 s**. Jobs are now collected first and the subprocesses run through a thread pool.

The proxy fix-ups deliberately stay **serial and in collection order**: two modules can name the same `%template` proxy, and `fixProxyCode` is a read-modify-write of a shared file. Only the SWIG calls overlap, and no two modules write the same output.

## Testing

| | wall | CPU |
|---|---|---|
| serial | 28.3 s | 96% |
| parallel | **4.5 s** | 792% |

Correctness is the point here, not the clock: all **1038 generated files hash byte-for-byte identical** to the serial output (SHA-256 over the whole `generated/android-java` tree), and that held over **two consecutive parallel runs** — a race that only shows intermittently would have to survive both.

## Not done

`swigpp-objc.py` and `swigpp-csharp.py` have the identical loop and would take the identical change. Left alone because this checkout only generates the Java bindings, so I cannot verify their output the same way; happy to follow up if you can point me at a way to diff those trees.

## Context

Asked while looking at SWIG more broadly. Worth recording what the same investigation turned up, since it bounds what else is worth doing here:

- **The fork is SWIG 2.0.11 (2013)**, `farfromrefug/mobile-swig`, ~40 patches on top. Updating to 4.x is blocked by the fact that those patches include an **entire Objective-C backend** — upstream SWIG has never had an ObjC target, not even in 4.3. Some patches would become redundant (upstream gained `-doxygen` in 4.0), but the ObjC module has no upstream equivalent, so an update means porting a bespoke language module across 12 years of SWIG internals or dropping the iOS bindings.
- **The generator was never the expensive part.** What SWIG *emits* is: 322 wrapper `.cpp` at ~14% of build CPU, 0.71 MB of `.text`, and 3138 exported symbols costing 0.41 MB of `.dynsym`/`.dynstr`/hash tables. That last one is the remaining lever — a `RegisterNatives` table instead of 3138 exports.