### PR TITLE
fix(terrain): keep the map movable with the camera against the ground

### DIFF
--- a/all/modules/graphics/ViewState.i
+++ b/all/modules/graphics/ViewState.i
@@ -72,6 +72,7 @@
 %ignore carto::ViewState::getRTEModelviewProjectionMat;
 %ignore carto::ViewState::getRTESkyProjectionMat;
 %ignore carto::ViewState::setScreenSize;
+%ignore carto::ViewState::setTerrainCameraReference; // renderer plumbing, published every frame
 %ignore carto::ViewState::clampZoom;
 %ignore carto::ViewState::clampFocusPos;
 %ignore carto::ViewState::getFocusPosNormal;

--- a/all/native/graphics/ViewState.cpp
+++ b/all/native/graphics/ViewState.cpp
@@ -82,7 +82,11 @@ namespace carto {
         }
     }
 
-    void ViewState::setTerrainMinCameraZ(double minCameraZ) {
+    void ViewState::setTerrainCameraReference(double terrainZ, double minCameraZ) {
+        if (terrainZ != _terrainCameraZ) {
+            _terrainCameraZ = terrainZ;
+            _cameraChanged = true; // the near plane is built on it
+        }
         _terrainMinCameraZ = minCameraZ;
     }
 
@@ -801,7 +805,19 @@ namespace carto {
         // The FAR plane is theirs too - see calculateViewDistance, which is also what the tile
         // walk stops at, so the view and the tiles fetched for it always agree.
         double viewDistance = calculateViewDistance(options);
-        float terrainNear = static_cast<float>(calculateCameraDistance() / 50.0);
+        // Tangram's near is a fiftieth of the camera's distance to what it looks at, and their
+        // camera is held a distance away from the TERRAIN (view.cpp: the depth at the screen
+        // centre against minCameraDist). Ours is held a clearance above the terrain UNDER it, so at
+        // a low tilt the focus is kilometres away while the ground is a couple of hundred metres
+        // below - a fiftieth of the focus distance then parks the near plane in front of the ground
+        // at the bottom of the screen and cuts it away. Take the smaller of the two distances: over
+        // flat ground with the focus close they are the same, and it is only the close-to-terrain
+        // case that spends depth precision.
+        double cameraDistance = calculateCameraDistance();
+        if (_terrainCameraZ != 0 && _cameraPos(2) > _terrainCameraZ) {
+            cameraDistance = std::min(cameraDistance, _cameraPos(2) - _terrainCameraZ);
+        }
+        float terrainNear = static_cast<float>(cameraDistance / 50.0);
         if (viewDistance > 0) {
             float viewDistanceFactor = 1.0f;
             bool absoluteViewDistance = false;

--- a/all/native/graphics/ViewState.h
+++ b/all/native/graphics/ViewState.h
@@ -208,12 +208,14 @@ namespace carto {
         void setTerrainHeightRange(float minZ, float maxZ);
 
         /**
-         * Sets the minimum camera height (in internal units) imposed by the terrain
-         * clearance, or 0 to disable the terrain zoom bound. Published once per frame
-         * by the renderer from the elevation under the camera.
-         * @param minCameraZ The minimum camera height, 0 to disable.
+         * Sets the terrain reference under the camera (in internal units), published once
+         * per frame by the renderer: the ground height there, and the minimum camera height
+         * the clearance imposes. The height bounds the near plane (the ground cannot be
+         * further than that below the camera), the minimum drives the terrain zoom bound.
+         * @param terrainZ The terrain height under the camera.
+         * @param minCameraZ The minimum camera height, 0 to disable the zoom bound.
          */
-        void setTerrainMinCameraZ(double minCameraZ);
+        void setTerrainCameraReference(double terrainZ, double minCameraZ);
         /**
          * Returns the maximum zoom allowed by the terrain clearance, or infinity when
          * no terrain bound is active. Evaluated against the CURRENT camera state, so it
@@ -482,6 +484,7 @@ namespace carto {
         float _terrainHeightMin = 0.0f;
         float _terrainHeightMax = 0.0f;
         double _terrainMinCameraZ = 0.0; // 0 = no terrain zoom bound
+        double _terrainCameraZ = 0.0; // terrain height under the camera, 0 = unknown
     
         int _fovY;
         float _halfFOVY;

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1990,7 +1990,7 @@ namespace carto {
                     }
 
                     // Camera terrain-following. The clearance is expressed as a BOUND on the
-                    // zoom (ViewState::setTerrainMinCameraZ -> getTerrainMaxZoom), which every
+                    // zoom (ViewState::setTerrainCameraReference -> getTerrainMaxZoom), which every
                     // zoom path clamps against, rather than as a corrective zoom-out issued
                     // after the camera has already broken through. A corrective event fights
                     // whatever is driving the camera down - the pinch gesture, the double-tap
@@ -2013,7 +2013,7 @@ namespace carto {
                         double minCameraZ = terrainZ + cameraClearance * elevationManager->getDisplayScale(cameraPos(1));
                         {
                             std::lock_guard<std::recursive_mutex> lock(_mutex);
-                            _viewState.setTerrainMinCameraZ(minCameraZ);
+                            _viewState.setTerrainCameraReference(terrainZ, minCameraZ);
                         }
                         // The correction has to LAND on the shell, and it has to have a dead band.
                         // Zooming out scales the camera-to-focus vector, so the camera height it
@@ -2046,7 +2046,7 @@ namespace carto {
                         }
                     } else {
                         std::lock_guard<std::recursive_mutex> lock(_mutex);
-                        _viewState.setTerrainMinCameraZ(0);
+                        _viewState.setTerrainCameraReference(0, 0);
                     }
                 }
             }
@@ -2058,7 +2058,7 @@ namespace carto {
                 }
             }
             std::lock_guard<std::recursive_mutex> lock(_mutex);
-            _viewState.setTerrainMinCameraZ(0); // release the terrain zoom bound
+            _viewState.setTerrainCameraReference(0, 0); // release the terrain zoom bound
         }
 
         // Cross-layer terrain draping. Every drapeable tile layer bakes into ONE texture per

--- a/all/native/renderers/cameraevents/CameraZoomEvent.cpp
+++ b/all/native/renderers/cameraevents/CameraZoomEvent.cpp
@@ -99,8 +99,14 @@ namespace carto {
         // Clamping the REQUESTED zoom makes the gesture come to rest against the terrain;
         // letting it through and correcting the camera afterwards makes the two fight
         // every frame, which is what made zooming jump back and forth.
+        // The terrain bound STOPS a zoom in; it never drives a zoom OUT from here. Clamping a
+        // zoom-in request to below the current zoom - which happens whenever the camera is already
+        // inside the clearance shell - scales the map about the PIVOT, and with the pivot under the
+        // fingers that throws the map sideways: the pinch that jumps somewhere else. Getting back
+        // onto the shell is MapRenderer's per-frame correction, which zooms about the focus and so
+        // moves nothing sideways.
         MapRange zoomRange = options.getZoomRange();
-        float maxZoom = std::min(zoomRange.getMax(), viewState.getTerrainMaxZoom());
+        float maxZoom = std::min(zoomRange.getMax(), std::max(viewState.getTerrainMaxZoom(), viewState.getZoom()));
         float zoom = GeneralUtils::Clamp(viewState.getZoom() + _zoomDelta, viewState.getMinZoom(), maxZoom);
         double scale = std::pow(2.0f, viewState.getZoom() - zoom);
         cglib::mat4x4<double> shiftTransform = projectionSurface->calculateTranslateMatrix(focusPos, targetPos, 1.0 - scale);

--- a/all/native/ui/TouchHandler.cpp
+++ b/all/native/ui/TouchHandler.cpp
@@ -277,20 +277,17 @@ namespace carto {
             _mapRenderer->getAnimationHandler().stopTilt();
             _mapRenderer->getAnimationHandler().stopZoom();
             
-            if (_options->getPivotMode() != PivotMode::PIVOT_MODE_TOUCHPOINT || isValidScreenPosition(screenPos, viewState)) {
-                updateGestureAnchorHeight(screenPos, viewState);
-                MapPos targetPos = (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT ? mapScreenPosition(screenPos, viewState) : projectionSurface->calculateMapPos(viewState.getFocusPos()));
+            updateGestureAnchorHeight(screenPos, viewState);
 
-                CameraZoomEvent cameraZoomTargetEvent;
-                cameraZoomTargetEvent.setZoomDelta(delta * WHEEL_TICK_TO_ZOOM_DELTA);
-                cameraZoomTargetEvent.setTargetPos(targetPos);
-                _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, 0, true);
+            CameraZoomEvent cameraZoomTargetEvent;
+            cameraZoomTargetEvent.setZoomDelta(delta * WHEEL_TICK_TO_ZOOM_DELTA);
+            cameraZoomTargetEvent.setTargetPos(calculatePivotPos(screenPos, viewState));
+            _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, 0, true);
 
-                DirectorPtr<MapEventListener> mapEventListener = _mapEventListener;
+            DirectorPtr<MapEventListener> mapEventListener = _mapEventListener;
 
-                if (mapEventListener) {
-                    mapEventListener->onMapInteraction(std::make_shared<MapInteractionInfo>(false, true, false, false));
-                }
+            if (mapEventListener) {
+                mapEventListener->onMapInteraction(std::make_shared<MapInteractionInfo>(false, true, false, false));
             }
         }
     }
@@ -354,76 +351,103 @@ namespace carto {
     
     void TouchHandler::singlePointerPan(const ScreenPos& screenPos, const ViewState& viewState) {
         if (_options->isUserInput()) {
-            std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
-            if (!projectionSurface) {
-                return;
-            }
-            
             _mapRenderer->getAnimationHandler().stopPan();
             _mapRenderer->getAnimationHandler().stopRotation();
             _mapRenderer->getAnimationHandler().stopTilt();
             _mapRenderer->getAnimationHandler().stopZoom();
-            
-            double panScale = _panScale.load();
-            if (_options->getPanningSpeedMode() != PanningSpeedMode::PANNING_SPEED_MODE_MAP && panScale > 0) {
-                // The pan travels the SCREEN delta at the scale the gesture started with. Grabbing
-                // the world exactly - the other mode - re-derives that scale from wherever the
-                // finger is now, so a drag that starts near the camera and travels up the screen
-                // speeds up as it goes, which is not something the hand asked for.
-                float dx = screenPos.getX() - _prevScreenPos1.getX();
-                float dy = screenPos.getY() - _prevScreenPos1.getY();
-                _prevScreenPos1 = screenPos;
-                if (dx == 0 && dy == 0) {
-                    return;
-                }
 
-                cglib::vec3<double> focusPos = viewState.getFocusPos();
-                MapPos focusMapPos = projectionSurface->calculateMapPos(focusPos);
-                cglib::vec3<double> normal = projectionSurface->calculateNormal(focusMapPos);
-                // NOT '== 0': looking straight down, this cross product is meant to collapse and
-                // hand over to the up vector - but a tilt REACHED BY GESTURE is vertical only to
-                // within rounding, so it comes out at ~1e-16 instead of 0, the hand-over is missed,
-                // and unit() then turns pure floating point noise into a unit vector pointing
-                // anywhere. That is a pan that goes sideways when the finger goes up. Setting the
-                // tilt to 90 outright happens to build the camera exactly vertical, which is why
-                // only the gesture shows it.
-                cglib::vec3<double> right = cglib::vector_product(viewState.calculateViewDir(), normal);
-                if (cglib::length(right) < VIEW_AXIS_EPSILON) {
-                    right = cglib::vector_product(viewState.getUpVec(), normal); // straight up or down
-                }
-                if (cglib::length(right) < VIEW_AXIS_EPSILON) {
-                    return;
-                }
-                right = cglib::unit(right);
-                cglib::vec3<double> forward = cglib::vector_product(normal, right);
-                if (cglib::length(forward) < VIEW_AXIS_EPSILON) {
-                    return;
-                }
-                forward = cglib::unit(forward);
-
-                // Dragging the world down brings what was beyond the top edge into view, i.e. the
-                // camera goes forward; dragging it right takes the camera left.
-                cglib::vec3<double> offset = forward * (dy * panScale) + right * (-dx * panScale);
-                CameraPanEvent cameraEvent;
-                cameraEvent.setPosDelta(std::make_pair(focusMapPos, projectionSurface->calculateMapPos(focusPos + offset)));
-                _cameraEvents |= CAMERA_PAN;
-                _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
-                return;
-            }
-
-            if (isValidScreenPosition(screenPos, viewState) && isValidScreenPosition(_prevScreenPos1, viewState)) {
-                MapPos currentPos = mapScreenPosition(screenPos, viewState);
-                MapPos prevPos = mapScreenPosition(_prevScreenPos1, viewState);
-
-                CameraPanEvent cameraEvent;
-                cameraEvent.setPosDelta(std::make_pair(currentPos, prevPos));
-                _cameraEvents |= CAMERA_PAN;
-                _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
-            }
+            panBetween(_prevScreenPos1, screenPos, viewState);
         }
         _prevScreenPos1 = screenPos;
     }
-    
+
+    /**
+     * Move the map so that what was under prevScreenPos ends up under screenPos - the one pan
+     * both the one-finger drag and the two-finger gesture go through, so they cannot disagree
+     * about the speed mode or about what a grazing ray is allowed to do.
+     */
+    void TouchHandler::panBetween(const ScreenPos& prevScreenPos, const ScreenPos& screenPos, const ViewState& viewState) {
+        std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
+        if (!projectionSurface) {
+            return;
+        }
+
+        float dx = screenPos.getX() - prevScreenPos.getX();
+        float dy = screenPos.getY() - prevScreenPos.getY();
+        if (dx == 0 && dy == 0) {
+            return;
+        }
+
+        double panScale = _panScale.load();
+        if (_options->getPanningSpeedMode() != PanningSpeedMode::PANNING_SPEED_MODE_MAP && panScale > 0) {
+            // The pan travels the SCREEN delta at the scale the gesture started with. Grabbing
+            // the world exactly - the other mode - re-derives that scale from wherever the
+            // finger is now, so a drag that starts near the camera and travels up the screen
+            // speeds up as it goes, which is not something the hand asked for.
+            cglib::vec3<double> focusPos = viewState.getFocusPos();
+            MapPos focusMapPos = projectionSurface->calculateMapPos(focusPos);
+            cglib::vec3<double> normal = projectionSurface->calculateNormal(focusMapPos);
+            // NOT '== 0': looking straight down, this cross product is meant to collapse and
+            // hand over to the up vector - but a tilt REACHED BY GESTURE is vertical only to
+            // within rounding, so it comes out at ~1e-16 instead of 0, the hand-over is missed,
+            // and unit() then turns pure floating point noise into a unit vector pointing
+            // anywhere. That is a pan that goes sideways when the finger goes up. Setting the
+            // tilt to 90 outright happens to build the camera exactly vertical, which is why
+            // only the gesture shows it.
+            cglib::vec3<double> right = cglib::vector_product(viewState.calculateViewDir(), normal);
+            if (cglib::length(right) < VIEW_AXIS_EPSILON) {
+                right = cglib::vector_product(viewState.getUpVec(), normal); // straight up or down
+            }
+            if (cglib::length(right) < VIEW_AXIS_EPSILON) {
+                return;
+            }
+            right = cglib::unit(right);
+            cglib::vec3<double> forward = cglib::vector_product(normal, right);
+            if (cglib::length(forward) < VIEW_AXIS_EPSILON) {
+                return;
+            }
+            forward = cglib::unit(forward);
+
+            // Dragging the world down brings what was beyond the top edge into view, i.e. the
+            // camera goes forward; dragging it right takes the camera left.
+            cglib::vec3<double> offset = forward * (dy * panScale) + right * (-dx * panScale);
+            CameraPanEvent cameraEvent;
+            cameraEvent.setPosDelta(std::make_pair(focusMapPos, projectionSurface->calculateMapPos(focusPos + offset)));
+            _cameraEvents |= CAMERA_PAN;
+            _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
+            return;
+        }
+
+        if (!isValidScreenPosition(screenPos, viewState) || !isValidScreenPosition(prevScreenPos, viewState)) {
+            return;
+        }
+        MapPos currentPos = mapScreenPosition(screenPos, viewState);
+        MapPos prevPos = mapScreenPosition(prevScreenPos, viewState);
+
+        if (viewState.getTilt() < PAN_CLAMP_MAX_TILT) {
+            // Tangram's guard (inputHandler.cpp getTranslation): near the horizon the two rays run
+            // almost parallel to the ground and their hit points fly apart, so a finger travel of a
+            // few pixels comes out as kilometres. Cap the travel at what those pixels are worth at
+            // the map scale - the pan stops grabbing exactly, which is the point.
+            cglib::vec3<double> pos0 = projectionSurface->calculatePosition(currentPos);
+            cglib::vec3<double> pos1 = projectionSurface->calculatePosition(prevPos);
+            double travel = projectionSurface->calculateDistance(pos0, pos1);
+            // What a pixel is worth at the focus - their pixelsPerMeter, which is the map scale
+            // and knows nothing about where on the screen the finger is.
+            double unitsPerPixel = 2.0 * viewState.calculateCameraDistance() * viewState.getTanHalfFOVY() / std::max(1, viewState.getHeight());
+            double limit = std::sqrt(static_cast<double>(dx) * dx + static_cast<double>(dy) * dy) * unitsPerPixel;
+            if (limit > 0 && travel > limit) {
+                cglib::mat4x4<double> transform = projectionSurface->calculateTranslateMatrix(pos0, pos1, limit / travel);
+                prevPos = projectionSurface->calculateMapPos(cglib::transform_point(pos0, transform));
+            }
+        }
+
+        CameraPanEvent cameraEvent;
+        cameraEvent.setPosDelta(std::make_pair(currentPos, prevPos));
+        _cameraEvents |= CAMERA_PAN;
+        _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
+    }
+
     void TouchHandler::singlePointerLook(const ScreenPos& screenPos, const ViewState& viewState) {
         if (_options->isUserInput()) {
             _mapRenderer->getAnimationHandler().stopPan();
@@ -475,18 +499,19 @@ namespace carto {
             _mapRenderer->getAnimationHandler().stopTilt();
             _mapRenderer->getAnimationHandler().stopZoom();
             
-            if (isValidScreenPosition(screenPos, viewState) && isValidScreenPosition(_prevScreenPos1, viewState)) {
-                float dpi = _options->getDPI();
-                cglib::vec2<float> tempSwipe1(screenPos.getX() - _prevScreenPos1.getX(), screenPos.getY() - _prevScreenPos1.getY());
-                _swipe1 += tempSwipe1 * (1.0f / dpi);
+            // No ground hit required: this zoom is a vertical drag about the FOCUS, and gating it
+            // on one killed the gesture wherever the fingers' rays miss - a low camera over
+            // terrain, where the ground under half the screen is past the far plane.
+            float dpi = _options->getDPI();
+            cglib::vec2<float> tempSwipe1(screenPos.getX() - _prevScreenPos1.getX(), screenPos.getY() - _prevScreenPos1.getY());
+            _swipe1 += tempSwipe1 * (1.0f / dpi);
 
-                float delta = INCHES_TO_ZOOM_DELTA * (screenPos.getY() - _prevScreenPos1.getY()) / _options->getDPI();
+            float delta = INCHES_TO_ZOOM_DELTA * (screenPos.getY() - _prevScreenPos1.getY()) / dpi;
 
-                CameraZoomEvent cameraEvent;
-                cameraEvent.setZoomDelta(delta);
-                _cameraEvents |= CAMERA_ZOOM;
-                _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
-            }
+            CameraZoomEvent cameraEvent;
+            cameraEvent.setZoomDelta(delta);
+            _cameraEvents |= CAMERA_ZOOM;
+            _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
         }
         _prevScreenPos1 = screenPos;
     }
@@ -668,50 +693,47 @@ namespace carto {
             _mapRenderer->getAnimationHandler().stopTilt();
             _mapRenderer->getAnimationHandler().stopZoom();
 
-            if (isValidScreenPosition(screenPos1, viewState) && isValidScreenPosition(_prevScreenPos1, viewState)
-            &&  isValidScreenPosition(screenPos2, viewState) && isValidScreenPosition(_prevScreenPos2, viewState)) {
-                cglib::vec3<double> currentPos1 = projectionSurface->calculatePosition(mapScreenPosition(screenPos1, viewState));
-                cglib::vec3<double> currentPos2 = projectionSurface->calculatePosition(mapScreenPosition(screenPos2, viewState));
-                cglib::vec3<double> currentVec = currentPos2 - currentPos1;
-                double currentDist = projectionSurface->calculateDistance(currentPos1, currentPos2);
-                cglib::mat4x4<double> currentTranslateTransform = projectionSurface->calculateTranslateMatrix(currentPos1, currentPos2, 0.5f);
-                MapPos currentMiddlePos = projectionSurface->calculateMapPos(cglib::transform_point(currentPos1, currentTranslateTransform));
+            // The scale and the angle are what the FINGERS did, taken from the SCREEN - which is
+            // where a pinch and a two-finger turn happen, and how tangram takes them (inputHandler
+            // handlePinchGesture/handleRotateGesture, fed by the platform's gesture detector).
+            // Deriving them from where the two rays meet the ground instead - what this did - hands
+            // a grazing ray straight to the camera: a low camera over terrain puts one finger's hit
+            // kilometres away, so a pinch of a few pixels comes out as a wild zoom or spin, and
+            // where the ray missed the ground altogether the whole gesture was dropped and the map
+            // could not be zoomed at all.
+            cglib::vec2<float> currentVec(screenPos2.getX() - screenPos1.getX(), screenPos2.getY() - screenPos1.getY());
+            cglib::vec2<float> prevVec(_prevScreenPos2.getX() - _prevScreenPos1.getX(), _prevScreenPos2.getY() - _prevScreenPos1.getY());
+            double currentDist = cglib::length(currentVec);
+            double prevDist = cglib::length(prevVec);
 
-                cglib::vec3<double> prevPos1 = projectionSurface->calculatePosition(mapScreenPosition(_prevScreenPos1, viewState));
-                cglib::vec3<double> prevPos2 = projectionSurface->calculatePosition(mapScreenPosition(_prevScreenPos2, viewState));
-                cglib::vec3<double> prevVec = prevPos2 - prevPos1;
-                double prevDist = projectionSurface->calculateDistance(prevPos1, prevPos2);
-                cglib::mat4x4<double> prevTranslateTransform = projectionSurface->calculateTranslateMatrix(prevPos1, prevPos2, 0.5f);
-                MapPos prevMiddlePos = projectionSurface->calculateMapPos(cglib::transform_point(prevPos1, prevTranslateTransform));
+            ScreenPos currentMiddlePos((screenPos1.getX() + screenPos2.getX()) * 0.5f, (screenPos1.getY() + screenPos2.getY()) * 0.5f);
+            ScreenPos prevMiddlePos((_prevScreenPos1.getX() + _prevScreenPos2.getX()) * 0.5f, (_prevScreenPos1.getY() + _prevScreenPos2.getY()) * 0.5f);
 
-                MapPos pivotPos = (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT ? currentMiddlePos : projectionSurface->calculateMapPos(viewState.getFocusPos()));
+            MapPos pivotPos = calculatePivotPos(currentMiddlePos, viewState);
 
-                if (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT) {
-                    CameraPanEvent cameraPanEvent;
-                    cameraPanEvent.setPosDelta(std::make_pair(currentMiddlePos, prevMiddlePos));
-                    _cameraEvents |= CAMERA_PAN;
-                    _mapRenderer->calculateCameraEvent(cameraPanEvent, 0, true);
-                }
-            
-                if (scale && prevDist > 0 && currentDist > 0) {
-                    float ratio = static_cast<float>(prevDist / currentDist);
-                    CameraZoomEvent cameraZoomTargetEvent;
-                    cameraZoomTargetEvent.setScale(ratio);
-                    cameraZoomTargetEvent.setTargetPos(pivotPos);
-                    _cameraEvents |= CAMERA_ZOOM;
-                    _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, 0, true);
-                }
-    
-                if (rotate && _options->isRotationGestures() && cglib::norm(prevVec) > 0 && cglib::norm(currentVec) > 0) {
-                    cglib::vec3<double> axis = cglib::vector_product(cglib::unit(currentVec), cglib::unit(prevVec));
-                    float angle = std::asin(std::max(-1.0f, std::min(1.0f, static_cast<float>(cglib::length(axis)))));
-                    float dir = cglib::dot_product(axis, projectionSurface->calculateNormal(pivotPos)) > 0 ? 1 : -1;
-                    CameraRotationEvent cameraRotateTargetEvent;
-                    cameraRotateTargetEvent.setRotationDelta(static_cast<float>(angle * dir * Const::RAD_TO_DEG));
-                    cameraRotateTargetEvent.setTargetPos(pivotPos);
-                    _cameraEvents |= CAMERA_ROTATE;
-                    _mapRenderer->calculateCameraEvent(cameraRotateTargetEvent, 0, true);
-                }
+            if (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT) {
+                panBetween(prevMiddlePos, currentMiddlePos, viewState);
+            }
+
+            if (scale && prevDist > 0 && currentDist > 0) {
+                CameraZoomEvent cameraZoomTargetEvent;
+                cameraZoomTargetEvent.setScale(static_cast<float>(prevDist / currentDist));
+                cameraZoomTargetEvent.setTargetPos(pivotPos);
+                _cameraEvents |= CAMERA_ZOOM;
+                _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, 0, true);
+            }
+
+            if (rotate && _options->isRotationGestures() && prevDist > 0 && currentDist > 0) {
+                // Signed angle from the previous finger vector to the current one. Screen y points
+                // down, which is what turns a clockwise turn of the fingers into a positive map
+                // rotation - the same sign the ground-derived cross product produced.
+                double cross = static_cast<double>(prevVec(0)) * currentVec(1) - static_cast<double>(prevVec(1)) * currentVec(0);
+                double dot = static_cast<double>(prevVec(0)) * currentVec(0) + static_cast<double>(prevVec(1)) * currentVec(1);
+                CameraRotationEvent cameraRotateTargetEvent;
+                cameraRotateTargetEvent.setRotationDelta(static_cast<float>(std::atan2(cross, dot) * Const::RAD_TO_DEG));
+                cameraRotateTargetEvent.setTargetPos(pivotPos);
+                _cameraEvents |= CAMERA_ROTATE;
+                _mapRenderer->calculateCameraEvent(cameraRotateTargetEvent, 0, true);
             }
         }
     
@@ -730,11 +752,10 @@ namespace carto {
         }
 
         updateGestureAnchorHeight(screenPos, viewState);
-        MapPos targetPos = (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT ? mapScreenPosition(screenPos, viewState) : projectionSurface->calculateMapPos(viewState.getFocusPos()));
 
         CameraZoomEvent cameraZoomTargetEvent;
         cameraZoomTargetEvent.setZoomDelta(1.0f);
-        cameraZoomTargetEvent.setTargetPos(targetPos);
+        cameraZoomTargetEvent.setTargetPos(calculatePivotPos(screenPos, viewState));
         _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, ZOOM_GESTURE_ANIMATION_DURATION.count() / 1000.0f, true);
 
         DirectorPtr<MapEventListener> mapEventListener = _mapEventListener;
@@ -840,7 +861,11 @@ namespace carto {
         if (!viewState.getProjectionSurface()) {
             return false;
         }
-        cglib::vec3<double> pos = viewState.screenToWorld(cglib::vec2<float>(screenPos.getX(), screenPos.getY()), 0);
+        // The plane the gesture is actually anchored to (mapScreenPosition uses the same one).
+        // Testing the SEA LEVEL plane instead reported a touch as valid, or as past the far plane,
+        // for a surface no gesture ever uses - in the mountains the two are hundreds of metres and,
+        // at a low tilt, kilometres of ray apart.
+        cglib::vec3<double> pos = viewState.screenToWorld(cglib::vec2<float>(screenPos.getX(), screenPos.getY()), _gestureAnchorHeight.load());
         if (std::isnan(cglib::norm(pos))) {
             return false;
         }
@@ -906,6 +931,19 @@ namespace carto {
     MapPos TouchHandler::mapScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const {
         cglib::vec3<double> pos = viewState.screenToWorld(cglib::vec2<float>(screenPos.getX(), screenPos.getY()), _gestureAnchorHeight.load());
         return viewState.getProjectionSurface()->calculateMapPos(pos);
+    }
+
+    /**
+     * The point a zoom or a rotation turns about: what is under the fingers when the map is
+     * there, the focus otherwise. A missing ground hit must NOT cancel the gesture - that is what
+     * left the map frozen with the camera close to the terrain, where half the screen is sky or
+     * ground past the far plane.
+     */
+    MapPos TouchHandler::calculatePivotPos(const ScreenPos& screenPos, const ViewState& viewState) const {
+        if (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT && isValidScreenPosition(screenPos, viewState)) {
+            return mapScreenPosition(screenPos, viewState);
+        }
+        return viewState.getProjectionSurface()->calculateMapPos(viewState.getFocusPos());
     }
 
     double TouchHandler::calculateTerrainHeight(const ScreenPos& screenPos, const ViewState& viewState) const {
@@ -995,7 +1033,9 @@ namespace carto {
         // two-finger rotation are map gestures, and this control scheme has neither.
         _gestureMode = (_options->getFreeRoamMode() == FreeRoamMode::FREE_ROAM_MODE_FIRST_PERSON ? DUAL_POINTER_MOVE : DUAL_POINTER_GUESS);
         ScreenPos middlePos((screenPos1.getX() + screenPos2.getX()) * 0.5f, (screenPos1.getY() + screenPos2.getY()) * 0.5f);
-        updateGestureAnchorHeight(middlePos, _mapRenderer->getViewState());
+        ViewState viewState = _mapRenderer->getViewState();
+        updateGestureAnchorHeight(middlePos, viewState);
+        updatePanScale(middlePos, viewState); // the two-finger pan goes through the same speed mode
     }
 
     void TouchHandler::registerOnTouchListener(const std::shared_ptr<OnTouchListener>& listener) {
@@ -1069,6 +1109,8 @@ namespace carto {
     // A full turn takes about two swipes across a phone, which is what a look control wants.
 
     const float TouchHandler::INCHES_TO_ZOOM_DELTA = 1.0f;
+
+    const float TouchHandler::PAN_CLAMP_MAX_TILT = 15.0f; // tangram's pitch > 75 degrees
         
     const std::chrono::milliseconds TouchHandler::DUAL_KINETIC_HOLD_DURATION = std::chrono::milliseconds(100);
 

--- a/all/native/ui/TouchHandler.h
+++ b/all/native/ui/TouchHandler.h
@@ -107,6 +107,7 @@ namespace carto {
         float calculateRotatingScalingFactor(const ScreenPos& screenPos1, const ScreenPos& screenPos2) const;
 
         void singlePointerPan(const ScreenPos& screenPos, const ViewState& viewState);
+        void panBetween(const ScreenPos& prevScreenPos, const ScreenPos& screenPos, const ViewState& viewState);
         void singlePointerLook(const ScreenPos& screenPos, const ViewState& viewState);
         double calculatePanScale(const ScreenPos& screenPos, const ViewState& viewState) const;
         void updatePanScale(const ScreenPos& screenPos, const ViewState& viewState);
@@ -121,6 +122,7 @@ namespace carto {
         bool isValidScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const;
         cglib::ray3<double> calculateScreenRay(const ScreenPos& screenPos, const ViewState& viewState) const;
         MapPos mapScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const;
+        MapPos calculatePivotPos(const ScreenPos& screenPos, const ViewState& viewState) const;
         double calculateTerrainHeight(const ScreenPos& screenPos, const ViewState& viewState) const;
         void updateGestureAnchorHeight(const ScreenPos& screenPos, const ViewState& viewState);
 
@@ -155,6 +157,11 @@ namespace carto {
 
         // Determines how finger sliding distance will be converted to zoom delta
         static const float INCHES_TO_ZOOM_DELTA;
+
+        // Below this tilt a grabbed pan is capped at what the finger travel is worth at the
+        // map scale - tangram's guard against a near-horizontal view (inputHandler.cpp
+        // getTranslation, `m_view.getPitch() > 75 degrees`; their pitch is 90 - our tilt).
+        static const float PAN_CLAMP_MAX_TILT;
         
         // Determines how long it takes to cancel kinetic zoom and rotation after one
         // pointer is lifted but the other one is not

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -231,7 +231,7 @@ namespace carto {
         std::string _selectionParameter; // the one that selects a feature, if the style has one
         // Its value, hashed: the tiles read it while they are drawn, so setting the selection is a
         // style-byte rewrite rather than a decode. Shared with every tile this decoder built.
-        std::shared_ptr<std::atomic<std::uint64_t>> _selectionState = std::make_shared<std::atomic<std::uint64_t>>(0);
+        std::shared_ptr<std::atomic<std::uint64_t> > _selectionState = std::make_shared<std::atomic<std::uint64_t> >(0);
         std::shared_ptr<const mvt::Map> _map;
         std::shared_ptr<const mvt::Map::Settings> _mapSettings;
         std::shared_ptr<const mvt::SymbolizerContext> _symbolizerContext;

--- a/docs/rendering/04-terrain.md
+++ b/docs/rendering/04-terrain.md
@@ -151,6 +151,17 @@ floored at 1/16 of an internal unit — gave centimetre near planes next to a sl
 of 10⁴–10⁶, and NDC depth so non-linear that a constant-NDC bias was worth hundreds of metres at
 range. That is the mechanism behind every see-through this project has had.
 
+"Camera height" is the smaller of the distance to the **focus** and the height above the **terrain
+under the camera** (`ViewState::setTerrainCameraReference`, published every frame by the renderer
+next to the clearance). Tangram's `m_pos.z` is the distance to what the camera looks at and their
+camera is held a distance away from the terrain itself (the depth at the screen centre against
+`minCameraDist`); ours is held a *clearance above the ground under it*, so at a low tilt the focus
+is kilometres away while the ground is a couple of hundred metres below — and a fiftieth of the
+focus distance then parks the near plane in front of the ground at the bottom of the screen and
+cuts it away. Over flat ground with the focus close the two distances are the same; the cost of the
+smaller one is bounded by 1/sin(tilt) (2× at tilt 30), so the depth budget is only spent in the
+close-to-terrain case that needs it.
+
 The floor is a floor and the ground walk is a **ceiling** too, but only when the view is pitched
 away from the camera geometry — free roam looking up, or a first person camera
 ([13-celestial.md](13-celestial.md#seeing-them-free-roam)). The walk takes the near plane from
@@ -163,6 +174,37 @@ direction at all.
 Their far plane (`2·height/cos(pitch + fovy/2)`) is available as
 `TerrainOptions::ViewDistanceFactor` but changes nothing at the cameras tested: the ground-derived far is
 already inside the bound it gives.
+
+## The camera against the terrain
+
+`TerrainOptions::CameraClearance` keeps the camera a height above the ground under it. It is a
+**bound on the zoom** (`ViewState::getTerrainMaxZoom`, clamped in `CameraZoomEvent::calculate`)
+plus a per-frame correction in `MapRenderer` for the paths that lower the camera without zooming —
+panning into a hillside, tilting, a DEM tile arriving. Three rules keep a gesture against that
+bound from throwing the map somewhere else:
+
+- **The bound stops a zoom in; it never drives a zoom out.** A zoom event scales the map about its
+  pivot, and with the pivot under the fingers, clamping a zoom-*in* request to below the current
+  zoom scales the map the other way about that point — the map jumps sideways, once per pinch tick.
+  Getting back onto the shell is the renderer's correction, which zooms about the focus and moves
+  nothing sideways.
+- **A zoom is never cancelled for want of a ground hit.** `TouchHandler::calculatePivotPos` falls
+  back to the focus when the ray under the fingers misses the anchor plane or lands past the far
+  plane. Close to the terrain the far plane is short and half the screen is sky, so requiring a hit
+  (which the pinch, the wheel and the double tap all did) left the map unable to zoom out at all —
+  the "I have to pan somewhere else before I can move" symptom.
+- **The scale and the angle come from the SCREEN, not from the ground.** A pinch and a two-finger
+  turn are what the fingers did (tangram: `InputHandler::handlePinchGesture` /
+  `handleRotateGesture`, fed by the platform gesture detector). Taking them from where the two rays
+  meet the ground makes a grazing ray — a low camera, a finger near the horizon — into most of the
+  answer. The pan is still world-anchored (that is the point of a map pan) and goes through one
+  path for both gestures, `TouchHandler::panBetween`, which honours `PanningSpeedMode` and, below
+  tilt 15, caps the travel at what the finger's pixels are worth at the map scale — tangram's
+  `getTranslation` guard for a near-horizontal view.
+
+`isValidScreenPosition` tests the plane the gesture is actually anchored to (the terrain height
+under the touch, `_gestureAnchorHeight`), not sea level: in the mountains the two are hundreds of
+metres, and at a low tilt kilometres of ray, apart.
 
 ## The surface shader
 

--- a/docs/rendering/11-tangram-diff.md
+++ b/docs/rendering/11-tangram-diff.md
@@ -14,7 +14,9 @@ and *still different*, the latter with the reason it is not simply copied.
 | terrain surface | ONE shared static 64-grid VBO for every tile, per-tile uniforms (`core/src/style/rasterStyle.cpp:61`) | same shared grid (`buildCompiledTerrainGridSurfaces`), resolution = `MeshResolution` | **ported** |
 | content on terrain | displaced per vertex, one `texture2D` fetch (`res/scenes/terrain-3d.yaml`) | same | **ported** |
 | content depth | `gl_Position.z += (proxy − layer)·(2⁻¹⁹·w + depth_shift)`, `depth_shift` a flat 0.02, `proxy *= 48` for the raster | same, with the shift derived from the stack's ordinal span so the *budget* matches | **ported** ([05](05-depth-model.md)) |
-| near plane | `m_pos.z / 50` (`core/src/view/view.cpp:452`) | same in terrain mode | **ported** |
+| near plane | `m_pos.z / 50` (`core/src/view/view.cpp:452`), with the camera held a distance from the TERRAIN | `min(focus distance, height over the terrain under the camera) / 50` — their rule against our clearance model ([04](04-terrain.md#near-and-far-planes)) | **ported with a difference** |
+| pinch / rotate gesture | scale and angle from the platform gesture detector, i.e. the SCREEN (`core/src/util/inputHandler.cpp`) | same; the pan stays world-anchored and is capped below tilt 15 by their `getTranslation` guard ([04](04-terrain.md#the-camera-against-the-terrain)) | **ported** |
+| camera against the terrain | zoom-out push from the depth at the screen centre, eye lifted to elevation + 2 m (`core/src/view/view.cpp:404`) | clearance over the ground under the camera, as a zoom bound plus a per-frame correction | **different** |
 | per-layer depth pre-pass, stencil tile masks | none anywhere in `core/src` | none (shared ground) | **ported** |
 | map background | the framebuffer clear colour (`core/src/map.cpp`) | global terrain base fill before all layers; no per-tile background meshes | **ported** |
 | contour labels | generated from the elevation texture, no contour geometry (`core/src/style/contourTextStyle.cpp`) | label stubs in `ContourTileDataSource`, same algorithm | **ported** ([07](07-hillshade-contours.md)) |

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -1408,8 +1408,11 @@ public class DemoMap {
      * Free roam and how far above the horizon the view may look.
      *
      * A NEGATIVE tilt is the look up: the camera stays where the tilt geometry put it and only the
-     * view pitches, so nothing about zoom or the visible tiles changes. A map stops at the horizon
-     * by default (tilt range 0..90), which is why this has to be asked for.
+     * view pitches, so nothing about zoom or the visible tiles changes.
+     *
+     * A map stops at 30: below that the camera grazes the terrain and at 0 it looks along the
+     * ground from under it. Only the two modes that are ABOUT looking up - free roam and the star
+     * sky - get the full range.
      */
     public void applyLookRange() {
         Options options = mapView.getOptions();
@@ -1417,7 +1420,9 @@ public class DemoMap {
         options.setPanningSpeedMode(panningSpeedMode(DemoConfig.PANNING_SPEED_MODE));
         options.setFreeRoamLookSensitivity(DemoConfig.FREE_ROAM_LOOK_SENSITIVITY);
         options.setFreeRoamMoveSpeed(DemoConfig.FREE_ROAM_MOVE_SPEED);
-        options.setTiltRange(new com.carto.core.MapRange(-Math.max(30f, DemoConfig.LOOK_UP_LIMIT), 90f));
+        boolean lookUp = !"off".equals(DemoConfig.FREE_ROAM_MODE) || DemoConfig.STAR_SKY;
+        float minTilt = lookUp ? -Math.max(30f, DemoConfig.LOOK_UP_LIMIT) : 30f;
+        options.setTiltRange(new com.carto.core.MapRange(minTilt, 90f));
     }
 
     /** "map" / "anchored" / "constant" -> the SDK enum. */
@@ -1550,6 +1555,7 @@ public class DemoMap {
         }
         setMapLayerOpacity(0f);
         rebuildLayers();
+        applyLookRange(); // back to a map: the tilt stops at 30 again
         mapView.requestRender();
     }
 

--- a/scripts/ios-dev/CartoDemo/DemoMap.m
+++ b/scripts/ios-dev/CartoDemo/DemoMap.m
@@ -919,17 +919,22 @@ static const DemoFeature LAYER_ORDER[] = {
  * Free roam and how far above the horizon the view may look.
  *
  * A NEGATIVE tilt is the look up: the camera stays where the tilt geometry put it and only the view
- * pitches, so nothing about zoom or the visible tiles changes. A map stops at the horizon by
- * default (tilt range 0..90), which is why this has to be asked for.
+ * pitches, so nothing about zoom or the visible tiles changes.
+ *
+ * A map stops at 30: below that the camera grazes the terrain and at 0 it looks along the ground
+ * from under it. Only the two modes that are ABOUT looking up - free roam and the star sky - get
+ * the full range.
  */
 - (void)applyLookRange {
     NTOptions *options = [self.mapView getOptions];
-    [options setFreeRoamMode:[self freeRoamMode:[DemoConfig stringFor:@"freeRoam"]]];
+    NSString *freeRoam = [DemoConfig stringFor:@"freeRoam"];
+    [options setFreeRoamMode:[self freeRoamMode:freeRoam]];
     [options setPanningSpeedMode:[self panningSpeedMode:[DemoConfig stringFor:@"panSpeed"]]];
     [options setFreeRoamLookSensitivity:[DemoConfig floatFor:@"lookSensitivity"]];
     [options setFreeRoamMoveSpeed:[DemoConfig floatFor:@"moveSpeed"]];
-    [options setTiltRange:[[NTMapRange alloc] initWithMin:-fmaxf(30, [DemoConfig floatFor:@"lookUp"])
-                                                      max:90]];
+    BOOL lookUp = ![freeRoam isEqualToString:@"off"] || [DemoConfig boolFor:@"starSky"];
+    float minTilt = lookUp ? -fmaxf(30, [DemoConfig floatFor:@"lookUp"]) : 30;
+    [options setTiltRange:[[NTMapRange alloc] initWithMin:minTilt max:90]];
 }
 
 - (enum NTPanningSpeedMode)panningSpeedMode:(NSString *)name {
@@ -1325,6 +1330,7 @@ static const DemoFeature LAYER_ORDER[] = {
     }
     [self setMapLayerOpacity:0];
     [self rebuildLayers];
+    [self applyLookRange]; // back to a map: the tilt stops at 30 again
     [self requestRender];
 }
 


### PR DESCRIPTION
## Summary

Three separate mechanisms made a camera close to the terrain unusable:

- **The map could not be zoomed at all.** Every zoom path (pinch, wheel, double tap) required a
  valid ground hit under the fingers. Near the ground the far plane is short and half the screen is
  sky, so the ray misses or lands past it and the whole gesture was dropped. The pivot now falls
  back to the focus (`TouchHandler::calculatePivotPos`); no gesture is cancelled for a missing hit.
- **The map jumped sideways while pinching.** The pinch scale and the two-finger angle came from
  where the two rays meet the ground - a grazing ray makes that mostly error - and the terrain zoom
  bound clamped a zoom-*in* request to below the current zoom whenever the camera was already inside
  the clearance shell, which scales the map about the pinch point the other way. Scale and angle now
  come from the SCREEN like tangram takes them (`InputHandler::handlePinchGesture` /
  `handleRotateGesture`), both gestures pan through one path (`panBetween`) that honours
  `PanningSpeedMode` and caps the travel below tilt 15 with tangram's `getTranslation` guard, and the
  bound only ever stops a zoom in - the way back onto the shell stays the renderer's per-frame
  correction, about the focus.
- **The ground at the bottom of a tilted view was cut away.** The near plane was a fiftieth of the
  distance to the focus. Tangram's camera is held away from the TERRAIN; ours is held a clearance
  above the ground under it, so at a low tilt the focus is kilometres off while the ground is a few
  hundred metres below. It is now floored on the smaller of the two distances (cost bounded by
  1/sin(tilt), 2x at tilt 30).

Also: the demo's tilt range is 30..90 except in free roam and star sky (it allowed a tilt through the
ground), and `MBVectorTileDecoder.h` gets a `> >` so `swigpp-java.py` stops failing on master - it
silently leaves `MBVectorTileDecoder_wrap.cpp` missing after any wrapper regeneration.

## Testing

`clang++ -fsyntax-only` clean on TouchHandler, ViewState, CameraZoomEvent, MapRenderer; wrappers
regenerated (`standard+valhalla+geocoding+routing+packagemanager`); `scripts/android-dev` builds.

Emulator run, `--es lon 5.760595 --es lat 45.244172 --es zoom 16 --es tilt 30 --es ui false`: the
clearance clamps to z14.89 and the frame is complete; a one-finger drag moves the focus ~330 m with
no jump; a double-tap drag zooms 14.89 -> 15.48 with the focus unchanged.

**Still needs a device check** - adb cannot drive two fingers, so the pinch/rotate rework is
unverified in practice, and the missing bottom tiles did not reproduce on the emulator (tried the
camera above and `--es clearance 5 --es zoom 18 --es tilt 30`), so the near-plane change is reasoned
from the mechanism rather than from a repro. Worth watching for see-through at a low camera, since a
smaller near plane spends depth precision.

## Breaking changes

`ViewState.setTerrainMinCameraZ` is replaced by `setTerrainCameraReference(terrainZ, minCameraZ)` and
`%ignore`d in `all/modules/graphics/ViewState.i`: it is renderer plumbing published once per frame,
not something an app calls. Any binding that referenced it must drop the call.