### PR TITLE
fix(components): request a redraw after Layers::setAll

### DIFF
--- a/all/native/components/Layers.cpp
+++ b/all/native/components/Layers.cpp
@@ -103,9 +103,15 @@ namespace carto {
             for (const std::shared_ptr<Layer>& layer : layers) {
                 mapRenderer->layerChanged(layer, false);
             }
+            // ...and a redraw for the ones that are GONE, which nothing above speaks for: a layer
+            // that just left the list gets no layerChanged, so with the remaining layers already
+            // loaded there is nothing to schedule a frame and the removed content stays on screen
+            // until something else happens to redraw (a pan). Every other mutator here ends with
+            // this call.
+            mapRenderer->requestRedraw();
         }
     }
-    
+
     void Layers::insert(int index, const std::shared_ptr<Layer>& layer) {
         if (!layer) {
             throw NullArgumentException("Null layer");


### PR DESCRIPTION
## Summary

`Layers::setAll` notified the layers in the **new** list (`layerChanged`) and nothing else, so a removal told the renderer nothing: the layer that just left the list gets no `layerChanged`, and with the remaining layers already loaded there was nothing to schedule a frame. The removed content stayed on screen until something else happened to draw one.

Adding a layer looked fine, because the new layer loads and draws itself — which is what made this look like "removal is broken" rather than "setAll never asks for a frame".

Every other mutator in the file (`add`, `insert`, `remove`, `removeAll`) already ends with `requestRedraw()`. This adds the same call.

## How it showed up

Found from the iOS demo (#68): toggling a stand-alone layer off left it on screen until the next pan, while composite slots were fine — those change the composite layer itself, which does get a `layerChanged`.

An app whose own code calls `requestRedraw`/`requestRender` after changing layers (the Android demo does) never sees it, which is presumably why it survived this long.

## Testing

`clang++ -fsyntax-only` clean on `all/native/components/Layers.cpp`, and verified on the iOS simulator: with the fix, switching the satellite layer off from the settings panel clears it immediately with no pan; without it, the tiles stay until the map moves.

Not a render-path change — no doc page covers `Layers`.