### PR TITLE
feat(vectortiles): change a colour-only style parameter without decoding the tiles again

### DIFF
--- a/all/native/layers/VectorTileLayer.cpp
+++ b/all/native/layers/VectorTileLayer.cpp
@@ -33,7 +33,7 @@ namespace {
     template <typename T>
     std::optional<T> readDecoderParameter(const std::shared_ptr<carto::VectorTileDecoder>& decoder, const std::string& paramName) {
         if (auto symbolizerContextSettings = decoder->getSymbolizerContextSettings()) {
-            if (auto parameterValueMap = symbolizerContextSettings->getNutiParameterValueMap()) {
+            if (auto parameterValueMap = symbolizerContextSettings->getNutiParameterValueMap()) { // snapshot
                 auto it = parameterValueMap->find(paramName);
                 if (it != parameterValueMap->end()) {
                     return std::optional<T>(carto::mvt::ValueConverter<T>::convert(it->second));
@@ -651,7 +651,7 @@ namespace carto {
     mvt::ExpressionContext VectorTileLayer::getExpressionContext() const {
         mvt::ExpressionContext exprContext;
         if (auto symbolizerContextSettings = _tileDecoder->getSymbolizerContextSettings()) {
-            exprContext.setNutiParameterValueMap(symbolizerContextSettings->getNutiParameterValueMap());
+            exprContext.setNutiParameterStore(symbolizerContextSettings->getNutiParameterStore());
         }
         return exprContext;
     }
@@ -664,6 +664,19 @@ namespace carto {
     void VectorTileLayer::TileDecoderListener::onDecoderChanged() {
         if (std::shared_ptr<VectorTileLayer> layer = _layer.lock()) {
             layer->updateTiles(false);
+        } else {
+            Log::Error("VectorTileLayer::TileDecoderListener: Lost connection to layer");
+        }
+    }
+
+    void VectorTileLayer::TileDecoderListener::onDecoderRefreshed() {
+        // The decoded tiles already read the new value through the parameter store, and the colours
+        // and widths that read it are evaluated per frame - so the next frame is the only thing that
+        // has to change. No tile is fetched, decoded or re-culled.
+        if (std::shared_ptr<VectorTileLayer> layer = _layer.lock()) {
+            if (std::shared_ptr<MapRenderer> mapRenderer = layer->getMapRenderer()) {
+                mapRenderer->requestRedraw();
+            }
         } else {
             Log::Error("VectorTileLayer::TileDecoderListener: Lost connection to layer");
         }

--- a/all/native/layers/VectorTileLayer.h
+++ b/all/native/layers/VectorTileLayer.h
@@ -237,6 +237,7 @@ namespace carto {
             explicit TileDecoderListener(const std::shared_ptr<VectorTileLayer>& layer);
             
             virtual void onDecoderChanged();
+            virtual void onDecoderRefreshed();
     
         private:
             std::weak_ptr<VectorTileLayer> _layer;

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -35,6 +35,7 @@
 #include <mapnikvt/MBVTFeatureDecoder.h>
 #include <mapnikvt/MBVTTileReader.h>
 #include <mapnikvt/MapParser.h>
+#include <mapnikvt/NutiParameterResolver.h>
 #include <cartocss/CartoCSSMapLoader.h>
 
 #include <functional>
@@ -195,13 +196,7 @@ namespace carto {
         if (!_map) {
             return mvt::ResolvedLayerConfig();
         }
-        // Effective nuti value map: style defaults overlaid with runtime overrides (same as
-        // updateSymbolizer()).
-        auto nutiValues = std::make_shared<std::map<std::string, mvt::Value>>(*_symbolizerContextSettings->getNutiParameterValueMap());
-        for (auto it = _parameterValueMap.begin(); it != _parameterValueMap.end(); it++) {
-            (*nutiValues)[it->first] = it->second;
-        }
-        return mvt::resolveLayerConfig(*_map, layerName, viewZoom, nutiValues);
+        return mvt::resolveLayerConfig(*_map, layerName, viewZoom, _parameterStore);
     }
 
     std::vector<int> MBVectorTileDecoder::getStyleLayerZoomRange(const std::string& layerName) const {
@@ -214,13 +209,38 @@ namespace carto {
         return { range.first, range.second };
     }
 
-    void MBVectorTileDecoder::updateSymbolizer() {
-        auto parameterValueMap = std::make_shared<std::map<std::string, mvt::Value>>(*_symbolizerContextSettings->getNutiParameterValueMap());
-        for (auto it2 = _parameterValueMap.begin(); it2 != _parameterValueMap.end(); it2++) {
-            (*parameterValueMap)[it2->first] = it2->second;
+    void MBVectorTileDecoder::updateParameterStore() {
+        // The style defaults, overlaid with whatever the app has set. The store is never replaced,
+        // only its values are - the decoded tiles read through it.
+        std::map<std::string, mvt::Value> parameterValues;
+        for (auto it = _map->getNutiParameterMap().begin(); it != _map->getNutiParameterMap().end(); it++) {
+            parameterValues[it->first] = it->second.getDefaultValue();
         }
-        _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(_symbolizerContextSettings->getTileSize(), parameterValueMap, _symbolizerContextSettings->getFallbackFont(), _pixelScale);
+        for (auto it = _parameterValueMap.begin(); it != _parameterValueMap.end(); it++) {
+            parameterValues[it->first] = it->second;
+        }
+        _parameterStore->setValues(std::move(parameterValues));
+    }
+
+    void MBVectorTileDecoder::updateSymbolizer() {
+        updateParameterStore();
+
+        // Settings snapshot the parameters that scale geometry and glyphs, so they are rebuilt
+        // whenever a parameter changes structurally.
+        _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(_symbolizerContextSettings->getTileSize(), _parameterStore, _symbolizerContextSettings->getFallbackFont(), _pixelScale);
         _symbolizerContext = std::make_shared<mvt::SymbolizerContext>(_symbolizerContext->getBitmapManager(), _symbolizerContext->getFontManager(), _symbolizerContext->getStrokeMap(), _symbolizerContext->getGlyphMap(), *_symbolizerContextSettings);
+    }
+
+    bool MBVectorTileDecoder::areParametersLive(const std::vector<std::string>& params) const {
+        if (params.empty() || _liveParameters.empty()) {
+            return false;
+        }
+        for (const std::string& param : params) {
+            if (_liveParameters.find(param) == _liveParameters.end()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     bool MBVectorTileDecoder::setStyleParameterInternal(const std::string& param, const std::string& value) {
@@ -267,14 +287,26 @@ namespace carto {
     }
 
     bool MBVectorTileDecoder::setStyleParameter(const std::string& param, const std::string& value) {
+        bool live = false;
         {
             std::lock_guard<std::mutex> lock(_mutex);
 
             setStyleParameterInternal(param, value);
 
-            updateSymbolizer();
+            live = areParametersLive({ param });
+            if (live) {
+                updateParameterStore();
+            } else {
+                updateSymbolizer();
+            }
         }
-        notifyDecoderChanged();
+        // A parameter that nothing but a per-frame colour or width reads is already visible to the
+        // decoded tiles through the store: they only have to be drawn again.
+        if (live) {
+            notifyDecoderRefreshed();
+        } else {
+            notifyDecoderChanged();
+        }
         return true;
     }
     void MBVectorTileDecoder::setJSONStyleParameters(const std::string& params) {
@@ -287,14 +319,26 @@ namespace carto {
                 throw ParseException(std::string("JSON parsing failed: ") + err, params);
             }
             const picojson::object &jsonValues = val.get<picojson::object>();
+            bool live = false;
             {
                 std::lock_guard<std::mutex> lock(_mutex);
+                std::vector<std::string> params;
                 for (auto it = jsonValues.begin(); it != jsonValues.end(); it++) {
                     setStyleParameterInternal(it->first, it->second.get<std::string>());
+                    params.push_back(it->first);
                 }
-                updateSymbolizer();
+                live = areParametersLive(params);
+                if (live) {
+                    updateParameterStore();
+                } else {
+                    updateSymbolizer();
+                }
             }
-            notifyDecoderChanged();
+            if (live) {
+                notifyDecoderRefreshed();
+            } else {
+                notifyDecoderChanged();
+            }
         }
         catch (const std::exception &ex)
         {
@@ -303,14 +347,27 @@ namespace carto {
         }
     }
     void MBVectorTileDecoder::setStyleParameters(const std::map<std::string, std::string>& params) {
-        std::lock_guard<std::mutex> lock(_mutex);
+        bool live = false;
         {
+            std::lock_guard<std::mutex> lock(_mutex);
+
+            std::vector<std::string> paramNames;
             for (auto p = params.begin(); p != params.end(); ++p)  {
                 setStyleParameterInternal(p->first, p->second);
+                paramNames.push_back(p->first);
             }
-            updateSymbolizer();
+            live = areParametersLive(paramNames);
+            if (live) {
+                updateParameterStore();
+            } else {
+                updateSymbolizer();
+            }
         }
-        notifyDecoderChanged();
+        if (live) {
+            notifyDecoderRefreshed();
+        } else {
+            notifyDecoderChanged();
+        }
     }
 
     bool MBVectorTileDecoder::isFeatureIdOverride() const {
@@ -671,14 +728,10 @@ namespace carto {
                 // Styles without any font (inline CartoCSS, for example) still need a font for their labels
                 fallbackFont = fontManager->getFont(DEFAULT_FALLBACK_FONT_NAME, fallbackFont);
             }
-            mvt::SymbolizerContext::Settings settings(DEFAULT_TILE_SIZE, std::make_shared<std::map<std::string, mvt::Value>>(), fallbackFont, _pixelScale);
+            mvt::SymbolizerContext::Settings settings(DEFAULT_TILE_SIZE, std::make_shared<mvt::NutiParameterStore>(), fallbackFont, _pixelScale);
             symbolizerContext = std::make_shared<mvt::SymbolizerContext>(bitmapManager, fontManager, strokeMap, glyphMap, settings);
         }
 
-        auto parameterValueMap = std::make_shared<std::map<std::string, mvt::Value>>();
-        for (auto it = map->getNutiParameterMap().begin(); it != map->getNutiParameterMap().end(); it++) {
-            (*parameterValueMap)[it->first] = it->second.getDefaultValue();
-        }
         for (auto it = _parameterValueMap.begin(); it != _parameterValueMap.end(); ) {
             auto it2 = map->getNutiParameterMap().find(it->first);
             if (it2 == map->getNutiParameterMap().end()) {
@@ -702,11 +755,16 @@ namespace carto {
                 continue;
             }
 
-            (*parameterValueMap)[it->first] = it->second;
             it++;
         }
 
-        _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(symbolizerContext->getSettings().getTileSize(), parameterValueMap, symbolizerContext->getSettings().getFallbackFont(), _pixelScale);
+        if (!_parameterStore) {
+            _parameterStore = std::make_shared<mvt::NutiParameterStore>();
+        }
+        updateParameterStore();
+        _liveParameters = mvt::resolveLiveNutiParameters(*_map);
+
+        _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(symbolizerContext->getSettings().getTileSize(), _parameterStore, symbolizerContext->getSettings().getFallbackFont(), _pixelScale);
         _symbolizerContext = std::make_shared<mvt::SymbolizerContext>(symbolizerContext->getBitmapManager(), symbolizerContext->getFontManager(), symbolizerContext->getStrokeMap(), symbolizerContext->getGlyphMap(), *_symbolizerContextSettings);
         _cachedFeatureDecoder.first.reset();
         _cachedFeatureDecoder.second.reset();

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -369,8 +369,9 @@ namespace carto {
             std::lock_guard<std::mutex> lock(_mutex);
             if (fontData) {
                 _fallbackFonts.push_back(fontData);
+                // Fonts live in the symbolizer context, not in the compiled map: rebuild only that.
                 _assetPackageSymbolizerContexts.clear();
-                updateCurrentStyleSet(_styleSet);
+                updateSymbolizerContext();
             }
         }
         notifyDecoderChanged();
@@ -383,10 +384,12 @@ namespace carto {
                 return;
             }
             _pixelScale = pixelScale;
-            // The glyph render size is picked from it when a tile is decoded, so the decoded tiles
-            // have to go. In practice this fires once, when the layer joins a map.
+            // The glyph render size is picked from it when a tile is decoded, so the glyph/stroke
+            // maps have to go. The compiled map does not depend on it - reloading the style here
+            // cost a full parse + compile (~0.5 s for a 23-layer style) on every layer that joins
+            // a map, which is where this fires.
             _assetPackageSymbolizerContexts.clear();
-            updateCurrentStyleSet(_styleSet);
+            updateSymbolizerContext();
         }
         notifyDecoderChanged();
     }
@@ -611,6 +614,20 @@ namespace carto {
             throw InvalidArgumentException("Invalid style set");
         }
 
+        _styleSet = styleSet;
+        _styleAssetName = styleAssetName;
+        _styleAssetPackage = assetPackage;
+        _map = map;
+        _mapSettings = std::make_shared<mvt::Map::Settings>(_map->getSettings());
+
+        updateSymbolizerContext();
+    }
+
+    void MBVectorTileDecoder::updateSymbolizerContext() {
+        const std::string& styleAssetName = _styleAssetName;
+        const std::shared_ptr<AssetPackage>& assetPackage = _styleAssetPackage;
+        const std::shared_ptr<const mvt::Map>& map = _map;
+
         if (_assetPackageSymbolizerContexts.find(std::make_pair(styleAssetName, assetPackage)) == _assetPackageSymbolizerContexts.end() && _assetPackageSymbolizerContexts.size() >= MAX_ASSETPACKAGE_SYMBOLIZER_CONTEXTS) {
             _assetPackageSymbolizerContexts.clear();
         }
@@ -691,9 +708,6 @@ namespace carto {
 
         _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(symbolizerContext->getSettings().getTileSize(), parameterValueMap, symbolizerContext->getSettings().getFallbackFont(), _pixelScale);
         _symbolizerContext = std::make_shared<mvt::SymbolizerContext>(symbolizerContext->getBitmapManager(), symbolizerContext->getFontManager(), symbolizerContext->getStrokeMap(), symbolizerContext->getGlyphMap(), *_symbolizerContextSettings);
-        _map = map;
-        _mapSettings = std::make_shared<mvt::Map::Settings>(_map->getSettings());
-        _styleSet = styleSet;
         _cachedFeatureDecoder.first.reset();
         _cachedFeatureDecoder.second.reset();
     }

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -117,6 +117,51 @@ namespace carto {
         bool isContainerValue(const mvt::Value& value) {
             return std::get_if<std::shared_ptr<const mvt::ValueObject>>(&value) || std::get_if<std::shared_ptr<const mvt::ValueArray>>(&value);
         }
+
+        // Compiled maps, shared between decoders. Parsing and compiling a style is 0.5-0.7 s for a
+        // 23-layer project, and an app that switches between two styles of one asset package - day
+        // and night - or builds several layers from the same style, pays it every time otherwise.
+        // A compiled map is read-only, and the values a decoder sets live in its own parameter
+        // store, so sharing one is safe.
+        struct MapCacheKey {
+            const AssetPackage* assetPackage = nullptr;
+            std::string styleAssetName;
+            std::string cartoCSS;
+            bool ignoreLayerPredicates = false;
+
+            bool operator == (const MapCacheKey& other) const {
+                return assetPackage == other.assetPackage && styleAssetName == other.styleAssetName && cartoCSS == other.cartoCSS && ignoreLayerPredicates == other.ignoreLayerPredicates;
+            }
+        };
+
+        std::mutex g_mapCacheMutex;
+        std::vector<std::pair<MapCacheKey, std::weak_ptr<const mvt::Map>>> g_mapCache;
+        std::vector<std::shared_ptr<const mvt::Map>> g_mapCacheRetained; // keeps the last few alive
+
+        std::shared_ptr<const mvt::Map> findCachedMap(const MapCacheKey& key) {
+            std::lock_guard<std::mutex> lock(g_mapCacheMutex);
+            for (auto it = g_mapCache.begin(); it != g_mapCache.end(); ) {
+                std::shared_ptr<const mvt::Map> map = it->second.lock();
+                if (!map) {
+                    it = g_mapCache.erase(it);
+                    continue;
+                }
+                if (it->first == key) {
+                    return map;
+                }
+                it++;
+            }
+            return std::shared_ptr<const mvt::Map>();
+        }
+
+        void storeCachedMap(const MapCacheKey& key, const std::shared_ptr<const mvt::Map>& map) {
+            std::lock_guard<std::mutex> lock(g_mapCacheMutex);
+            g_mapCache.emplace_back(key, map);
+            g_mapCacheRetained.push_back(map);
+            if (g_mapCacheRetained.size() > 2) {
+                g_mapCacheRetained.erase(g_mapCacheRetained.begin());
+            }
+        }
     }
 
     MBVectorTileDecoder::MBVectorTileDecoder(const std::shared_ptr<CompiledStyleSet>& compiledStyleSet) :
@@ -703,13 +748,26 @@ namespace carto {
 
     void MBVectorTileDecoder::updateCurrentStyleSet(const std::variant<std::shared_ptr<CompiledStyleSet>, std::shared_ptr<CartoCSSStyleSet> >& styleSet) {
         std::string styleAssetName;
+        std::string cartoCSS;
         std::shared_ptr<AssetPackage> assetPackage;
-        std::shared_ptr<mvt::Map> map;
+        std::shared_ptr<const mvt::Map> map;
 
+        // What identifies the compiled map: the asset package it came from, which style of it, and
+        // whether layer predicates were ignored (that one changes how the style compiles).
         if (auto cartoCSSStyleSet = std::get_if<std::shared_ptr<CartoCSSStyleSet> >(&styleSet)) {
-            styleAssetName = "";
             assetPackage = (*cartoCSSStyleSet)->getAssetPackage();
+            cartoCSS = (*cartoCSSStyleSet)->getCartoCSS();
+        } else if (auto compiledStyleSet = std::get_if<std::shared_ptr<CompiledStyleSet> >(&styleSet)) {
+            styleAssetName = (*compiledStyleSet)->getStyleAssetName();
+            assetPackage = (*compiledStyleSet)->getAssetPackage();
+        }
+        MapCacheKey mapCacheKey { assetPackage.get(), styleAssetName, cartoCSS, _cartoCSSLayerNamesIgnored };
+        map = findCachedMap(mapCacheKey);
+        bool mapWasCached = static_cast<bool>(map);
 
+        if (map) {
+            // Already compiled - by this decoder before, or by another layer using the same style.
+        } else if (auto cartoCSSStyleSet = std::get_if<std::shared_ptr<CartoCSSStyleSet> >(&styleSet)) {
             try {
                 auto assetLoader = std::make_shared<CartoCSSAssetLoader>("", (*cartoCSSStyleSet)->getAssetPackage());
                 css::CartoCSSMapLoader mapLoader(assetLoader, _logger);
@@ -720,11 +778,9 @@ namespace carto {
                 throw ParseException(std::string("CartoCSS style parsing failed: ") + ex.what(), (*cartoCSSStyleSet)->getCartoCSS());
             }
         } else if (auto compiledStyleSet = std::get_if<std::shared_ptr<CompiledStyleSet> >(&styleSet)) {
-            styleAssetName = (*compiledStyleSet)->getStyleAssetName();
             if (styleAssetName.empty()) {
                 throw InvalidArgumentException("Could not find any styles in the style set");
             }
-            assetPackage = (*compiledStyleSet)->getAssetPackage();
 
             std::shared_ptr<BinaryData> styleData;
             if (assetPackage) {
@@ -762,6 +818,10 @@ namespace carto {
             }
         } else {
             throw InvalidArgumentException("Invalid style set");
+        }
+
+        if (!mapWasCached) {
+            storeCachedMap(mapCacheKey, map);
         }
 
         _styleSet = styleSet;

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -45,6 +45,80 @@
 
 namespace carto {
 
+    namespace {
+        // A style parameter may hold an object or an array (a table the style reads with get()),
+        // and the public API passes parameter values as strings - so those are carried as JSON.
+        mvt::Value convertJSONValue(const picojson::value& value) {
+            if (value.is<std::string>()) {
+                return mvt::Value(value.get<std::string>());
+            }
+            if (value.is<bool>()) {
+                return mvt::Value(value.get<bool>());
+            }
+            if (value.is<std::int64_t>()) {
+                return mvt::Value(static_cast<long long>(value.get<std::int64_t>()));
+            }
+            if (value.is<double>()) {
+                return mvt::Value(value.get<double>());
+            }
+            if (value.is<picojson::object>()) {
+                std::map<std::string, mvt::Value> members;
+                const picojson::object& obj = value.get<picojson::object>();
+                for (auto it = obj.begin(); it != obj.end(); it++) {
+                    members[it->first] = convertJSONValue(it->second);
+                }
+                return mvt::Value(std::make_shared<const mvt::ValueObject>(std::move(members)));
+            }
+            if (value.is<picojson::array>()) {
+                std::vector<mvt::Value> elements;
+                const picojson::array& arr = value.get<picojson::array>();
+                for (auto it = arr.begin(); it != arr.end(); it++) {
+                    elements.push_back(convertJSONValue(*it));
+                }
+                return mvt::Value(std::make_shared<const mvt::ValueArray>(std::move(elements)));
+            }
+            return mvt::Value();
+        }
+
+        picojson::value convertValueToJSON(const mvt::Value& value) {
+            if (auto val = std::get_if<bool>(&value)) {
+                return picojson::value(*val);
+            }
+            if (auto val = std::get_if<long long>(&value)) {
+                return picojson::value(static_cast<std::int64_t>(*val));
+            }
+            if (auto val = std::get_if<double>(&value)) {
+                return picojson::value(*val);
+            }
+            if (auto val = std::get_if<std::string>(&value)) {
+                return picojson::value(*val);
+            }
+            if (auto val = std::get_if<std::shared_ptr<const mvt::ValueObject>>(&value)) {
+                picojson::object obj;
+                if (*val) {
+                    for (auto it = (*val)->members.begin(); it != (*val)->members.end(); it++) {
+                        obj[it->first] = convertValueToJSON(it->second);
+                    }
+                }
+                return picojson::value(obj);
+            }
+            if (auto val = std::get_if<std::shared_ptr<const mvt::ValueArray>>(&value)) {
+                picojson::array arr;
+                if (*val) {
+                    for (auto it = (*val)->elements.begin(); it != (*val)->elements.end(); it++) {
+                        arr.push_back(convertValueToJSON(*it));
+                    }
+                }
+                return picojson::value(arr);
+            }
+            return picojson::value();
+        }
+
+        bool isContainerValue(const mvt::Value& value) {
+            return std::get_if<std::shared_ptr<const mvt::ValueObject>>(&value) || std::get_if<std::shared_ptr<const mvt::ValueArray>>(&value);
+        }
+    }
+
     MBVectorTileDecoder::MBVectorTileDecoder(const std::shared_ptr<CompiledStyleSet>& compiledStyleSet) :
         _logger(std::make_shared<MVTLogger>("MBVectorTileDecoder")),
         _pixelScale(1.0f),
@@ -158,6 +232,10 @@ namespace carto {
             }
         }
 
+        if (isContainerValue(value)) {
+            return convertValueToJSON(value).serialize(); // a table parameter reads back as JSON
+        }
+
         if (!nutiParam.getEnumMap().empty()) {
             for (auto it2 = nutiParam.getEnumMap().begin(); it2 != nutiParam.getEnumMap().end(); it2++) {
                 if (it2->second == value) {
@@ -258,6 +336,21 @@ namespace carto {
                 return false;
             }
             _parameterValueMap[param] = it2->second;
+        } else if (isContainerValue(nutiParam.getDefaultValue())) {
+            // An object/array parameter is set as JSON, and its shape must match what the style
+            // declared - a style reading get(table, key) must not be handed a scalar.
+            picojson::value jsonValue;
+            std::string err = picojson::parse(jsonValue, value);
+            if (!err.empty()) {
+                Log::Errorf("MBVectorTileDecoder::setStyleParameter: Could not parse JSON for parameter %s: %s", param.c_str(), err.c_str());
+                return false;
+            }
+            mvt::Value val = convertJSONValue(jsonValue);
+            if (val.index() != nutiParam.getDefaultValue().index()) {
+                Log::Errorf("MBVectorTileDecoder::setStyleParameter: Value of parameter %s does not match the declared object/array type", param.c_str());
+                return false;
+            }
+            _parameterValueMap[param] = val;
         } else {
             try {
                 mvt::Value val = nutiParam.getDefaultValue();

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -12,11 +12,13 @@
 #include <memory>
 #include <mutex>
 #include <map>
+#include <set>
 #include <vector>
 #include <string>
 #include <variant>
 
 #include <mapnikvt/Value.h>
+#include <mapnikvt/NutiParameterStore.h>
 #include <mapnikvt/LayerConfigResolver.h>
 
 namespace carto {
@@ -201,7 +203,9 @@ namespace carto {
     protected:
         void updateCurrentStyleSet(const std::variant<std::shared_ptr<CompiledStyleSet>, std::shared_ptr<CartoCSSStyleSet> >& styleSet);
         void updateSymbolizerContext();
+        void updateParameterStore();
         bool setStyleParameterInternal(const std::string& param, const std::string& value);
+        bool areParametersLive(const std::vector<std::string>& params) const;
         void updateSymbolizer();
 
         static const std::string DEFAULT_FALLBACK_FONT_NAME;
@@ -220,6 +224,8 @@ namespace carto {
         std::variant<std::shared_ptr<CompiledStyleSet>, std::shared_ptr<CartoCSSStyleSet> > _styleSet;
         std::string _styleAssetName; // what the current _map was loaded from, so the symbolizer
         std::shared_ptr<AssetPackage> _styleAssetPackage; // context can be rebuilt without it
+        std::shared_ptr<mvt::NutiParameterStore> _parameterStore; // the values the decoded tiles read
+        std::set<std::string> _liveParameters; // those of them that only a per-frame function reads
         std::shared_ptr<const mvt::Map> _map;
         std::shared_ptr<const mvt::Map::Settings> _mapSettings;
         std::shared_ptr<const mvt::SymbolizerContext> _symbolizerContext;

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -200,6 +200,7 @@ namespace carto {
     
     protected:
         void updateCurrentStyleSet(const std::variant<std::shared_ptr<CompiledStyleSet>, std::shared_ptr<CartoCSSStyleSet> >& styleSet);
+        void updateSymbolizerContext();
         bool setStyleParameterInternal(const std::string& param, const std::string& value);
         void updateSymbolizer();
 
@@ -217,6 +218,8 @@ namespace carto {
         std::map<std::string, mvt::Value> _parameterValueMap;
         std::vector<std::shared_ptr<BinaryData> > _fallbackFonts;
         std::variant<std::shared_ptr<CompiledStyleSet>, std::shared_ptr<CartoCSSStyleSet> > _styleSet;
+        std::string _styleAssetName; // what the current _map was loaded from, so the symbolizer
+        std::shared_ptr<AssetPackage> _styleAssetPackage; // context can be rebuilt without it
         std::shared_ptr<const mvt::Map> _map;
         std::shared_ptr<const mvt::Map::Settings> _mapSettings;
         std::shared_ptr<const mvt::SymbolizerContext> _symbolizerContext;

--- a/all/native/vectortiles/TorqueTileDecoder.cpp
+++ b/all/native/vectortiles/TorqueTileDecoder.cpp
@@ -178,7 +178,7 @@ namespace carto {
             std::string fontName = fontManager->loadFontData(*fontData->getDataPtr());
             fallbackFont = fontManager->getFont(fontName, fallbackFont);
         }
-        auto symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(DEFAULT_TILE_SIZE, std::make_shared<std::map<std::string, mvt::Value>>(), fallbackFont);
+        auto symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(DEFAULT_TILE_SIZE, std::make_shared<mvt::NutiParameterStore>(), fallbackFont);
         auto symbolizerContext = std::make_shared<mvt::SymbolizerContext>(bitmapManager, fontManager, strokeMap, glyphMap, *symbolizerContextSettings);
 
         _map = map;

--- a/all/native/vectortiles/VectorTileDecoder.cpp
+++ b/all/native/vectortiles/VectorTileDecoder.cpp
@@ -21,6 +21,17 @@ namespace carto {
         }
     }
         
+    void VectorTileDecoder::notifyDecoderRefreshed() {
+        std::vector<std::shared_ptr<OnChangeListener> > onChangeListeners;
+        {
+            std::lock_guard<std::mutex> lock(_onChangeListenersMutex);
+            onChangeListeners = _onChangeListeners;
+        }
+        for (const std::shared_ptr<OnChangeListener>& listener : onChangeListeners) {
+            listener->onDecoderRefreshed();
+        }
+    }
+
     void VectorTileDecoder::registerOnChangeListener(const std::shared_ptr<OnChangeListener>& listener) {
         std::lock_guard<std::mutex> lock(_onChangeListenersMutex);
         _onChangeListeners.push_back(listener);

--- a/all/native/vectortiles/VectorTileDecoder.h
+++ b/all/native/vectortiles/VectorTileDecoder.h
@@ -49,6 +49,13 @@ namespace carto {
              * Listener method that gets called when decoder parameters have changed and need to be updated.
              */
             virtual void onDecoderChanged() = 0;
+
+            /**
+             * Listener method that gets called when only the appearance of the already decoded tiles
+             * has changed - a style parameter that nothing but a per-frame colour or width reads.
+             * Redrawing is enough, the tiles do not have to be decoded again.
+             */
+            virtual void onDecoderRefreshed() { onDecoderChanged(); }
         };
     
         virtual ~VectorTileDecoder();
@@ -124,6 +131,7 @@ namespace carto {
          * listeners, but generally all cached tiles will be reloaded. 
          */
         virtual void notifyDecoderChanged();
+        virtual void notifyDecoderRefreshed();
         
         /**
          * Registers listener for decoder change events.

--- a/all/native/vectortiles/utils/MVTValueConverter.h
+++ b/all/native/vectortiles/utils/MVTValueConverter.h
@@ -15,6 +15,27 @@ namespace carto {
 
     struct MVTValueConverter {
         Variant operator() (std::monostate) const { return Variant(); }
+
+        Variant operator() (const std::shared_ptr<const mvt::ValueArray>& val) const {
+            std::vector<Variant> elements;
+            if (val) {
+                for (auto it = val->elements.begin(); it != val->elements.end(); it++) {
+                    elements.push_back(std::visit(MVTValueConverter(), *it));
+                }
+            }
+            return Variant(elements);
+        }
+
+        Variant operator() (const std::shared_ptr<const mvt::ValueObject>& val) const {
+            std::map<std::string, Variant> members;
+            if (val) {
+                for (auto it = val->members.begin(); it != val->members.end(); it++) {
+                    members[it->first] = std::visit(MVTValueConverter(), it->second);
+                }
+            }
+            return Variant(members);
+        }
+
         template <typename T> Variant operator() (T val) const { return Variant(val); }
     };
 

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -96,6 +96,55 @@ The GPU is not the limit: `PROF GPU` with content puts the layers at 29–43 ms 
 So the lever is **fewer draws and fewer layers**, which is [07-hillshade-contours.md](07-hillshade-contours.md)
 and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 
+## Style load and tile decode (off the render thread, but in front of the user)
+
+Measured on a Crosscall HLTE556N with the demo's bundled style project (`--es style assets`:
+`osm.json`, 23 layers, 67 styles, 461 nutiparameters, 9 `.less`/`.mss` files, 74 KB), with temporary
+timers in `CartoCSSMapLoader`, `TileReader` and `MBVectorTileDecoder`. Device clocks move the
+absolute numbers by up to 40% between runs — compare a change against a run whose *style load* time
+matches, or pair the runs.
+
+**Loading a style: ~0.5–0.7 s**, split roughly 7 / 75 / 20 between parse, compile and everything else:
+
+| section | ms |
+|---|---|
+| `CartoCSSParser::parse`, all 9 files (boost::spirit) | 34 |
+| `CartoCSSMapLoader::buildMap` | 362 |
+| — `CartoCSSCompiler::compileLayer`, all layers | 271 |
+| — translate to mapnik rules | 71 |
+| — `Style::optimizeRules` | 9 |
+| fonts, asset scan, symbolizer context | ~110 |
+
+The compile is three layers: `transportation` **115 ms** (2230 rules, 23 attachments), `route` 61 ms,
+`poi` 61 ms; the other 20 together ≈ 35 ms. Two structural reasons, both still open:
+`CartoCSSCompiler::buildPropertyLists` walks the **whole** stylesheet once per layer (23 × 407
+elements here), and `compileLayer` evaluates every property's filters at **all 25 zooms** even when
+the layer resolves to a handful of distinct zoom ranges (`transportation`: 11).
+
+**`setPixelScale` used to reload the style.** It rebuilt the symbolizer context by calling
+`updateCurrentStyleSet`, i.e. a full parse + compile, and `VectorTileLayer` calls it when the layer
+joins a map — so every startup paid the ~0.5 s twice. Split into `updateSymbolizerContext()`
+(fonts, bitmap/stroke/glyph maps, settings), the second pass is **~100–130 ms**. `addFallbackFont`
+took the same path. `setCartoCSSLayerNamesIgnored` genuinely changes compilation and still reloads.
+
+**Decoding a tile: 120–150 ms mean, ~0.5 s worst** at a z16 city camera. Section split (probe
+overhead ~30%, so read the shares, not the absolutes):
+
+| section | share |
+|---|---|
+| symbolizer → geometry/label build (tesselation) | 35% |
+| loop glue: `shared_ptr`-keyed caches, 67 layer builders per tile, batching | 22% |
+| `TileLayerBuilder::buildTileLayer` | 13% |
+| filter predicate evaluation | 12% |
+| feature tag decode | 7% |
+| protobuf geometry decode + clip | 5% |
+| symbolizer property evaluation | 4% |
+| rule prefilter + field gathering | 2% |
+
+So the CartoCSS/expression machinery is **~18% of a decode** — geometry building is the cost. Note
+what this means for `setStyleParameter`: it invalidates every tile ([TileLayer.cpp](../../all/native/layers/TileLayer.cpp)
+`updateTiles`), so changing one `nuti::` colour costs *visible tiles × ~130 ms* of decode CPU.
+
 ## Measured NOT to matter — do not re-run these
 
 | hypothesis | result |
@@ -112,6 +161,7 @@ and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 | the per-tile CPU surface rebuild ("the pan hang") | **does not happen at all** in grid mode: `surfBuilt=0 surfInval=0`, the block costs 0.04 ms |
 | DEM border patching instead of full re-encode | 93% fewer re-encodes, **no fps change** at any camera — the encode was never on the render thread |
 | the DEM encode path in a warm pan | **zero encodes** — there is nothing there to optimise |
+| skipping the layer builder for styles the prefilter empties (67 per tile) | 3 paired cold runs each: decode mean 148 vs 147 ms — inside the noise |
 
 ## Things that did pay
 
@@ -130,6 +180,7 @@ and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 | label terrain re-anchor: DEM tile loads no longer read as a scale-only change, plus a grid and a latitude-scale memo | full stack over terrain, interleaved ×3: **1.00 → 1.55 fps**, `prepare` 658 → 219 ms |
 | an off-screen, already-anchored label defers its re-anchor | 1.60 → 1.70 fps — small, most dirty labels do hold a placement |
 | label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
+| `setPixelScale` rebuilds only the symbolizer context, not the compiled map | startup style cost 2 × 0.5–0.7 s → one load plus a ~0.1 s context rebuild |
 | render and tile paths at `-O2` in Release instead of `-Oz` | device 39.09 → 37.82 ms/frame (3.2%), CPU work minus the swap wait 14.39 → 13.51 ms (6.1%), `prepare` 2.65 → 2.22, `prelude` 0.91 → 0.70; +614 KB on arm64 |
 
 The `-Oz` → `-O2` A/B is a warning about the emulator as much as a result. Three interleaved cycles

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -136,11 +136,23 @@ went over every property inserted so far); **intern the field strings and hand o
 `buildLayerAttachment` (its innermost operation was a string compare, and each property visit copied
 a `shared_ptr`). Summed over all 23 layers: **264 → 157 ms**, `buildMap` 362 → 261 ms.
 
+A second round took the same three sections further, for **157 → 129 ms** (`buildMap` 220 ms):
+
+- **A zoom whose predicates evaluate exactly as the previous one is skipped whole.** The optimized
+  property lists are a pure function of (property lists, predicate results), so equal results mean
+  equal lists and equal attachments. Comparing ~80 bytes replaces rebuilding every property list and
+  deep-comparing it. A layer resolves to 1–14 distinct ranges out of the 25 zooms evaluated.
+  `boost::tribool` cannot be compared as a block — two indeterminate values do not test equal — so
+  the results are kept as a three-state byte.
+- `buildLayerAttachment` built a fresh property set (two vectors) per (property, property set) pair
+  considered and dropped it on the common path; one reused object keeps the buffers.
+
+Cumulative: **compile 264 → 129 ms**, `buildMap` 362 → 220 ms on the same style and device.
+
 Left on the table: `buildPropertyLists` still walks the **whole** stylesheet once per layer (23 × 407
-elements here), and `compileLayer` still evaluates at **all 25 zooms** even when the layer resolves
-to a handful of distinct zoom ranges (`transportation`: 11) — the zoom-breakpoint version of that
-loop would cut the remaining evaluation *and* the attachment rebuilds, which are now the largest
-single item.
+elements here) — worth ~10–15 ms total, so low priority — and `buildLayerAttachment` remains the
+biggest single item (~31 ms of `transportation`'s 55). Its cost is O(properties × property sets²) per
+distinct zoom range, which is the algorithm, not a constant factor.
 
 **`setPixelScale` used to reload the style.** It rebuilt the symbolizer context by calling
 `updateCurrentStyleSet`, i.e. a full parse + compile, and `VectorTileLayer` calls it when the layer
@@ -202,7 +214,8 @@ what this means for `setStyleParameter`: it invalidates every tile ([TileLayer.c
 | an off-screen, already-anchored label defers its re-anchor | 1.60 → 1.70 fps — small, most dirty labels do hold a placement |
 | label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
 | `setPixelScale` rebuilds only the symbolizer context, not the compiled map | startup style cost 2 × 0.5–0.7 s → one load plus a ~0.1 s context rebuild |
-| CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile sections 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
+| CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
+| CartoCSS compile: skip a zoom whose predicate results repeat, reuse the trial property set | compile 157 → 129 ms, `buildMap` → 220 ms |
 | render and tile paths at `-O2` in Release instead of `-Oz` | device 39.09 → 37.82 ms/frame (3.2%), CPU work minus the swap wait 14.39 → 13.51 ms (6.1%), `prepare` 2.65 → 2.22, `prelude` 0.91 → 0.70; +614 KB on arm64 |
 
 The `-Oz` → `-O2` A/B is a warning about the emulator as much as a result. Three interleaved cycles

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -205,6 +205,19 @@ which is the point of the feature.
 
 Classification costs ~37 ms once per style load on that style (a walk over every rule and property).
 
+**What this does not solve: selection.** A style that drives "selected" with a parameter — the route
+style's `when ([nuti::selected_osmid]=@osmid)::selected`, plus a width that mixes the parameter with
+the feature field `[osmid]` — stays on the re-decode path, and the filter part *has* to: the casing
+of the selected route only exists because that rule matched, and a redraw cannot build geometry. The
+durable answer is maplibre's `feature-state` model: the selected id becomes a **uniform** and the
+comparison happens per vertex against a feature-id attribute, so a selection change costs nothing on
+the CPU at all. That needs a feature-id vertex attribute in `vt` and shader support — not done.
+A cheaper half-step is to let "parameter + feature field" expressions be live: `TileReader` already
+builds one processor per distinct feature-data, so the function can close over that feature's value
+and read the store per frame. The price is one function object per feature-data, and geometries only
+batch when they share one (16 style-parameter slots per geometry), so it fragments draws on a dense
+layer.
+
 ## Measured NOT to matter — do not re-run these
 
 | hypothesis | result |

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -176,6 +176,20 @@ overhead ~30%, so read the shares, not the absolutes):
 
 So the CartoCSS/expression machinery is **~18% of a decode** — geometry building is the cost.
 
+### The compiled map is cached
+
+A compiled `mvt::Map` is read-only, and a decoder's parameter values live in its own store, so the
+same map can serve several decoders. `MBVectorTileDecoder` keeps a small process-wide cache keyed by
+**(asset package, style asset name, `cartoCSSLayerNamesIgnored`)** — weak references plus the last
+two held strongly, so a day/night pair stays warm without pinning every style ever loaded. Measured
+on the device, loading the same style a second time: **411 ms → 0.00 ms** (the symbolizer context is
+already cached by asset package too, so the second load is free end to end).
+
+The key is the asset **package object**, not its contents: two styles of one package (the day/night
+case, `CompiledStyleSet(pack, "day")` / `(pack, "night")`) hit the cache, but re-creating the package
+around the same files does not. Hashing the assets to do better would cost more than it saves for
+the single-load case.
+
 ### Live style parameters
 
 `setStyleParameter` used to invalidate every tile ([TileLayer.cpp](../../all/native/layers/TileLayer.cpp)
@@ -257,6 +271,7 @@ layer.
 | CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
 | CartoCSS compile: skip a zoom whose predicate results repeat, reuse the trial property set | compile 157 → 129 ms, `buildMap` → 220 ms |
 | live style parameters (a colour-only parameter swaps values and redraws) | a parameter change went from *visible tiles × ~130 ms* of decode to **zero decodes** |
+| compiled-map cache keyed by asset package + style name | loading the same style again: 411 ms → **0.00 ms** |
 | render and tile paths at `-O2` in Release instead of `-Oz` | device 39.09 → 37.82 ms/frame (3.2%), CPU work minus the swap wait 14.39 → 13.51 ms (6.1%), `prepare` 2.65 → 2.22, `prelude` 0.91 → 0.70; +614 KB on arm64 |
 
 The `-Oz` → `-O2` A/B is a warning about the emulator as much as a result. Three interleaved cycles

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -116,10 +116,31 @@ matches, or pair the runs.
 | fonts, asset scan, symbolizer context | ~110 |
 
 The compile is three layers: `transportation` **115 ms** (2230 rules, 23 attachments), `route` 61 ms,
-`poi` 61 ms; the other 20 together ≈ 35 ms. Two structural reasons, both still open:
-`CartoCSSCompiler::buildPropertyLists` walks the **whole** stylesheet once per layer (23 × 407
-elements here), and `compileLayer` evaluates every property's filters at **all 25 zooms** even when
-the layer resolves to a handful of distinct zoom ranges (`transportation`: 11).
+`poi` 61 ms; the other 20 together ≈ 35 ms.
+
+Inside `compileLayer` it was three near-equal thirds, and each answered to a constant factor rather
+than to the algorithm (per-section ms, `transportation`, cold runs on the Crosscall):
+
+| section | before | after |
+|---|---|---|
+| `buildPropertyLists` | 37.8 | 22.8 |
+| per-zoom filter evaluation | 33.4 | 12.1 |
+| `buildLayerAttachment` | 39.6 | 31.4 |
+| list comparison | 2.2 | 2.0 |
+
+What the three fixes were, in the order they pay: **evaluate each distinct predicate once per zoom**
+(a layer has ~77 predicates and ~640 properties, and every property re-evaluated its own filters —
+this is a memo, not a semantic change); **bucket `insertProperty` by field** (two properties can only
+be equal if they set the same field, and comparing them is a deep expression comparison, so the scan
+went over every property inserted so far); **intern the field strings and hand out references** in
+`buildLayerAttachment` (its innermost operation was a string compare, and each property visit copied
+a `shared_ptr`). Summed over all 23 layers: **264 → 157 ms**, `buildMap` 362 → 261 ms.
+
+Left on the table: `buildPropertyLists` still walks the **whole** stylesheet once per layer (23 × 407
+elements here), and `compileLayer` still evaluates at **all 25 zooms** even when the layer resolves
+to a handful of distinct zoom ranges (`transportation`: 11) — the zoom-breakpoint version of that
+loop would cut the remaining evaluation *and* the attachment rebuilds, which are now the largest
+single item.
 
 **`setPixelScale` used to reload the style.** It rebuilt the symbolizer context by calling
 `updateCurrentStyleSet`, i.e. a full parse + compile, and `VectorTileLayer` calls it when the layer
@@ -181,6 +202,7 @@ what this means for `setStyleParameter`: it invalidates every tile ([TileLayer.c
 | an off-screen, already-anchored label defers its re-anchor | 1.60 → 1.70 fps — small, most dirty labels do hold a placement |
 | label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
 | `setPixelScale` rebuilds only the symbolizer context, not the compiled map | startup style cost 2 × 0.5–0.7 s → one load plus a ~0.1 s context rebuild |
+| CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile sections 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
 | render and tile paths at `-O2` in Release instead of `-Oz` | device 39.09 → 37.82 ms/frame (3.2%), CPU work minus the swap wait 14.39 → 13.51 ms (6.1%), `prepare` 2.65 → 2.22, `prelude` 0.91 → 0.70; +614 KB on arm64 |
 
 The `-Oz` → `-O2` A/B is a warning about the emulator as much as a result. Three interleaved cycles

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -174,9 +174,36 @@ overhead ~30%, so read the shares, not the absolutes):
 | symbolizer property evaluation | 4% |
 | rule prefilter + field gathering | 2% |
 
-So the CartoCSS/expression machinery is **~18% of a decode** — geometry building is the cost. Note
-what this means for `setStyleParameter`: it invalidates every tile ([TileLayer.cpp](../../all/native/layers/TileLayer.cpp)
-`updateTiles`), so changing one `nuti::` colour costs *visible tiles × ~130 ms* of decode CPU.
+So the CartoCSS/expression machinery is **~18% of a decode** — geometry building is the cost.
+
+### Live style parameters
+
+`setStyleParameter` used to invalidate every tile ([TileLayer.cpp](../../all/native/layers/TileLayer.cpp)
+`updateTiles`), so changing one `nuti::` colour cost *visible tiles × ~130 ms* of decode CPU. A
+parameter that **only** feeds properties the renderer evaluates per frame does not need any of that:
+
+- the values live in a `mvt::NutiParameterStore` that decoded tiles hold a pointer to, so replacing
+  them is visible to already-decoded tiles;
+- a colour/width property whose expression reads parameters (and at most the view state) becomes a
+  `vt::ColorFunction`/`FloatFunction` instead of being folded at decode — `Property::isLiveCapable`;
+- `mvt::resolveLiveNutiParameters` classifies each parameter at load, and `MBVectorTileDecoder`
+  takes the cheap path only when **every** parameter in the call is live: swap the values, ask for a
+  redraw (`onDecoderRefreshed`), decode nothing.
+
+Conservative by construction. A parameter is **not** live when it appears in a rule filter (it
+decides what the tile contains), when it feeds a property that is also read at decode time — glyph
+raster size, generated marker bitmap, stroke pattern (`Property::isBakedAtDecode`) — when the
+expression also reads a feature field or the zoom, or when it drives `_geometryscale`, `_fontscale`
+or `_zoomlevelbias`. Anything unclassified stays on the re-decode path.
+
+Measured on the device with the demo's in-memory nuti style (`--es style nuti`): flipping a colour
+parameter every 3 s produced **zero `decodeTile` calls** and the water polygons changed between the
+two colours in the next frame; flipping the boolean the style uses in a filter still re-decodes, as
+it must. Worth knowing: the bundled 23-layer style has **no** live parameter — its 461 parameters all
+sit in filters, text or marker sizes — so this pays only for styles written with colour parameters,
+which is the point of the feature.
+
+Classification costs ~37 ms once per style load on that style (a walk over every rule and property).
 
 ## Measured NOT to matter — do not re-run these
 
@@ -216,6 +243,7 @@ what this means for `setStyleParameter`: it invalidates every tile ([TileLayer.c
 | `setPixelScale` rebuilds only the symbolizer context, not the compiled map | startup style cost 2 × 0.5–0.7 s → one load plus a ~0.1 s context rebuild |
 | CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
 | CartoCSS compile: skip a zoom whose predicate results repeat, reuse the trial property set | compile 157 → 129 ms, `buildMap` → 220 ms |
+| live style parameters (a colour-only parameter swaps values and redraws) | a parameter change went from *visible tiles × ~130 ms* of decode to **zero decodes** |
 | render and tile paths at `-O2` in Release instead of `-Oz` | device 39.09 → 37.82 ms/frame (3.2%), CPU work minus the swap wait 14.39 → 13.51 ms (6.1%), `prepare` 2.65 → 2.22, `prelude` 0.91 → 0.70; +614 KB on arm64 |
 
 The `-Oz` → `-O2` A/B is a warning about the emulator as much as a result. Three interleaved cycles

--- a/docs/style-parameters.md
+++ b/docs/style-parameters.md
@@ -1,0 +1,80 @@
+# Style parameters (`nuti::`)
+
+A style parameter is a value the **app** owns and the style reads. It is declared in the style
+project's `nutiparameters` block and set at runtime through `MBVectorTileDecoder`:
+
+```java
+decoder.setStyleParameter("show_relief", "true");
+decoder.setStyleParameters(Map.of("lang", "fr", "buildings", "1"));
+decoder.setJSONStyleParameters("{\"lang\":\"fr\"}");
+```
+
+## Declaring one
+
+```json
+"nutiparameters": {
+  "show_relief":  { "default": true },
+  "lang":         { "default": "en" },
+  "routes_type":  [0, 1, 2],
+  "poi_colors":   { "default": { "restaurant": "#c0392b", "cafe": "#8e6e53" } },
+  "zoom_steps":   { "default": [10, 12, 14] }
+}
+```
+
+| form | meaning |
+|---|---|
+| `{ "default": <scalar> }` | a bool / integer / float / string parameter |
+| `[a, b, c]` | an **enum**: the allowed values, the last one is the default |
+| `{ "default": <object> }` / `{ "default": <array> }` | a **table** the style indexes into |
+
+The array form has always meant "enum", so a table must be declared under `default`.
+
+## Reading one
+
+Scalars read like any other variable, in an expression or a filter:
+
+```css
+#road['nuti::show_underground' = 1] { line-color: @underground_color; }
+#label { text-size: 12 / [nuti::_fontscale]; }
+```
+
+Tables are read with `get`, which takes an optional fallback, plus `has` and `length`:
+
+```css
+#poi { marker-fill: get([nuti::poi_colors], [class], #888888); }
+#contour { line-width: get([nuti::widths], 0, 0.8); }
+```
+
+`get(table, key)` takes a member by name from an object, or an element by index from an array, and
+is unset when the key is missing (so the third argument is what you usually want). One table
+parameter replaces one parameter per class, and the app can rewrite the whole table at once:
+
+```java
+decoder.setStyleParameter("poi_colors", "{\"restaurant\":\"#c0392b\",\"cafe\":\"#8e6e53\"}");
+```
+
+`getStyleParameter` returns a table as JSON.
+
+## What a change costs
+
+Changing a parameter is either a **redraw** or a **re-decode of every visible tile** (~130 ms of CPU
+per tile), decided per parameter when the style loads:
+
+- **Redraw** — the parameter is read *only* by properties the renderer evaluates per frame:
+  colours, opacities, widths, and only where the expression reads nothing else that is fixed at
+  decode time.
+- **Re-decode** — everything else, and deliberately so:
+  - the parameter appears in a **filter** (`#road['nuti::x' = 1]`, `when (...)`): it decides which
+    rules match, i.e. what geometry the tile contains at all;
+  - it feeds a property that is *also* read while the tile is built — `text-size` and `shield-size`
+    pick the glyph raster, marker `width`/`height`/`stroke-width` draw the generated bitmap, line
+    `stroke-width` and `stroke-miterlimit` shape the stroke pattern;
+  - the expression also reads a **feature field** or the zoom — `get([nuti::poi_colors], [class])`
+    is in this group, because the class comes from the feature;
+  - it is `_geometryscale`, `_fontscale` or `_zoomlevelbias`, which scale the geometry and the
+    glyphs a tile is built with.
+
+So a colour an app exposes as a setting (`"water_color"`) is free to change, while a table read per
+feature class, and anything driving selection, still costs a decode. See
+[`rendering/10-performance.md`](rendering/10-performance.md#live-style-parameters) for the
+measurements and for the feature-state design that would make selection free too.

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -1611,6 +1611,8 @@ public class DemoMap {
                 }
                 nutiParameterOn = !nutiParameterOn;
                 baseDecoder.setStyleParameter(DemoStyles.NUTI_PARAMETER, Boolean.toString(nutiParameterOn));
+                // The colour parameter takes the live path: no tile is decoded for it
+                baseDecoder.setStyleParameter(DemoStyles.NUTI_COLOR_PARAMETER, nutiParameterOn ? "#9cc3e0" : "#2f6f4f");
                 Log.d(TAG, "nuti " + DemoStyles.NUTI_PARAMETER + "=" + nutiParameterOn);
                 handler.postDelayed(this, DemoConfig.NUTI_TOGGLE_INTERVAL_MS);
             }

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -1613,6 +1613,10 @@ public class DemoMap {
                 baseDecoder.setStyleParameter(DemoStyles.NUTI_PARAMETER, Boolean.toString(nutiParameterOn));
                 // The colour parameter takes the live path: no tile is decoded for it
                 baseDecoder.setStyleParameter(DemoStyles.NUTI_COLOR_PARAMETER, nutiParameterOn ? "#9cc3e0" : "#2f6f4f");
+                // The table parameter is set as JSON; the style reads it per road class with get()
+                baseDecoder.setStyleParameter(DemoStyles.NUTI_TABLE_PARAMETER, nutiParameterOn
+                    ? "{\"motorway\":\"#e27d60\",\"trunk\":\"#f0a868\",\"primary\":\"#d9b382\"}"
+                    : "{\"motorway\":\"#7048e8\",\"trunk\":\"#9775fa\",\"primary\":\"#b197fc\"}");
                 Log.d(TAG, "nuti " + DemoStyles.NUTI_PARAMETER + "=" + nutiParameterOn);
                 handler.postDelayed(this, DemoConfig.NUTI_TOGGLE_INTERVAL_MS);
             }

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStyles.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStyles.java
@@ -537,17 +537,28 @@ public final class DemoStyles {
     /** Name of the boolean parameter the demo flips; see DemoMap.startNutiToggleLoop. */
     public static final String NUTI_PARAMETER = "show_relief";
 
+    /**
+     * A parameter that nothing but a colour reads. The SDK classifies it as LIVE: setting it swaps
+     * the value the decoded tiles already point at and asks for a redraw, where NUTI_PARAMETER sits
+     * in a filter and so decides what the tile contains - changing that one decodes every tile
+     * again. Flipped by the same loop, so a run shows both paths.
+     */
+    public static final String NUTI_COLOR_PARAMETER = "water_color";
+
     private static MBVectorTileDecoder createNutiDecoder() {
         // 'layers' is TOP -> BOTTOM (reversed into draw order) and must list every composite slot.
         String projectJson = String.join("\n",
             "{",
             "  \"styles\": [\"style.mss\"],",
             "  \"layers\": [\"contour\", \"building\", \"transportation\", \"satellite\", \"hillshade\", \"landcover\", \"water\"],",
-            "  \"nutiparameters\": { \"" + NUTI_PARAMETER + "\": { \"default\": true } }",
+            "  \"nutiparameters\": {",
+            "    \"" + NUTI_PARAMETER + "\": { \"default\": true },",
+            "    \"" + NUTI_COLOR_PARAMETER + "\": { \"default\": \"#9cc3e0\" }",
+            "  }",
             "}");
         String mss = String.join("\n",
             "Map { background-color: " + DemoConfig.INLINE_BACKGROUND_COLOR + "; }",
-            "#water { polygon-fill: #9cc3e0; }",
+            "#water { polygon-fill: [nuti::" + NUTI_COLOR_PARAMETER + "]; }",
             "#landcover { polygon-fill: #dbe8cc;" + landcoverOpacity() + " }",
             // the hillshade slot exists only while the user setting is on
             "#hillshade['nuti::" + NUTI_PARAMETER + "'=true][zoom>=4] {",

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStyles.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStyles.java
@@ -545,6 +545,13 @@ public final class DemoStyles {
      */
     public static final String NUTI_COLOR_PARAMETER = "water_color";
 
+    /**
+     * A parameter holding a TABLE - one colour per road class - that the style reads with
+     * get(table, key, fallback). One parameter replaces one-per-class, and the app owns the
+     * contents. Reading it uses the feature's [class], so changing the table still re-decodes.
+     */
+    public static final String NUTI_TABLE_PARAMETER = "road_colors";
+
     private static MBVectorTileDecoder createNutiDecoder() {
         // 'layers' is TOP -> BOTTOM (reversed into draw order) and must list every composite slot.
         String projectJson = String.join("\n",
@@ -553,7 +560,8 @@ public final class DemoStyles {
             "  \"layers\": [\"contour\", \"building\", \"transportation\", \"satellite\", \"hillshade\", \"landcover\", \"water\"],",
             "  \"nutiparameters\": {",
             "    \"" + NUTI_PARAMETER + "\": { \"default\": true },",
-            "    \"" + NUTI_COLOR_PARAMETER + "\": { \"default\": \"#9cc3e0\" }",
+            "    \"" + NUTI_COLOR_PARAMETER + "\": { \"default\": \"#9cc3e0\" },",
+            "    \"" + NUTI_TABLE_PARAMETER + "\": { \"default\": { \"motorway\": \"#e27d60\", \"trunk\": \"#f0a868\", \"primary\": \"#d9b382\" } }",
             "  }",
             "}");
         String mss = String.join("\n",
@@ -569,8 +577,9 @@ public final class DemoStyles {
             "}",
             "#satellite[zoom>=" + DemoConfig.INLINE_SATELLITE_MIN_ZOOM + "] { raster-opacity: 0.45; }",
                 "#contour[zoom>=12] { line-color: #9a5a12; line-width: 0.8; line-opacity: 0.7; }",
-            "#transportation { line-color: #ffffff; line-width: 1.2; }",
-            "#transportation['class'='motorway'] { line-color: #e27d60; line-width: " + DemoConfig.INLINE_MOTORWAY_WIDTH + "; }",
+            // one rule for every class, the colour comes out of the table parameter
+            "#transportation { line-color: get([nuti::" + NUTI_TABLE_PARAMETER + "], [class], #ffffff); line-width: 1.2; }",
+            "#transportation['class'='motorway'] { line-width: " + DemoConfig.INLINE_MOTORWAY_WIDTH + "; }",
             DemoConfig.INLINE_BUILDINGS_3D
                 ? "#building[zoom>=14] { building-fill: #d9cfc4; building-height: " + DemoConfig.INLINE_BUILDING_HEIGHT + "; }"
                 : "#building[zoom>=14] { polygon-fill: #d9cfc4; }");


### PR DESCRIPTION
## Summary

`setStyleParameter` invalidated every tile, so changing a colour cost a full decode of everything on screen — ~130 ms per tile on a Crosscall HLTE556N. A parameter that only feeds properties the renderer evaluates per frame no longer does that:

- `MBVectorTileDecoder` keeps the values in a `mvt::NutiParameterStore` the decoded tiles read through, and asks mapnikvt which parameters are live at style load.
- When **every** parameter of a `setStyleParameter` / `setStyleParameters` / `setJSONStyleParameters` call is live, it swaps the values and fires the new `OnChangeListener::onDecoderRefreshed`, which `VectorTileLayer` answers with a redraw — no fetch, no decode, no re-cull. Anything else takes the old path.
- `_geometryscale` / `_fontscale` / `_zoomlevelbias` are snapshot when the symbolizer context is built, so they stay on the re-decode path by construction.

No public API signature changes; `OnChangeListener` gains a virtual with a default that forwards to `onDecoderChanged()`.

The demo's in-memory nuti project gains a `water_color` parameter next to `show_relief`, so one run shows both paths.

## Testing

- `clang++ -fsyntax-only -std=c++17` clean on every touched translation unit.
- Device (Crosscall HLTE556N, `--es style nuti`): the colour parameter flipped every 3 s gave **zero `decodeTile` calls** over five flips, and the water polygons changed between `#2f6f4f` and `#9cc3e0` in the next frame (pixel-checked). The boolean the same style uses in a filter still re-decodes.
- Device (`--es style assets`, the 23-layer bundled style): renders unchanged at Grenoble z16.22 / tilt 26. That style reports **no** live parameter — its 461 parameters sit in filters, text and marker sizes — so it is a pure regression check.
- A startup crash found and fixed on the way (null property registrations in `TextSymbolizer`); see the submodule PR.

## Depends on

farfromrefug/mobile-carto-libs#33 — merge that first; no submodule pointer bump here.

Stacked on Akylas/mobile-sdk#72 (shares the `docs/rendering/10-performance.md` edits).