### PR TITLE
feat(vectortiles): answer a selection style parameter with a repaint instead of a decode

### DIFF
--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -345,21 +345,38 @@ namespace carto {
         _parameterStore->setValues(std::move(parameterValues));
     }
 
+    void MBVectorTileDecoder::updateSelectionState() {
+        // The whole of the selection, as the tiles see it: every feature keeps the hash of what the
+        // parameter is compared with, and is drawn selected exactly while the two agree.
+        std::uint64_t stateKey = 0;
+        if (!_selectionParameter.empty()) {
+            std::shared_ptr<const std::map<std::string, mvt::Value>> parameterValues = _parameterStore->getValues();
+            auto it = parameterValues->find(_selectionParameter);
+            stateKey = mvt::hashValue(it != parameterValues->end() ? it->second : mvt::Value());
+        }
+        _selectionState->store(stateKey, std::memory_order_relaxed);
+    }
+
     void MBVectorTileDecoder::updateSymbolizer() {
         updateParameterStore();
 
         // Settings snapshot the parameters that scale geometry and glyphs, so they are rebuilt
         // whenever a parameter changes structurally.
-        _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(_symbolizerContextSettings->getTileSize(), _parameterStore, _symbolizerContextSettings->getFallbackFont(), _pixelScale);
+        _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(_symbolizerContextSettings->getTileSize(), _parameterStore, _symbolizerContextSettings->getFallbackFont(), _pixelScale, _selectionState);
         _symbolizerContext = std::make_shared<mvt::SymbolizerContext>(_symbolizerContext->getBitmapManager(), _symbolizerContext->getFontManager(), _symbolizerContext->getStrokeMap(), _symbolizerContext->getGlyphMap(), *_symbolizerContextSettings);
     }
 
-    bool MBVectorTileDecoder::areParametersLive(const std::vector<std::string>& params) const {
-        if (params.empty() || _liveParameters.empty()) {
+    bool MBVectorTileDecoder::areParametersRepaintable(const std::vector<std::string>& params) const {
+        if (params.empty()) {
             return false;
         }
         for (const std::string& param : params) {
-            if (_liveParameters.find(param) == _liveParameters.end()) {
+            // Either nothing but a per-frame function reads it, or it is the SELECTING parameter,
+            // whose two appearances every feature already carries as two style slots. Both are
+            // answered by drawing the tiles again; anything else has to decode them.
+            bool live = _liveParameters.find(param) != _liveParameters.end();
+            bool selecting = !_selectionParameter.empty() && param == _selectionParameter;
+            if (!live && !selecting) {
                 return false;
             }
         }
@@ -431,9 +448,10 @@ namespace carto {
 
             setStyleParameterInternal(param, value);
 
-            live = areParametersLive({ param });
+            live = areParametersRepaintable({ param });
             if (live) {
                 updateParameterStore();
+                updateSelectionState();
             } else {
                 updateSymbolizer();
             }
@@ -465,9 +483,10 @@ namespace carto {
                     setStyleParameterInternal(it->first, it->second.get<std::string>());
                     params.push_back(it->first);
                 }
-                live = areParametersLive(params);
+                live = areParametersRepaintable(params);
                 if (live) {
                     updateParameterStore();
+                    updateSelectionState();
                 } else {
                     updateSymbolizer();
                 }
@@ -494,9 +513,10 @@ namespace carto {
                 setStyleParameterInternal(p->first, p->second);
                 paramNames.push_back(p->first);
             }
-            live = areParametersLive(paramNames);
+            live = areParametersRepaintable(paramNames);
             if (live) {
                 updateParameterStore();
+                updateSelectionState();
             } else {
                 updateSymbolizer();
             }
@@ -821,6 +841,10 @@ namespace carto {
         }
 
         if (!mapWasCached) {
+            // Which parameter this style selects features with - a property of the compiled style,
+            // so it is resolved once, here, while the map is still ours alone.
+            std::shared_ptr<mvt::Map> compiledMap = std::const_pointer_cast<mvt::Map>(map);
+            compiledMap->setSelectionParameter(mvt::resolveSelectionParameter(*compiledMap, _logger));
             storeCachedMap(mapCacheKey, map);
         }
 
@@ -916,8 +940,10 @@ namespace carto {
         }
         updateParameterStore();
         _liveParameters = mvt::resolveLiveNutiParameters(*_map);
+        _selectionParameter = _map->getSelectionParameter() ? _map->getSelectionParameter()->name : std::string();
+        updateSelectionState();
 
-        _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(symbolizerContext->getSettings().getTileSize(), _parameterStore, symbolizerContext->getSettings().getFallbackFont(), _pixelScale);
+        _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(symbolizerContext->getSettings().getTileSize(), _parameterStore, symbolizerContext->getSettings().getFallbackFont(), _pixelScale, _selectionState);
         _symbolizerContext = std::make_shared<mvt::SymbolizerContext>(symbolizerContext->getBitmapManager(), symbolizerContext->getFontManager(), symbolizerContext->getStrokeMap(), symbolizerContext->getGlyphMap(), *_symbolizerContextSettings);
         _cachedFeatureDecoder.first.reset();
         _cachedFeatureDecoder.second.reset();

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -9,6 +9,7 @@
 
 #include "vectortiles/VectorTileDecoder.h"
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <map>
@@ -204,8 +205,9 @@ namespace carto {
         void updateCurrentStyleSet(const std::variant<std::shared_ptr<CompiledStyleSet>, std::shared_ptr<CartoCSSStyleSet> >& styleSet);
         void updateSymbolizerContext();
         void updateParameterStore();
+        void updateSelectionState();
         bool setStyleParameterInternal(const std::string& param, const std::string& value);
-        bool areParametersLive(const std::vector<std::string>& params) const;
+        bool areParametersRepaintable(const std::vector<std::string>& params) const;
         void updateSymbolizer();
 
         static const std::string DEFAULT_FALLBACK_FONT_NAME;
@@ -226,6 +228,10 @@ namespace carto {
         std::shared_ptr<AssetPackage> _styleAssetPackage; // context can be rebuilt without it
         std::shared_ptr<mvt::NutiParameterStore> _parameterStore; // the values the decoded tiles read
         std::set<std::string> _liveParameters; // those of them that only a per-frame function reads
+        std::string _selectionParameter; // the one that selects a feature, if the style has one
+        // Its value, hashed: the tiles read it while they are drawn, so setting the selection is a
+        // style-byte rewrite rather than a decode. Shared with every tile this decoder built.
+        std::shared_ptr<std::atomic<std::uint64_t>> _selectionState = std::make_shared<std::atomic<std::uint64_t>>(0);
         std::shared_ptr<const mvt::Map> _map;
         std::shared_ptr<const mvt::Map::Settings> _mapSettings;
         std::shared_ptr<const mvt::SymbolizerContext> _symbolizerContext;

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -253,18 +253,66 @@ which is the point of the feature.
 
 Classification costs ~37 ms once per style load on that style (a walk over every rule and property).
 
-**What this does not solve: selection.** A style that drives "selected" with a parameter — the route
-style's `when ([nuti::selected_osmid]=@osmid)::selected`, plus a width that mixes the parameter with
-the feature field `[osmid]` — stays on the re-decode path, and the filter part *has* to: the casing
-of the selected route only exists because that rule matched, and a redraw cannot build geometry. The
-durable answer is maplibre's `feature-state` model: the selected id becomes a **uniform** and the
-comparison happens per vertex against a feature-id attribute, so a selection change costs nothing on
-the CPU at all. That needs a feature-id vertex attribute in `vt` and shader support — not done.
-A cheaper half-step is to let "parameter + feature field" expressions be live: `TileReader` already
-builds one processor per distinct feature-data, so the function can close over that feature's value
-and read the store per frame. The price is one function object per feature-data, and geometries only
-batch when they share one (16 style-parameter slots per geometry), so it fragments draws on a dense
-layer.
+### Selection: the appearance half, without a decode
+
+A selection is a parameter compared with a feature field — `[nuti::selected_id] = [osmid] + ''` —
+which the classification above rejects, because the comparison can only be answered per feature. The
+**appearance** half of it no longer needs a decode either, for a style that asks:
+
+```json
+"nutiparameters": { "selected_id": { "default": "", "selects": true } }
+```
+
+Opt-in on purpose. It only works for a style written a particular way, so inferring it would make
+every other style pay a walk over its rules to be told no, and would leave an author whose style
+just misses the conditions with no way to find out. `resolveSelectionParameter` returns before
+touching anything when no parameter declares itself, and warns with the reason when a declared one
+does not qualify.
+
+A geometry already carries up to 16 style slots, whose colour and width are uniform arrays refilled
+every frame, and every vertex names its slot in one byte of `aVertexAttribs`. So the decoder folds
+the comparison BOTH ways: it builds the symbolizer twice, once with the parameter forced to the
+feature's own value and once to a value it cannot equal, and both answers land as two slots of the
+same geometry. Nothing else about the feature changes, so it is tesselated once.
+
+- `mvt::resolveSelectionParameter` verifies the declared parameter at style load and marks the
+  properties it may fold (`Property::setSelectionFoldable`). A folded property reads no parameter, so
+  it collapses to a constant — which is what makes it a slot, and what lets every unselected feature
+  share one.
+- `ExpressionContext::setNutiParameterOverride` is how the fold is forced; `TileReader::createSelectionFeatureProcessor`
+  runs the branch that is not drawn over an EMPTY feature collection, so it registers its slot without
+  laying down vertices.
+- Each feature keeps a 64-bit `hashValue` of what it is compared with, next to the vertex run
+  (`vt::TileGeometry::FeatureStyleRange`). `MBVectorTileDecoder` publishes the hash of the parameter
+  in a shared atomic; `GLTileRenderer` compares the two in `buildCompiledTileGeometry`, rewrites the
+  style byte of the runs that changed and re-uploads exactly those bytes with `glBufferSubData`.
+
+Deciding it on the render thread rather than walking the tile cache is what keeps it free of locks:
+the vertex data is only ever touched where it is uploaded, and a tile decoded later picks the state
+up on its own.
+
+Conservative, because a fold that got the tesselation wrong could not be undone by a repaint. The
+parameter has to be read only by the `stroke`, `stroke-opacity` and `stroke-width` of line
+symbolizers — the three that end up as slots and touch no vertex — always inside an `=` against the
+same field expression, never in a rule filter, never beside another parameter in one property. A
+dashed line whose width is selected is refused as well: the dash raster is sized by the width, so the
+two branches would not share their vertices.
+
+Measured with the demo's selection bench (`--es routeSelect true --es routeSelectCycle 2500`,
+12 routes, z12.5, `--es tilt 90`), with a temporary `decodeTile` probe. `value` mode goes from 6
+`decodeTile` calls per selection to **zero**, on the emulator and on the Crosscall alike, and
+`setStyleParameter` from 2.2-3.6 ms to **0.32-0.81 ms** on the device (0.08-0.39 ms on the emulator).
+`filter` mode still decodes its 6 tiles per selection, as it must, and logs `it is read by a rule
+filter, which decides whether the geometry exists at all`. The selected route changes colour and
+width in the next frame in both, and the 23-layer base-map style is unaffected - it declares no
+selecting parameter, so its rules are never walked.
+
+**What is still a decode: the structural half.** `when ([nuti::selected_id] = [osmid] + '')::selected`
+decides whether the casing geometry exists at all, and no repaint can build geometry. A style that
+wants a free selection has to express the casing as appearance — a width and a colour that fold —
+rather than as a rule. The durable answer for the general case is maplibre's `feature-state` model:
+the selected id becomes a **uniform** compared per vertex against a feature-id attribute, which needs
+a feature-id vertex attribute in `vt` and shader support — not done.
 
 ## Measured NOT to matter — do not re-run these
 

--- a/docs/style-parameters.md
+++ b/docs/style-parameters.md
@@ -63,6 +63,7 @@ per tile), decided per parameter when the style loads:
 - **Redraw** — the parameter is read *only* by properties the renderer evaluates per frame:
   colours, opacities, widths, and only where the expression reads nothing else that is fixed at
   decode time.
+- **Redraw** — or it SELECTS a feature (below).
 - **Re-decode** — everything else, and deliberately so:
   - the parameter appears in a **filter** (`#road['nuti::x' = 1]`, `when (...)`): it decides which
     rules match, i.e. what geometry the tile contains at all;
@@ -75,6 +76,45 @@ per tile), decided per parameter when the style loads:
     glyphs a tile is built with.
 
 So a colour an app exposes as a setting (`"water_color"`) is free to change, while a table read per
-feature class, and anything driving selection, still costs a decode. See
-[`rendering/10-performance.md`](rendering/10-performance.md#live-style-parameters) for the
-measurements and for the feature-state design that would make selection free too.
+feature class still costs a decode.
+
+## Selecting one feature
+
+The one "parameter compared with a feature field" that can be free is a SELECTION, and the style has
+to **ask for it** — nothing is inferred, and a style that declares nothing is not even inspected:
+
+```json
+"nutiparameters": {
+  "selected_id": { "default": "", "selects": true }
+}
+```
+
+```css
+@is_selected: [nuti::selected_id] = [osmid] + '';
+#routes {
+  line-color: @is_selected ? #ff3b00 : #3388ff;
+  line-width: 5 + (@is_selected ? 4 : 0);
+}
+```
+
+```java
+decoder.setStyleParameter("selected_id", Long.toString(osmid));   // no tile is decoded again
+```
+
+The decoder folds the comparison both ways at decode, so the tile carries the selected and the
+unselected appearance as two style slots, and each feature keeps a hash of what it is compared with.
+Setting the parameter rewrites one byte per vertex and redraws.
+
+The rules are narrow, and a style that breaks one falls back to the re-decode path — with a warning
+in the log naming the reason, so `selects` never fails silently:
+
+- only `line-color`, `line-opacity` and `line-width` of a **line** rule may read the parameter;
+- always as `[nuti::x] = <expression of feature fields>`, with the same expression everywhere, and
+  never together with another parameter in one property;
+- never in a **filter** — `when ([nuti::selected_id] = [osmid] + '')::casing` decides whether the
+  casing geometry EXISTS, and no repaint can build geometry. Write the casing as a width and a
+  colour instead of as a rule if you want the selection to stay free;
+- not on a **dashed** line whose width is selected: the dash raster is sized by the width.
+
+See [`rendering/10-performance.md`](rendering/10-performance.md#selection-the-appearance-half-without-a-decode)
+for the mechanism and the measurements.

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -94,6 +94,8 @@ public final class DemoConfig {
     public static boolean LAYER_ROUTES = false;
     /** Synthetic mountain-road route (GeoJSON tiles + CartoCSS): the line join / cap / opacity bench. */
     public static boolean LAYER_ROUTE_TEST = false;
+    /** Many routes, one of them selected through a style parameter - the selection-cost bench. */
+    public static boolean LAYER_ROUTE_SELECT = false;
     /** Navigation maneuver arrows (ManeuverArrowBuilder + CartoCSS). Filled by the routing test. */
     public static boolean LAYER_MANEUVERS = false;
 
@@ -534,6 +536,40 @@ public final class DemoConfig {
     public static String ROUTE_TEST_OPACITY_MODE = "geom";
 
     // =============================================================================================
+    // ROUTE SELECTION BENCH (LAYER_ROUTE_SELECT)
+    // Many routes served as GeoJSON vector tiles, with ONE of them selected through a style
+    // parameter that is compared with a feature field - the shape every real route style uses:
+    //
+    //     @is_selected: [nuti::selected_id] = [osmid] + '';
+    //
+    // The point of the bench is what a selection change costs. Two modes, so the two halves can be
+    // told apart:
+    //   value  - the parameter only feeds line-color / line-width, i.e. the APPEARANCE. Nothing
+    //            about which geometry exists changes, so this is the half that could repaint.
+    //   filter - adds the 'when (...)::selected' casing attachment of a real style, which decides
+    //            whether the casing geometry EXISTS. That half can only be answered by decoding.
+    // Tap a route to select it, or let it cycle with routeSelectCycle.
+    // =============================================================================================
+
+    /** Number of routes generated around the start position. */
+    public static int ROUTE_SELECT_COUNT = 12;
+    /** Extent of the fan of routes, in degrees. */
+    public static float ROUTE_SELECT_SPAN = 0.05f;
+    /** Vertices per route: more geometry per feature = more vertex bytes to repoint on selection. */
+    public static int ROUTE_SELECT_VERTICES = 60;
+    public static float ROUTE_SELECT_WIDTH = 5f;
+    /** Width added to the selected route (the appearance half of a real selection). */
+    public static float ROUTE_SELECT_WIDTH_BUMP = 4f;
+    public static String ROUTE_SELECT_COLOR = "#3388ff";
+    public static String ROUTE_SELECT_SELECTED_COLOR = "#ff3b00";
+    /** value = colour/width only; filter = also the 'when (...)::selected' casing of a real style. */
+    public static String ROUTE_SELECT_MODE = "value";
+    /** Style parameter holding the selected id, declared by the in-memory project. */
+    public static String ROUTE_SELECT_PARAMETER = "selected_id";
+    /** Select the next route every N ms. 0 = only on tap / the panel button. */
+    public static int ROUTE_SELECT_CYCLE_MS = 0;
+
+    // =============================================================================================
     // MANEUVER ARROWS (LAYER_MANEUVERS)
     // The turn arrow of a navigation app: ManeuverArrowBuilder cuts it out of a route geometry
     // and serves it as ONE vector tile layer ('maneuver'), styled below like any other layer. The
@@ -781,6 +817,11 @@ public final class DemoConfig {
         LAYER_ELEMENTS = DemoCfg.cfgBool("elements", LAYER_ELEMENTS);
         LAYER_ROUTES = DemoCfg.cfgBool("routes", LAYER_ROUTES);
         LAYER_ROUTE_TEST = DemoCfg.cfgBool("routeTest", LAYER_ROUTE_TEST);
+        LAYER_ROUTE_SELECT = DemoCfg.cfgBool("routeSelect", LAYER_ROUTE_SELECT);
+        ROUTE_SELECT_COUNT = DemoCfg.cfgInt("routeSelectCount", ROUTE_SELECT_COUNT);
+        ROUTE_SELECT_MODE = DemoCfg.cfgStr("routeSelectMode", ROUTE_SELECT_MODE);
+        ROUTE_SELECT_CYCLE_MS = DemoCfg.cfgInt("routeSelectCycle", ROUTE_SELECT_CYCLE_MS);
+        ROUTE_SELECT_WIDTH = DemoCfg.cfgFloat("routeSelectWidth", ROUTE_SELECT_WIDTH);
         LAYER_MANEUVERS = DemoCfg.cfgBool("maneuvers", LAYER_MANEUVERS);
 
         // composite slots ('hs', 'sat', 'contour' are the historical keys)

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -88,7 +88,7 @@ public class DemoMap {
 
     /** One switchable layer of the demo. */
     public enum Feature {
-        CELESTIAL, STARS, BASE, SATELLITE, HILLSHADE, HYPSO, CONTOUR, CONTOUR_TILES, ROUTES, ROUTE_TEST, MANEUVERS, ELEMENTS, PEAKS
+        CELESTIAL, STARS, BASE, SATELLITE, HILLSHADE, HYPSO, CONTOUR, CONTOUR_TILES, ROUTES, ROUTE_TEST, ROUTE_SELECT, MANEUVERS, ELEMENTS, PEAKS
     }
 
     /** Bottom -> top draw order. Toggling a layer never reorders the others. */
@@ -97,7 +97,7 @@ public class DemoMap {
         // behind it - which is what a body in the sky should do.
         Feature.CELESTIAL, Feature.STARS,
         Feature.BASE, Feature.SATELLITE, Feature.HILLSHADE, Feature.HYPSO,
-        Feature.CONTOUR, Feature.CONTOUR_TILES, Feature.ROUTES, Feature.ROUTE_TEST, Feature.MANEUVERS, Feature.ELEMENTS,
+        Feature.CONTOUR, Feature.CONTOUR_TILES, Feature.ROUTES, Feature.ROUTE_TEST, Feature.ROUTE_SELECT, Feature.MANEUVERS, Feature.ELEMENTS,
         // Last: the summit names go over everything the map draws.
         Feature.PEAKS
     };
@@ -108,6 +108,10 @@ public class DemoMap {
     public final DemoStars stars = new DemoStars();
     /** Device orientation driving the camera, for the star sky mode. */
     private DemoOrientation orientation;
+    /** Decoder of the route selection bench - the selection is one style parameter on it. */
+    private MBVectorTileDecoder routeSelectDecoder;
+    private long routeSelectId = 1;
+    private Runnable routeSelectCycle;
     /** Live camera preview behind the transparent map, for the star sky mode. */
     private DemoCameraPreview cameraPreview;
 
@@ -232,6 +236,7 @@ public class DemoMap {
             case CONTOUR_TILES: return DemoConfig.LAYER_CONTOUR_TILES;
             case ROUTES: return DemoConfig.LAYER_ROUTES;
             case ROUTE_TEST: return DemoConfig.LAYER_ROUTE_TEST;
+            case ROUTE_SELECT: return DemoConfig.LAYER_ROUTE_SELECT;
             case MANEUVERS: return DemoConfig.LAYER_MANEUVERS;
             case ELEMENTS: return DemoConfig.LAYER_ELEMENTS;
             case PEAKS: return DemoConfig.LAYER_PEAKS;
@@ -251,6 +256,7 @@ public class DemoMap {
             case CONTOUR_TILES: DemoConfig.LAYER_CONTOUR_TILES = enabled; break;
             case ROUTES: DemoConfig.LAYER_ROUTES = enabled; break;
             case ROUTE_TEST: DemoConfig.LAYER_ROUTE_TEST = enabled; break;
+            case ROUTE_SELECT: DemoConfig.LAYER_ROUTE_SELECT = enabled; break;
             case MANEUVERS: DemoConfig.LAYER_MANEUVERS = enabled; break;
             case ELEMENTS: DemoConfig.LAYER_ELEMENTS = enabled; break;
             case PEAKS: DemoConfig.LAYER_PEAKS = enabled; break;
@@ -311,6 +317,7 @@ public class DemoMap {
             case CONTOUR_TILES: return createContourTilesLayer();
             case ROUTES: return createRoutesLayer();
             case ROUTE_TEST: return createRouteTestLayer();
+            case ROUTE_SELECT: return createRouteSelectLayer();
             case MANEUVERS: return createManeuversLayer();
             case ELEMENTS: return createElementsLayer();
             case PEAKS: return createPeaksLayer();
@@ -746,6 +753,114 @@ public class DemoMap {
             return null;
         }
         return new VectorTileLayer(source, decoder);
+    }
+
+    /**
+     * The SELECTION bench: many routes as GeoJSON vector tiles, one of them selected through a
+     * style parameter compared with the feature's own osmid - what every real route style does.
+     *
+     * Tap a route to select it (or let it cycle with routeSelectCycle). What to watch in logcat is
+     * not the paint but the reload: the tile load listener fires again for every visible tile when
+     * the change forced the tiles to be decoded again, and stays quiet when it did not.
+     */
+    private Layer createRouteSelectLayer() {
+        MBVectorTileDecoder decoder = DemoStyles.createRouteSelectDecoder();
+        if (decoder == null) {
+            return null; // already logged
+        }
+        GeoJSONVectorTileDataSource source = new GeoJSONVectorTileDataSource(0, 24);
+        try {
+            int layerIndex = source.createLayer("routes");
+            source.setLayerGeoJSONString(layerIndex, buildRouteSelectGeoJSON());
+        } catch (IOException e) {
+            Log.w(TAG, "route selection geojson rejected: " + e.getMessage());
+            return null;
+        }
+        VectorTileLayer layer = new VectorTileLayer(source, decoder);
+        layer.setVectorTileEventListener(new VectorTileEventListener() {
+            @Override
+            public boolean onVectorTileClicked(VectorTileClickInfo clickInfo) {
+                Variant properties = clickInfo.getFeature().getProperties();
+                selectRoute((long) properties.getObjectElement("osmid").getLong());
+                return true;
+            }
+        });
+        routeSelectDecoder = decoder;
+        selectRoute(routeSelectId); // the parameter has to carry the current selection into a fresh decoder
+        startRouteSelectCycle();
+        return layer;
+    }
+
+    /** Selects one route by its osmid, which is all a real app does to change the selection. */
+    public void selectRoute(long osmid) {
+        routeSelectId = osmid;
+        if (routeSelectDecoder == null) {
+            return;
+        }
+        long start = System.nanoTime();
+        routeSelectDecoder.setStyleParameter(DemoConfig.ROUTE_SELECT_PARAMETER, Long.toString(osmid));
+        Log.i(TAG, "route " + osmid + " selected in " + ((System.nanoTime() - start) / 1000000.0) + " ms (mode "
+                + DemoConfig.ROUTE_SELECT_MODE + ")");
+    }
+
+    public void selectNextRoute() {
+        selectRoute(routeSelectId % Math.max(1, DemoConfig.ROUTE_SELECT_COUNT) + 1);
+    }
+
+    private void startRouteSelectCycle() {
+        if (routeSelectCycle != null) {
+            mapView.removeCallbacks(routeSelectCycle);
+            routeSelectCycle = null;
+        }
+        if (DemoConfig.ROUTE_SELECT_CYCLE_MS <= 0) {
+            return;
+        }
+        routeSelectCycle = new Runnable() {
+            public void run() {
+                if (!DemoConfig.LAYER_ROUTE_SELECT || DemoConfig.ROUTE_SELECT_CYCLE_MS <= 0) {
+                    return;
+                }
+                selectNextRoute();
+                mapView.postDelayed(this, DemoConfig.ROUTE_SELECT_CYCLE_MS);
+            }
+        };
+        mapView.postDelayed(routeSelectCycle, DemoConfig.ROUTE_SELECT_CYCLE_MS);
+    }
+
+    /**
+     * A fan of routes around the start position, each one a feature with its own 'osmid'. They
+     * overlap near the centre so a tap has something to disambiguate, and every route carries the
+     * same vertex count - the geometry a selection change would have to repoint.
+     */
+    private String buildRouteSelectGeoJSON() {
+        int count = Math.max(1, DemoConfig.ROUTE_SELECT_COUNT);
+        int vertices = Math.max(2, DemoConfig.ROUTE_SELECT_VERTICES);
+        double span = DemoConfig.ROUTE_SELECT_SPAN;
+        StringBuilder json = new StringBuilder("{\"type\":\"FeatureCollection\",\"features\":[");
+        for (int route = 0; route < count; route++) {
+            double angle = Math.PI * route / count;
+            double dx = Math.cos(angle) * span, dy = Math.sin(angle) * span;
+            if (route > 0) {
+                json.append(',');
+            }
+            json.append("{\"type\":\"Feature\",\"properties\":{\"osmid\":").append(route + 1)
+                .append(",\"name\":\"route ").append(route + 1).append("\"},")
+                .append("\"geometry\":{\"type\":\"LineString\",\"coordinates\":[");
+            for (int i = 0; i < vertices; i++) {
+                double t = (double) i / (vertices - 1) - 0.5;
+                // a gentle wave along the route, so the line has joins to tesselate
+                double wave = Math.sin(t * Math.PI * 6) * span * 0.05;
+                double lon = DemoConfig.START_LON + dx * t * 2 - dy * wave;
+                double lat = DemoConfig.START_LAT + dy * t * 2 + dx * wave;
+                if (i > 0) {
+                    json.append(',');
+                }
+                json.append('[').append(lon).append(',').append(lat).append(']');
+            }
+            json.append("]}}");
+        }
+        json.append("]}");
+        return json.toString();
     }
 
     /**

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoPanel.java
@@ -204,6 +204,7 @@ public final class DemoPanel {
         buildHillshadeSection(context, demo);
         buildContourSection(context, demo);
         buildRouteTestSection(context, demo);
+        buildRouteSelectSection(context, demo);
         buildSunSection(context, demo);
         buildCelestialSection(context, demo);
         buildSkyFogSection(context, demo);
@@ -615,6 +616,24 @@ public final class DemoPanel {
         demo.applyContourConfig();
         // Generated tiles are cached by the layers, so drop them to see the new parameters.
         demo.contourSource().notifyTilesChanged(true);
+    }
+
+    /** The selection bench: pick a route, or let it cycle, and watch what the change costs. */
+    private static void buildRouteSelectSection(Context context, final DemoMap demo) {
+        header(context, "ROUTE SELECT");
+        button(context, "select next route", new Action() {
+            public void run() { demo.selectNextRoute(); }
+        });
+        final String[] modes = { "value", "filter" };
+        choice(context, "mode", modes, indexOf(modes, DemoConfig.ROUTE_SELECT_MODE), new IntSetting() {
+            public void set(int index) { DemoConfig.ROUTE_SELECT_MODE = modes[index]; demo.rebuildLayers(); }
+        });
+        slider(context, "routes", 2, 40, DemoConfig.ROUTE_SELECT_COUNT, false, new FloatSetting() {
+            public void set(float value) { DemoConfig.ROUTE_SELECT_COUNT = (int) value; demo.rebuildLayers(); }
+        });
+        slider(context, "cycle ms", 0, 5000, DemoConfig.ROUTE_SELECT_CYCLE_MS, false, new FloatSetting() {
+            public void set(float value) { DemoConfig.ROUTE_SELECT_CYCLE_MS = (int) value; demo.rebuildLayers(); }
+        });
     }
 
     /** Join / cap / opacity of the route test layer - the line tesselation bench. */

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStyles.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStyles.java
@@ -622,7 +622,11 @@ public final class DemoStyles {
             "  \"styles\": [\"style.mss\"],",
             "  \"layers\": [\"routes\"],",
             "  \"nutiparameters\": {",
-            "    \"" + DemoConfig.ROUTE_SELECT_PARAMETER + "\": { \"default\": \"\" }",
+            // 'selects' opts this parameter into the repaint path: the decoder folds the comparison
+            // both ways so a selection change rewrites style bytes instead of decoding the tiles.
+            // In 'filter' mode the same parameter also gates a rule, so it is refused (with a
+            // warning saying why) and the bench measures the decode it always did.
+            "    \"" + DemoConfig.ROUTE_SELECT_PARAMETER + "\": { \"default\": \"\", \"selects\": true }",
             "  }",
             "}");
         boolean filterMode = "filter".equalsIgnoreCase(DemoConfig.ROUTE_SELECT_MODE);

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStyles.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoStyles.java
@@ -603,6 +603,70 @@ public final class DemoStyles {
     }
 
     /**
+     * Decoder of the ROUTE SELECTION bench (DemoConfig.LAYER_ROUTE_SELECT). It needs a project,
+     * not a bare CartoCSS string, because 'nuti::selected_id' has to be DECLARED before a rule can
+     * read it - the same in-memory zip trick as {@link #createNutiDecoder()}.
+     *
+     * The style is written the way a real route style writes selection, so what the bench measures
+     * is the real shape:
+     *
+     *     @is_selected: [nuti::selected_id] = [osmid] + '';
+     *
+     * In 'value' mode the parameter only reaches line-color and line-width - the appearance. In
+     * 'filter' mode it also gates a casing attachment, which is what decides whether that geometry
+     * exists at all; that is the half no repaint can answer.
+     */
+    public static MBVectorTileDecoder createRouteSelectDecoder() {
+        String projectJson = String.join("\n",
+            "{",
+            "  \"styles\": [\"style.mss\"],",
+            "  \"layers\": [\"routes\"],",
+            "  \"nutiparameters\": {",
+            "    \"" + DemoConfig.ROUTE_SELECT_PARAMETER + "\": { \"default\": \"\" }",
+            "  }",
+            "}");
+        boolean filterMode = "filter".equalsIgnoreCase(DemoConfig.ROUTE_SELECT_MODE);
+        StringBuilder mss = new StringBuilder();
+        mss.append("@osm_id: [osmid] + '';\n");
+        mss.append("@is_selected: [nuti::").append(DemoConfig.ROUTE_SELECT_PARAMETER).append("] = @osm_id;\n");
+        mss.append("#routes {\n");
+        if (filterMode) {
+            // The structural half: the casing only EXISTS for the selected feature
+            // spelled out, not @is_selected: a 'when' filter takes the comparison itself, which is
+            // also how a real route style writes it
+            mss.append("  when ([nuti::").append(DemoConfig.ROUTE_SELECT_PARAMETER).append("] = [osmid] + '') {\n")
+               .append("    casing/line-color: #ffffff;\n")
+               .append("    casing/line-width: ").append(DemoConfig.ROUTE_SELECT_WIDTH + DemoConfig.ROUTE_SELECT_WIDTH_BUMP + 4f).append(";\n")
+               .append("    casing/line-join: round;\n")
+               .append("    casing/line-cap: round;\n")
+               .append("  }\n");
+        }
+        mss.append("  line-join: round;\n")
+           .append("  line-cap: round;\n")
+           .append("  line-color: @is_selected ? ").append(DemoConfig.ROUTE_SELECT_SELECTED_COLOR)
+           .append(" : ").append(DemoConfig.ROUTE_SELECT_COLOR).append(";\n")
+           .append("  line-width: ").append(DemoConfig.ROUTE_SELECT_WIDTH)
+           .append(" + (@is_selected ? ").append(DemoConfig.ROUTE_SELECT_WIDTH_BUMP).append(" : 0);\n")
+           .append("}");
+
+        try {
+            java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+            java.util.zip.ZipOutputStream zos = new java.util.zip.ZipOutputStream(bos);
+            String[][] entries = new String[][] { { "project.json", projectJson }, { "style.mss", mss.toString() } };
+            for (String[] entry : entries) {
+                zos.putNextEntry(new java.util.zip.ZipEntry(entry[0]));
+                zos.write(entry[1].getBytes("UTF-8"));
+                zos.closeEntry();
+            }
+            zos.close();
+            return new MBVectorTileDecoder(new CompiledStyleSet(new ZippedAssetPackage(new BinaryData(bos.toByteArray()))));
+        } catch (Exception e) {
+            Log.e(TAG, "could not build the route selection style", e);
+            return null;
+        }
+    }
+
+    /**
      * Style of the ROUTE TEST layer (DemoConfig.LAYER_ROUTE_TEST): a navigation route drawn the way
      * a turn-by-turn app draws it - a dark casing attachment first (CartoCSS renders attachments in
      * declaration order, so it lands UNDER) and the coloured fill over it.


### PR DESCRIPTION
## Summary

Started as a bench for **what a selection change costs**; it now also removes that cost for the appearance half.

**The bench** (`--es routeSelect true`): many routes as GeoJSON vector tiles, one selected through a style parameter compared with the feature's own `osmid` — the shape `assets/style/shared/route.mss` already uses. Two modes, because the two halves of a real selection style behave differently:

- **`value`** — the parameter feeds only `line-color` and `line-width`, i.e. the *appearance*.
- **`filter`** — adds the `when (...)::selected` casing, which decides whether that geometry *exists at all*.

It measured 6 decoded tiles per selection change in both, and 2.2–3.6 ms of main thread — for what is, in `value` mode, a colour and a width.

**The fix.** A style now opts in by declaring the parameter as selecting, and the decoder folds the comparison both ways at decode so the tiles carry both appearances as two style slots. Setting the parameter publishes a hash and asks for a redraw; no tile is decoded.

```json
"nutiparameters": { "selected_id": { "default": "", "selects": true } }
```

- `resolveSelectionParameter` runs once per **compiled** map, before it enters the shared cache, and warns naming the reason when a declared parameter does not qualify (`it is read by a rule filter, which decides whether the geometry exists at all`). A style that declares nothing is not inspected at all.
- `_selectionState` is the hash of the value, shared with every tile this decoder built and read on the render thread. `areParametersLive` becomes `areParametersRepaintable`: live parameters and the selecting one both take the `notifyDecoderRefreshed` path.
- `docs/style-parameters.md` gains the selection section and the rules; `docs/rendering/10-performance.md` replaces its "what this does not solve" note with the mechanism and the numbers.

## Measured

Crosscall HLTE556N and the emulator, 12 routes at z12.5 tilt 90, temporary `decodeTile` probe (**not** in this diff):

| mode | decodes per selection | `setStyleParameter` (device) |
|---|---|---|
| `value` | 6 → **0** | 2.2–3.6 ms → **0.32–0.81 ms** |
| `filter` | 6 → 6 (unchanged) | unchanged |

`filter` mode cannot be helped and is the negative control: no repaint creates geometry that was never built. A real route style only wins if its `::selected` attachment becomes a width and a colour that fold, rather than a rule — [`docs/style-parameters.md`](docs/style-parameters.md) shows that rewrite.

## How to run

```sh
adb shell am start -n com.akylas.cartotest/.MainActivity --es ui false \
  --es base false --es map false --es hillshade false --es satellite false --es drape false \
  --es routeSelect true --es zoom 12.5 --es tilt 90 \
  --es routeSelectMode value --es routeSelectCycle 2500
```

Tap a route to select it, or use the **ROUTE SELECT** panel section (select next / mode / routes / cycle ms). Off by default. `tilt 90` is top-down in this SDK.

## Notes for a reviewer

- The bench style is an **in-memory project** (`project.json` + `style.mss`, zipped), not a bare `CartoCSSStyleSet`: `nuti::selected_id` has to be *declared* before a rule can read it, and `selects` is declared alongside it.
- `when (@is_selected)` is rejected — a `when` filter needs the comparison written inline. That is also why the real route style spells it out.
- The routes are generated in Java around the start position, so there is no new asset.
- Demo-app edits stay additive: new defaults in `DemoConfig`, controls in `DemoPanel`.
- Base-map regression checked on both device and emulator: renders normally, no warning, rules never walked.

## Depends on

farfromrefug/mobile-carto-libs#36 — carries the `vt` + `mapnikvt` half. It merges **first**; the pointer bump here is then rebased onto the merged commit rather than the branch commit.