### PR TITLE
feat(ios): add the camera readout overlay and mirror requestRender

### DIFF
--- a/scripts/ios-dev/CartoDemo/DemoMap.h
+++ b/scripts/ios-dev/CartoDemo/DemoMap.h
@@ -85,6 +85,10 @@ typedef NS_ENUM(NSInteger, DemoFeature) {
 - (void)applyDebugConfig;
 - (void)applyDayCycle:(float)hourUtc;
 - (void)applyCamera;
+/** Redraw request, the counterpart of Android's mapView.requestRender(). */
+- (void)requestRender;
+/** Elevation under a WGS84 position; blocks on tile loading, so call it off the main thread. */
+- (double)getElevation:(NTMapPos *)wgs84Pos;
 /** Free roam, panning mode and how far above the horizon the view may look. */
 - (void)applyLookRange;
 

--- a/scripts/ios-dev/CartoDemo/DemoMap.m
+++ b/scripts/ios-dev/CartoDemo/DemoMap.m
@@ -145,6 +145,16 @@ static const DemoFeature LAYER_ORDER[] = {
     [self startScriptedAnimation];
 }
 
+/** Elevation under a WGS84 position; blocks on tile loading, so call it off the main thread. */
+- (double)getElevation:(NTMapPos *)wgs84Pos {
+    return _terrainOptions ? [_terrainOptions getElevation:wgs84Pos] : 0;
+}
+
+/** The counterpart of Android's mapView.requestRender(): iOS redraws when the renderer asks. */
+- (void)requestRender {
+    [[self.mapView getMapRenderer] requestRedraw];
+}
+
 - (void)after:(float)seconds run:(void (^)(void))block {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(seconds * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), block);
@@ -216,6 +226,7 @@ static const DemoFeature LAYER_ORDER[] = {
     // The sky objects are built with their layer, which happens here, so place them now that they
     // exist.
     [self updateSky];
+    [self requestRender];
 }
 
 - (void)updateSky {
@@ -225,6 +236,7 @@ static const DemoFeature LAYER_ORDER[] = {
                                              day:[DemoConfig intFor:@"sunDay"]
                                             hour:[DemoConfig currentHourUtc]];
     [self.stars updateWithN:n lat:[DemoConfig doubleFor:@"lat"] lon:[DemoConfig doubleFor:@"lon"]];
+    [self requestRender];
 }
 
 - (NTLayer *)createLayer:(DemoFeature)feature {
@@ -314,6 +326,7 @@ static const DemoFeature LAYER_ORDER[] = {
         [_compositeLayer removeExternalDataSource:@"contour"];
     }
     [self checkCompositeSlots];
+    [self requestRender];
 }
 
 /**
@@ -392,6 +405,7 @@ static const DemoFeature LAYER_ORDER[] = {
     BOOL slopes = [DemoConfig boolFor:@"slopes"];
     [layer setExagerateHeightScaleEnabled:!slopes];
     [layer setNormalMapLightingShader:slopes ? [DemoStyles slopesShader] : @""];
+    [self requestRender];
 }
 
 - (enum NTHillshadeMethod)hillshadeMethod {
@@ -741,6 +755,7 @@ static const DemoFeature LAYER_ORDER[] = {
     // Stubs off the terrain's own elevation: no DEM tile of the contour source's own to fetch and
     // decode. Same DEM source on both sides, so the labels state the heights the terrain draws.
     [_contourSource setTerrainOptions:[DemoConfig boolFor:@"stubsFromTerrain"] ? _terrainOptions : nil];
+    [self requestRender];
 }
 
 - (NTElevationDecoder *)elevationDecoder {
@@ -762,6 +777,7 @@ static const DemoFeature LAYER_ORDER[] = {
 
 - (void)applyDebugConfig {
     [[self.mapView getOptions] setDebugTileBorders:[DemoConfig boolFor:@"tileBorders"]];
+    [self requestRender];
 }
 
 - (void)applyTerrainOptions {
@@ -796,6 +812,7 @@ static const DemoFeature LAYER_ORDER[] = {
     [_terrainOptions setViewDistance:[DemoConfig floatFor:@"viewDistanceMeters"]];
     [_terrainOptions setMaxTileZoomCoarsening:[DemoConfig intFor:@"coarsening"]];
     [self applyReliefSurface];
+    [self requestRender];
 }
 
 - (void)applyLightOptions {
@@ -851,6 +868,7 @@ static const DemoFeature LAYER_ORDER[] = {
         [_skyOptions setSkyColor:[DemoMap colorFromHex:[DemoMap reliefSky]]];
         [[self.mapView getOptions] setSkyColor:[DemoMap colorFromHex:[DemoMap reliefSky]]];
     }
+    [self requestRender];
 }
 
 /**
@@ -872,6 +890,7 @@ static const DemoFeature LAYER_ORDER[] = {
     NTProjection *projection = [[self.mapView getOptions] getBaseProjection];
     NTMapPos *centre = [projection toWgs84:[self.mapView getFocusPos]];
     [DemoSky applyHour:hourUtc light:_lightOptions sky:_skyOptions lat:[centre getY] lon:[centre getX]];
+    [self requestRender];
 }
 
 // =================================================================================================
@@ -1015,6 +1034,7 @@ static const DemoFeature LAYER_ORDER[] = {
     [_terrainOptions setSurfaceParameter:@"uAmbient" value:[DemoConfig floatFor:@"reliefAmbient"]];
     [_terrainOptions setSurfaceParameter:@"uHaze" value:[DemoConfig floatFor:@"reliefHaze"]];
     [_terrainOptions setSurfaceParameter:@"uHazeDistance" value:[DemoConfig floatFor:@"reliefHazeDistance"]];
+    [self requestRender];
 }
 
 /** PeakFinder-style relief outline post-process effect. */
@@ -1034,6 +1054,7 @@ static const DemoFeature LAYER_ORDER[] = {
         _reliefEffect = nil;
         [renderer setPostProcessEffect:nil];
     }
+    [self requestRender];
 }
 
 - (void)applyReliefOutlineParameters {
@@ -1054,6 +1075,7 @@ static const DemoFeature LAYER_ORDER[] = {
     [_reliefEffect setFloatParameter:@"uDistanceFade" value:0.45f];
     [_reliefEffect setColorParameter:@"uInkColor" color:[DemoMap colorFromHex:[DemoMap reliefInk]]];
     [_reliefEffect setColorParameter:@"uPaperColor" color:[DemoMap colorFromHex:[DemoMap reliefPaper]]];
+    [self requestRender];
 }
 
 /**
@@ -1129,6 +1151,7 @@ static const DemoFeature LAYER_ORDER[] = {
             [self.mapView setTilt:_savedTilt durationSeconds:0.6f];
         }
     }
+    [self requestRender];
 }
 
 /**
@@ -1220,6 +1243,7 @@ static const DemoFeature LAYER_ORDER[] = {
         [_skyOptions setEnabled:[DemoConfig boolFor:@"sky"]];
         [self setReliefDark:NO];
     }
+    [self requestRender];
 }
 
 // =================================================================================================
@@ -1286,6 +1310,7 @@ static const DemoFeature LAYER_ORDER[] = {
     [self setMapLayerOpacity:1]; // the layers are out of the list now: leave them ready to come back
     [self applyLookRange];
     [self setOrientationFollowing:[DemoConfig boolFor:@"starSkyOrientation"]];
+    [self requestRender];
 }
 
 - (void)leaveStarSky {
@@ -1300,6 +1325,7 @@ static const DemoFeature LAYER_ORDER[] = {
     }
     [self setMapLayerOpacity:0];
     [self rebuildLayers];
+    [self requestRender];
 }
 
 /** Opacity of every layer that is NOT the sky. */
@@ -1310,6 +1336,7 @@ static const DemoFeature LAYER_ORDER[] = {
             [layer setOpacity:opacity];
         }
     }];
+    [self requestRender];
 }
 
 - (void)fadeMapLayersFrom:(float)from to:(float)to duration:(float)duration

--- a/scripts/ios-dev/CartoDemo/DemoViewController.m
+++ b/scripts/ios-dev/CartoDemo/DemoViewController.m
@@ -2,10 +2,23 @@
 #import "DemoConfig.h"
 #import "DemoMap.h"
 #import "DemoPanel.h"
+#import "DemoToast.h"
 
 @interface DemoViewController ()
 @property (nonatomic, strong) NTMapView *mapView;
 @property (nonatomic, strong) DemoMap *demo;
+/** The camera readout along the bottom - Android's zoomText. */
+@property (nonatomic, strong) UILabel *statusLabel;
+@property (nonatomic, strong) NTMapEventListener *mapListener;
+- (void)updateStatusLabel;
+@end
+
+/**
+ * Camera readout (also what a scripted run reads back out of the log) + a terrain-aware click
+ * probe, the same pair SecondFragment.installMapListener sets up on Android.
+ */
+@interface DemoMapListener : NTMapEventListener
+@property (nonatomic, weak) DemoViewController *controller;
 @end
 
 @implementation DemoViewController
@@ -47,7 +60,48 @@
 
     if ([DemoConfig boolFor:@"ui"]) {
         [self addSettingsButton];
+        [self addStatusLabel];
     }
+    [self installMapListener];
+}
+
+/** The camera readout, bottom centre - the counterpart of the Android layout's zoomText. */
+- (void)addStatusLabel {
+    UILabel *label = [[UILabel alloc] init];
+    label.font = [UIFont monospacedDigitSystemFontOfSize:12 weight:UIFontWeightRegular];
+    label.textColor = [UIColor whiteColor];
+    label.backgroundColor = [UIColor colorWithWhite:0 alpha:0.55];
+    label.textAlignment = NSTextAlignmentCenter;
+    label.layer.cornerRadius = 6;
+    label.clipsToBounds = YES;
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    // The map keeps every gesture it has under the readout.
+    label.userInteractionEnabled = NO;
+    [self.view addSubview:label];
+    self.statusLabel = label;
+
+    UILayoutGuide *safe = self.view.safeAreaLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [label.centerXAnchor constraintEqualToAnchor:safe.centerXAnchor],
+        [label.bottomAnchor constraintEqualToAnchor:safe.bottomAnchor constant:-16],
+        [label.heightAnchor constraintEqualToConstant:24],
+        [label.widthAnchor constraintGreaterThanOrEqualToConstant:240],
+    ]];
+    [self updateStatusLabel];
+}
+
+- (void)updateStatusLabel {
+    NTMapPos *focus = [[[self.mapView getOptions] getBaseProjection] toWgs84:[self.mapView getFocusPos]];
+    self.statusLabel.text = [NSString stringWithFormat:@"z=%.2f  tilt=%.0f  %.5f, %.5f",
+                             [self.mapView getZoom], [self.mapView getTilt],
+                             [focus getY], [focus getX]];
+}
+
+- (void)installMapListener {
+    DemoMapListener *listener = [[DemoMapListener alloc] init];
+    listener.controller = self;
+    self.mapListener = listener;
+    [self.mapView setMapEventListener:listener];
 }
 
 /** Bottom-left gear, the same corner the Android demo puts it in. */
@@ -90,6 +144,40 @@
         sheet.preferredCornerRadius = 16;
     }
     [self presentViewController:nav animated:YES completion:nil];
+}
+
+@end
+
+@implementation DemoMapListener
+
+- (void)onMapMoved {
+    DemoViewController *controller = self.controller;
+    if (!controller) {
+        return;
+    }
+    NTMapView *mapView = controller.mapView;
+    NTMapPos *focus = [[[mapView getOptions] getBaseProjection] toWgs84:[mapView getFocusPos]];
+    NSLog(@"CartoDemo: lat=%.6f lng=%.6f rotation=%.2f z=%.2f tilt=%.0f",
+          [focus getY], [focus getX], [mapView getRotation], [mapView getZoom], [mapView getTilt]);
+    // The listener runs on the map's own thread; the label is UIKit.
+    dispatch_async(dispatch_get_main_queue(), ^{ [controller updateStatusLabel]; });
+}
+
+- (void)onMapClicked:(NTMapClickInfo *)mapClickInfo {
+    DemoViewController *controller = self.controller;
+    if (!controller) {
+        return;
+    }
+    // getClickPos already resolves to the TERRAIN surface; the elevation query itself may block on
+    // tile loading, so it runs off the caller's thread.
+    NTMapPos *wgs84Pos = [[[controller.mapView getOptions] getBaseProjection]
+                          toWgs84:[mapClickInfo getClickPos]];
+    DemoMap *demo = controller.demo;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        double elevation = [demo getElevation:wgs84Pos];
+        [DemoToast show:[NSString stringWithFormat:@"%.5f, %.5f   %.0f m",
+                         [wgs84Pos getY], [wgs84Pos getX], elevation]];
+    });
 }
 
 @end

--- a/scripts/ios-dev/README.md
+++ b/scripts/ios-dev/README.md
@@ -101,6 +101,10 @@ Keplerian elements for the planets), `DemoSky` places the sun with
 `LightOptions.setSunPositionFromTime` and generates the same sky shader, and `DemoStarCatalogue`
 carries the same ~190 stars and 30 constellation figures.
 
+A **camera readout** sits along the bottom (`z=… tilt=… lat, lon`), the counterpart of the Android
+layout's `zoomText`, and every move logs the same line the Android demo logs so a scripted run can
+read the camera back out. Tapping the map reports the position and the terrain elevation under it.
+
 ### One structure, two platforms
 
 `DemoMap` mirrors `DemoMap.java` method for method: a `DemoFeature` registry with a fixed
@@ -135,6 +139,11 @@ defaults and same key names as the Android demo, where `contour` is on by defaul
 - **Screen sizes in the celestial API are pixels, not points.** The Android demo multiplies them by
   the display density and this one multiplies by `UIScreen.mainScreen.scale`; without it every star
   and figure line comes out a third of its intended size on a 3x phone.
+- **Nothing repaints unless the renderer is asked.** Android's demo ends every apply with
+  `mapView.requestRender()`; the iOS `MapView` has no such method, so `DemoMap.requestRender` calls
+  `[[mapView getMapRenderer] requestRedraw]` in the same places. Adding a layer used to appear at
+  once and removing one only on the next pan, which was `Layers::setAll` never requesting a redraw
+  of its own (fixed in the SDK - it notified the surviving layers only).
 - **Positions must go through the map's own projection.** `[[mapView getOptions] getBaseProjection]`
   is EPSG3857; converting with `NTEPSG4326` instead compiles, looks right, and silently feeds
   lon/lat to the map as metres, which puts the camera in the ocean off 0,0.


### PR DESCRIPTION
## Summary

Two things the iOS demo port had dropped from the Android glue.

**The camera readout** along the bottom (`z=12.00  tilt=90  45.18770, 5.72490`), the counterpart of the Android layout's `zoomText`. It sits on a `MapEventListener` that also logs the same line `SecondFragment` logs on every move — so a scripted run can read the camera back out of the log — and probes the terrain elevation under a tap, the way `installMapListener` does.

**The redraw requests.** `DemoMap.java` ends every apply with `mapView.requestRender()`; the iOS `MapView` has no such method, so nothing here ever asked for a frame. `DemoMap` gains `requestRender` (`[[mapView getMapRenderer] requestRedraw]`), called in the same 17 places, plus `getElevation` for the click probe.

## Depends on

Stacked on [#68](https://github.com/Akylas/mobile-sdk/pull/68) — every file it touches is added there. Merge #68 first; this diff is then the 4 files above.

Related: [#69](https://github.com/Akylas/mobile-sdk/pull/69) fixes the SDK side of the same report (`Layers::setAll` never requesting a redraw, so removing a layer only showed after a pan). The two are independent — this one repaints because the demo now asks, #69 because the SDK does.

## Testing

Run on the simulator: the readout shows at launch and tracks pan/zoom/tilt, and toggling the satellite layer off from the settings panel clears the map immediately with no pan.

Not tested: the tap elevation probe against a known summit height.