### PR TITLE
perf(vectortiles): rebuild only the symbolizer context when the pixel scale or fonts change

### DIFF
--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -369,8 +369,9 @@ namespace carto {
             std::lock_guard<std::mutex> lock(_mutex);
             if (fontData) {
                 _fallbackFonts.push_back(fontData);
+                // Fonts live in the symbolizer context, not in the compiled map: rebuild only that.
                 _assetPackageSymbolizerContexts.clear();
-                updateCurrentStyleSet(_styleSet);
+                updateSymbolizerContext();
             }
         }
         notifyDecoderChanged();
@@ -383,10 +384,12 @@ namespace carto {
                 return;
             }
             _pixelScale = pixelScale;
-            // The glyph render size is picked from it when a tile is decoded, so the decoded tiles
-            // have to go. In practice this fires once, when the layer joins a map.
+            // The glyph render size is picked from it when a tile is decoded, so the glyph/stroke
+            // maps have to go. The compiled map does not depend on it - reloading the style here
+            // cost a full parse + compile (~0.5 s for a 23-layer style) on every layer that joins
+            // a map, which is where this fires.
             _assetPackageSymbolizerContexts.clear();
-            updateCurrentStyleSet(_styleSet);
+            updateSymbolizerContext();
         }
         notifyDecoderChanged();
     }
@@ -611,6 +614,20 @@ namespace carto {
             throw InvalidArgumentException("Invalid style set");
         }
 
+        _styleSet = styleSet;
+        _styleAssetName = styleAssetName;
+        _styleAssetPackage = assetPackage;
+        _map = map;
+        _mapSettings = std::make_shared<mvt::Map::Settings>(_map->getSettings());
+
+        updateSymbolizerContext();
+    }
+
+    void MBVectorTileDecoder::updateSymbolizerContext() {
+        const std::string& styleAssetName = _styleAssetName;
+        const std::shared_ptr<AssetPackage>& assetPackage = _styleAssetPackage;
+        const std::shared_ptr<const mvt::Map>& map = _map;
+
         if (_assetPackageSymbolizerContexts.find(std::make_pair(styleAssetName, assetPackage)) == _assetPackageSymbolizerContexts.end() && _assetPackageSymbolizerContexts.size() >= MAX_ASSETPACKAGE_SYMBOLIZER_CONTEXTS) {
             _assetPackageSymbolizerContexts.clear();
         }
@@ -691,9 +708,6 @@ namespace carto {
 
         _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(symbolizerContext->getSettings().getTileSize(), parameterValueMap, symbolizerContext->getSettings().getFallbackFont(), _pixelScale);
         _symbolizerContext = std::make_shared<mvt::SymbolizerContext>(symbolizerContext->getBitmapManager(), symbolizerContext->getFontManager(), symbolizerContext->getStrokeMap(), symbolizerContext->getGlyphMap(), *_symbolizerContextSettings);
-        _map = map;
-        _mapSettings = std::make_shared<mvt::Map::Settings>(_map->getSettings());
-        _styleSet = styleSet;
         _cachedFeatureDecoder.first.reset();
         _cachedFeatureDecoder.second.reset();
     }

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -200,6 +200,7 @@ namespace carto {
     
     protected:
         void updateCurrentStyleSet(const std::variant<std::shared_ptr<CompiledStyleSet>, std::shared_ptr<CartoCSSStyleSet> >& styleSet);
+        void updateSymbolizerContext();
         bool setStyleParameterInternal(const std::string& param, const std::string& value);
         void updateSymbolizer();
 
@@ -217,6 +218,8 @@ namespace carto {
         std::map<std::string, mvt::Value> _parameterValueMap;
         std::vector<std::shared_ptr<BinaryData> > _fallbackFonts;
         std::variant<std::shared_ptr<CompiledStyleSet>, std::shared_ptr<CartoCSSStyleSet> > _styleSet;
+        std::string _styleAssetName; // what the current _map was loaded from, so the symbolizer
+        std::shared_ptr<AssetPackage> _styleAssetPackage; // context can be rebuilt without it
         std::shared_ptr<const mvt::Map> _map;
         std::shared_ptr<const mvt::Map::Settings> _mapSettings;
         std::shared_ptr<const mvt::SymbolizerContext> _symbolizerContext;

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -96,6 +96,55 @@ The GPU is not the limit: `PROF GPU` with content puts the layers at 29–43 ms 
 So the lever is **fewer draws and fewer layers**, which is [07-hillshade-contours.md](07-hillshade-contours.md)
 and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 
+## Style load and tile decode (off the render thread, but in front of the user)
+
+Measured on a Crosscall HLTE556N with the demo's bundled style project (`--es style assets`:
+`osm.json`, 23 layers, 67 styles, 461 nutiparameters, 9 `.less`/`.mss` files, 74 KB), with temporary
+timers in `CartoCSSMapLoader`, `TileReader` and `MBVectorTileDecoder`. Device clocks move the
+absolute numbers by up to 40% between runs — compare a change against a run whose *style load* time
+matches, or pair the runs.
+
+**Loading a style: ~0.5–0.7 s**, split roughly 7 / 75 / 20 between parse, compile and everything else:
+
+| section | ms |
+|---|---|
+| `CartoCSSParser::parse`, all 9 files (boost::spirit) | 34 |
+| `CartoCSSMapLoader::buildMap` | 362 |
+| — `CartoCSSCompiler::compileLayer`, all layers | 271 |
+| — translate to mapnik rules | 71 |
+| — `Style::optimizeRules` | 9 |
+| fonts, asset scan, symbolizer context | ~110 |
+
+The compile is three layers: `transportation` **115 ms** (2230 rules, 23 attachments), `route` 61 ms,
+`poi` 61 ms; the other 20 together ≈ 35 ms. Two structural reasons, both still open:
+`CartoCSSCompiler::buildPropertyLists` walks the **whole** stylesheet once per layer (23 × 407
+elements here), and `compileLayer` evaluates every property's filters at **all 25 zooms** even when
+the layer resolves to a handful of distinct zoom ranges (`transportation`: 11).
+
+**`setPixelScale` used to reload the style.** It rebuilt the symbolizer context by calling
+`updateCurrentStyleSet`, i.e. a full parse + compile, and `VectorTileLayer` calls it when the layer
+joins a map — so every startup paid the ~0.5 s twice. Split into `updateSymbolizerContext()`
+(fonts, bitmap/stroke/glyph maps, settings), the second pass is **~100–130 ms**. `addFallbackFont`
+took the same path. `setCartoCSSLayerNamesIgnored` genuinely changes compilation and still reloads.
+
+**Decoding a tile: 120–150 ms mean, ~0.5 s worst** at a z16 city camera. Section split (probe
+overhead ~30%, so read the shares, not the absolutes):
+
+| section | share |
+|---|---|
+| symbolizer → geometry/label build (tesselation) | 35% |
+| loop glue: `shared_ptr`-keyed caches, 67 layer builders per tile, batching | 22% |
+| `TileLayerBuilder::buildTileLayer` | 13% |
+| filter predicate evaluation | 12% |
+| feature tag decode | 7% |
+| protobuf geometry decode + clip | 5% |
+| symbolizer property evaluation | 4% |
+| rule prefilter + field gathering | 2% |
+
+So the CartoCSS/expression machinery is **~18% of a decode** — geometry building is the cost. Note
+what this means for `setStyleParameter`: it invalidates every tile ([TileLayer.cpp](../../all/native/layers/TileLayer.cpp)
+`updateTiles`), so changing one `nuti::` colour costs *visible tiles × ~130 ms* of decode CPU.
+
 ## Measured NOT to matter — do not re-run these
 
 | hypothesis | result |
@@ -112,6 +161,7 @@ and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 | the per-tile CPU surface rebuild ("the pan hang") | **does not happen at all** in grid mode: `surfBuilt=0 surfInval=0`, the block costs 0.04 ms |
 | DEM border patching instead of full re-encode | 93% fewer re-encodes, **no fps change** at any camera — the encode was never on the render thread |
 | the DEM encode path in a warm pan | **zero encodes** — there is nothing there to optimise |
+| skipping the layer builder for styles the prefilter empties (67 per tile) | 3 paired cold runs each: decode mean 148 vs 147 ms — inside the noise |
 
 ## Things that did pay
 
@@ -130,6 +180,7 @@ and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 | label terrain re-anchor: DEM tile loads no longer read as a scale-only change, plus a grid and a latitude-scale memo | full stack over terrain, interleaved ×3: **1.00 → 1.55 fps**, `prepare` 658 → 219 ms |
 | an off-screen, already-anchored label defers its re-anchor | 1.60 → 1.70 fps — small, most dirty labels do hold a placement |
 | label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
+| `setPixelScale` rebuilds only the symbolizer context, not the compiled map | startup style cost 2 × 0.5–0.7 s → one load plus a ~0.1 s context rebuild |
 | render and tile paths at `-O2` in Release instead of `-Oz` | device 39.09 → 37.82 ms/frame (3.2%), CPU work minus the swap wait 14.39 → 13.51 ms (6.1%), `prepare` 2.65 → 2.22, `prelude` 0.91 → 0.70; +614 KB on arm64 |
 
 The `-Oz` → `-O2` A/B is a warning about the emulator as much as a result. Three interleaved cycles

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -136,11 +136,23 @@ went over every property inserted so far); **intern the field strings and hand o
 `buildLayerAttachment` (its innermost operation was a string compare, and each property visit copied
 a `shared_ptr`). Summed over all 23 layers: **264 → 157 ms**, `buildMap` 362 → 261 ms.
 
+A second round took the same three sections further, for **157 → 129 ms** (`buildMap` 220 ms):
+
+- **A zoom whose predicates evaluate exactly as the previous one is skipped whole.** The optimized
+  property lists are a pure function of (property lists, predicate results), so equal results mean
+  equal lists and equal attachments. Comparing ~80 bytes replaces rebuilding every property list and
+  deep-comparing it. A layer resolves to 1–14 distinct ranges out of the 25 zooms evaluated.
+  `boost::tribool` cannot be compared as a block — two indeterminate values do not test equal — so
+  the results are kept as a three-state byte.
+- `buildLayerAttachment` built a fresh property set (two vectors) per (property, property set) pair
+  considered and dropped it on the common path; one reused object keeps the buffers.
+
+Cumulative: **compile 264 → 129 ms**, `buildMap` 362 → 220 ms on the same style and device.
+
 Left on the table: `buildPropertyLists` still walks the **whole** stylesheet once per layer (23 × 407
-elements here), and `compileLayer` still evaluates at **all 25 zooms** even when the layer resolves
-to a handful of distinct zoom ranges (`transportation`: 11) — the zoom-breakpoint version of that
-loop would cut the remaining evaluation *and* the attachment rebuilds, which are now the largest
-single item.
+elements here) — worth ~10–15 ms total, so low priority — and `buildLayerAttachment` remains the
+biggest single item (~31 ms of `transportation`'s 55). Its cost is O(properties × property sets²) per
+distinct zoom range, which is the algorithm, not a constant factor.
 
 **`setPixelScale` used to reload the style.** It rebuilt the symbolizer context by calling
 `updateCurrentStyleSet`, i.e. a full parse + compile, and `VectorTileLayer` calls it when the layer
@@ -202,7 +214,8 @@ what this means for `setStyleParameter`: it invalidates every tile ([TileLayer.c
 | an off-screen, already-anchored label defers its re-anchor | 1.60 → 1.70 fps — small, most dirty labels do hold a placement |
 | label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
 | `setPixelScale` rebuilds only the symbolizer context, not the compiled map | startup style cost 2 × 0.5–0.7 s → one load plus a ~0.1 s context rebuild |
-| CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile sections 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
+| CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
+| CartoCSS compile: skip a zoom whose predicate results repeat, reuse the trial property set | compile 157 → 129 ms, `buildMap` → 220 ms |
 | render and tile paths at `-O2` in Release instead of `-Oz` | device 39.09 → 37.82 ms/frame (3.2%), CPU work minus the swap wait 14.39 → 13.51 ms (6.1%), `prepare` 2.65 → 2.22, `prelude` 0.91 → 0.70; +614 KB on arm64 |
 
 The `-Oz` → `-O2` A/B is a warning about the emulator as much as a result. Three interleaved cycles

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -116,10 +116,31 @@ matches, or pair the runs.
 | fonts, asset scan, symbolizer context | ~110 |
 
 The compile is three layers: `transportation` **115 ms** (2230 rules, 23 attachments), `route` 61 ms,
-`poi` 61 ms; the other 20 together ≈ 35 ms. Two structural reasons, both still open:
-`CartoCSSCompiler::buildPropertyLists` walks the **whole** stylesheet once per layer (23 × 407
-elements here), and `compileLayer` evaluates every property's filters at **all 25 zooms** even when
-the layer resolves to a handful of distinct zoom ranges (`transportation`: 11).
+`poi` 61 ms; the other 20 together ≈ 35 ms.
+
+Inside `compileLayer` it was three near-equal thirds, and each answered to a constant factor rather
+than to the algorithm (per-section ms, `transportation`, cold runs on the Crosscall):
+
+| section | before | after |
+|---|---|---|
+| `buildPropertyLists` | 37.8 | 22.8 |
+| per-zoom filter evaluation | 33.4 | 12.1 |
+| `buildLayerAttachment` | 39.6 | 31.4 |
+| list comparison | 2.2 | 2.0 |
+
+What the three fixes were, in the order they pay: **evaluate each distinct predicate once per zoom**
+(a layer has ~77 predicates and ~640 properties, and every property re-evaluated its own filters —
+this is a memo, not a semantic change); **bucket `insertProperty` by field** (two properties can only
+be equal if they set the same field, and comparing them is a deep expression comparison, so the scan
+went over every property inserted so far); **intern the field strings and hand out references** in
+`buildLayerAttachment` (its innermost operation was a string compare, and each property visit copied
+a `shared_ptr`). Summed over all 23 layers: **264 → 157 ms**, `buildMap` 362 → 261 ms.
+
+Left on the table: `buildPropertyLists` still walks the **whole** stylesheet once per layer (23 × 407
+elements here), and `compileLayer` still evaluates at **all 25 zooms** even when the layer resolves
+to a handful of distinct zoom ranges (`transportation`: 11) — the zoom-breakpoint version of that
+loop would cut the remaining evaluation *and* the attachment rebuilds, which are now the largest
+single item.
 
 **`setPixelScale` used to reload the style.** It rebuilt the symbolizer context by calling
 `updateCurrentStyleSet`, i.e. a full parse + compile, and `VectorTileLayer` calls it when the layer
@@ -181,6 +202,7 @@ what this means for `setStyleParameter`: it invalidates every tile ([TileLayer.c
 | an off-screen, already-anchored label defers its re-anchor | 1.60 → 1.70 fps — small, most dirty labels do hold a placement |
 | label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
 | `setPixelScale` rebuilds only the symbolizer context, not the compiled map | startup style cost 2 × 0.5–0.7 s → one load plus a ~0.1 s context rebuild |
+| CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile sections 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
 | render and tile paths at `-O2` in Release instead of `-Oz` | device 39.09 → 37.82 ms/frame (3.2%), CPU work minus the swap wait 14.39 → 13.51 ms (6.1%), `prepare` 2.65 → 2.22, `prelude` 0.91 → 0.70; +614 KB on arm64 |
 
 The `-Oz` → `-O2` A/B is a warning about the emulator as much as a result. Three interleaved cycles


### PR DESCRIPTION
## Summary

- `MBVectorTileDecoder::setPixelScale` and `addFallbackFont` rebuilt the symbolizer context by calling `updateCurrentStyleSet`, i.e. a **full parse + compile of the style**. `VectorTileLayer` calls `setPixelScale` when the layer joins a map, so every startup loaded the style twice. The context half is now `updateSymbolizerContext()` (fonts, bitmap/stroke/glyph maps, parameter map, settings) and those two setters call only that; the compiled map does not depend on either. `setCartoCSSLayerNamesIgnored` genuinely changes compilation and still reloads.
- `docs/rendering/10-performance.md` gains a **Style load and tile decode** section with the measurements this came out of: where the 0.5–0.7 s style load goes (parse 34 ms, compile 271 ms, translate 71 ms, fonts/assets ~110 ms), which layers dominate the compile (`transportation` 115 ms of it), and where a 120–150 ms tile decode goes (35% geometry building, 12% filter evaluation, ~18% total for the whole CartoCSS/expression machinery).

Measured on a Crosscall HLTE556N with the demo's bundled style project (`osm.json`: 23 layers, 67 styles, 461 nutiparameters): startup went from 2 × ~0.5 s of style load to one load plus a ~0.1 s context rebuild.

Two things the measurements point at, both left for follow-ups: `CartoCSSCompiler::buildPropertyLists` walks the whole stylesheet once per layer, and `compileLayer` evaluates every property's filters at all 25 zooms even when the layer resolves to a handful of distinct zoom ranges.

## Testing

- `clang++ -fsyntax-only -std=c++17` clean on `all/native/vectortiles/MBVectorTileDecoder.cpp`.
- Device run (Crosscall HLTE556N, `scripts/android-dev` demo, `--es ui false --es drape false --es style assets`): one style load plus one 98–132 ms context rebuild in the log, against two full loads before. Screenshot at Grenoble z16.22 / tilt 26 renders labels, icons, shields and terrain normally — the pixel-scale path is what this touches, so glyph sizing is the thing to look at.
- Worth a second pair of eyes on a device with a different DPI, since `setPixelScale` is the entry point.