### PR TITLE
perf(ios): apply LTO to the static framework, not just the shared one

### DIFF
--- a/scripts/build/CMakeLists.txt
+++ b/scripts/build/CMakeLists.txt
@@ -72,10 +72,13 @@ if(APPLE)
     set(CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM ${SDK_DEV_TEAM})
   endif()
 
-  if(SHARED_LIBRARY)
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -flto=full")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto=full")
-  endif()
+  # LTO used to be shared-framework only, so the static framework - what actually ships - was the
+  # one build without it. It is safe here because the Release static library is prelinked into a
+  # single master object (GENERATE_MASTER_OBJECT_FILE below): the ld -r that produces it runs the
+  # LTO codegen, so the archive member we ship is native code, not bitcode that would then need a
+  # compatible toolchain in every consuming app.
+  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -flto=full")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto=full")
 
   if(CMAKE_BUILD_TYPE MATCHES "Release|RELEASE")
     set(CMAKE_XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING YES)


### PR DESCRIPTION
## Summary

`-flto=full` sat inside `if(SHARED_LIBRARY)` in `scripts/build/CMakeLists.txt`, so **the static framework — the artifact that actually ships — was the one build without it**, while Android has had `-flto=thin` all along.

**Why this is safe, verified rather than assumed.** The concern with LTO on a *distributed static library* is that the archive ends up holding LLVM bitcode, which then needs a compatible toolchain in every consuming app. That does not happen here: the Release static library is prelinked into a single master object (`CMAKE_XCODE_ATTRIBUTE_GENERATE_MASTER_OBJECT_FILE`, set a few lines below), and the `ld -r` that produces it runs the LTO codegen. The built framework contains exactly one member, `libcarto_mobile_sdk.a-arm64-prelink.o`, and `file(1)` reports `Mach-O 64-bit object arm64` — native code, not bitcode.

## Testing

Two full builds, arm64 device slice, `standard` profile, MetalANGLE, Xcode 26.5:

| | baseline | with LTO | delta |
|---|---|---|---|
| framework binary | 29,986,520 | 29,653,736 | **−332,784 (−1.1%)** |
| `__TEXT` segment | 23,125,616 | 22,872,680 | −252,936 |
| `__text` (code) | 10,015,404 | 9,931,532 | −83,872 |
| `__const` | 1,484,756 | 1,473,376 | −11,380 |
| `__gcc_except_tab` | 491,860 | 488,776 | −3,084 |
| build time for the slice | 45.9 s | 64.4 s | **+40%** |

Build time is one sample each and CI builds several slices, so budget for it there.

**Not measured:** the simulator and maccatalyst slices, the `full` profile, any runtime performance effect (cross-TU inlining should help, but I have no iOS bench), and no app was run against the result. An on-device smoke test before this leaves draft would be worth it.

## Two side findings

- **`i386`/`armv7` are already excluded** by default (`build-ios.py:366` filters them out of `IOS_ARCHS`). I had previously listed them as still being built — that was wrong.
- **The non-MetalANGLE iOS path does not build in this checkout.** `include_directories("${SDK_BASE_DIR}/ios/glwrapper")` is commented out in `scripts/build/CMakeLists.txt`, so a plain `build-ios.py` without `--use-metalangle` fails with `'GLES2/gl2.h' file not found`. CI always passes `--use-metalangle`, so it is invisible there. Not touched here — flagging it as a separate thing to decide (fix the include, or drop the non-MetalANGLE path).

Bitcode (`ENABLE_BITCODE=YES` for arm64, dead since Xcode 14) is still wired and is still passed; Xcode 26 ignores it and the build succeeds, so I left it alone rather than widen this PR.

## Note for whoever merges

mobile-sdk#65 documents this as an open item in `docs/build-size.md`; that entry needs updating once both land.