### PR TITLE
fix(vt): cap a terrain line against the unpacked binormal

### DIFF
--- a/docs/rendering/03-vt-renderer.md
+++ b/docs/rendering/03-vt-renderer.md
@@ -253,11 +253,22 @@ towards the camera until a near contour is a blob, so the projected offset is me
 back to the nominal width when it exceeds it. The factor is ≤ 1 by construction — it can never
 manufacture an oversized quad, which is what an unbounded screen-space fit does.
 
-The ceiling is **this vertex's own extrusion**, `roundedWidth * length(aVertexBinormal)`, not one
-line width. Not every line vertex sits one width out: a round cap's corners are at √2, and an end
-arrow's barbs at several. Clamping those to one width squashes the shape they belong to back into
-the line's silhouette — which is what made `line-end-arrow` draw nothing at all in terrain mode
-while it drew fine on a flat map.
+The ceiling is **this vertex's own extrusion**, `roundedWidth * length(aVertexBinormal *
+uBinormalUnitScale)`, not one line width. Not every line vertex sits one width out: a round cap's
+corners are at √2, and an end arrow's barbs at several. Clamping those to one width squashes the
+shape they belong to back into the line's silhouette — which is what made `line-end-arrow` draw
+nothing at all in terrain mode while it drew fine on a flat map.
+
+> **`aVertexBinormal` is PACKED — its raw length is not a number of line widths.** Binormals ship
+> as `GL_SHORT`, un-normalised (`GL_FALSE`), against a per-geometry scale
+> (`calculateScale` in `TileLayerBuilder`, a power of two ≈ 32768 for unit vectors), which is why
+> the extrusion itself reads `aVertexBinormal * (uBinormalScale * roundedWidth)`. Taking
+> `length(aVertexBinormal)` alone made the ceiling ~32768× too large, so `edgeLen > nominalLen`
+> never fired and **every** terrain line fell back to tangram's unbounded world-space extrusion:
+> near contours grew into fat, soft-edged blobs (their antialias band grows with them), roads read
+> as draped again, and neighbouring vertices no longer agreed on a width so joins came apart.
+> `uBinormalUnitScale` (`1 / binormalScale`, uploaded with `uScreenScale`) undoes the packing:
+> 1 for a plain vertex, more for a miter, a cap corner or an arrow barb.
 
 > **The capped vertex takes its DEPTH from the terrain, and its XY from the screen.** Both halves
 > are load-bearing. Applying the shrunk offset to `centerClip.xy` and keeping `centerClip.z` — the


### PR DESCRIPTION
## Summary

- Bumps `libs-carto` to the terrain line width fix: the ceiling in `lineVsh` measured a vertex's extrusion as `length(aVertexBinormal)`, but that attribute is packed (`GL_SHORT`, un-normalised, per-geometry scale ≈ 32768), so the ceiling was ~32768x too large and never engaged.
- Every terrain line therefore fell back to tangram's unbounded world-space extrusion: near contours grew into fat, soft-edged blobs, roads read as draped, and neighbouring vertices stopped agreeing on a width so the joins came apart. Regressed by farfromrefug/mobile-carto-libs#30.
- Documents the trap in `docs/rendering/03-vt-renderer.md`, next to the width model — the raw length of a packed attribute is not a number of line widths.

No API change, nothing to regenerate (no `all/modules/*.i` touched).

## Testing

- `clang++ -fsyntax-only -std=c++17` clean on `vt/src/vt/GLTileRenderer.cpp` (the only translation unit touched, in the submodule).
- Shader behaviour is not provable that way. Verified by the reporter in their own app (iOS, 3D terrain, z16-17 tilt 26, reported around lat 45.1985 lon 5.7249): contours and roads back to nominal width and joining.
- Worth a second look on Android at a low camera over a slope — e.g. `--es lat 45.2424 --es lon 5.7612 --es zoom 13.6 --es tilt 35 --es contour true` — plus a `line-end-arrow` route, since the arrow barbs are what the ceiling now relaxes for.
- Not covered: `SPHERICAL` render projection (`calculateVector` does not preserve vector length there).

## Depends on

farfromrefug/mobile-carto-libs#34 — merge that first, then rebase this pointer bump onto the merged commit.