### PR TITLE
fix(labels): restore the halo width the single-raster build drew

### DIFF
--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -440,6 +440,17 @@ zoom filter.
   laid along a line the whole way — still track their line at the ridge camera.
   What remains is genuine volume: a changed DEM tile at z12 intersects every label tile beneath it,
   so "targeted" still means most of the screen.
+- **Halo width is measured in antialias ramps, not in glyph texels.** `labelFsh` shifts the
+  coverage ramp outward by the halo, and the ramp is one screen pixel of signed distance, so a halo
+  reaching the renderer in screen pixels (`HALO_PIXELS_PER_UNIT`) is as wide as the style asks
+  whatever raster the label landed on. It used to be converted with the glyph's RENDER size
+  instead — harmless while every glyph was rastered at 27 texels, wrong the moment the raster ladder
+  (16/28/40, see [10-performance.md](10-performance.md)) made that size depend on the label. The
+  factor is `renderSize / (renderSize - spread)`: **3.0** on the smallest raster against **1.2** on
+  the largest, so one `text-halo-radius` drew a halo two and a half times wider on a small label
+  than on a large one, and up to **five times** what the single-raster build drew — a soft white
+  glow instead of an outline, reported as "halo huge at radius 2, fine at 1". If halos ever look
+  wrong again, check that term before the style.
 - **Vertex data.** Glyph quads are rebuilt from scratch for every visible label every frame and
   uploaded as one batch (`labelVertexBuildNs`, `labelBatchNs`). A GPU-billboard path would remove
   the per-frame world transform (`labelTransformNs`) — it is on the backlog, not implemented.


### PR DESCRIPTION
## Summary

- A label halo was converted to signed-distance units with the glyph's **render size**, which was
  one constant only while every glyph was rastered at 27 texels. The raster ladder (16/28/40) made
  it per-label, and the factor `renderSize / (renderSize - spread)` with it: **3.0** on the smallest
  raster against **1.2** on the largest.
- Reported as "halo is huge at `text-halo-radius: 2`, fine at 1". For an unchanged style the halo
  came out ~**5x** wider than before on small labels and ~2x on large ones — a soft white glow
  instead of an outline.
- The fix is in `libs-carto` (see below): the halo reaches the shader in screen pixels and is
  measured against the same one screen pixel the antialias ramp is. This PR carries the pointer bump
  and the note in [`docs/rendering/06-labels.md`](docs/rendering/06-labels.md).
- No style changes: the constant reproduces the width the single-raster build gave.

## Testing

- Docs + pointer bump only in this repo; the code change is syntax-checked and screen-verified in
  the submodule PR.
- Reproduce with the demo: `--es style assets --es base composite --es lat 45.244172 --es lon
  5.760595 --es zoom 13.6 --es tilt 35`, and compare small labels against large ones — before the
  fix the small ones carry a visibly wider halo for the same style rule.

## Depends on

https://github.com/farfromrefug/mobile-carto-libs/pull/38 — merge that first, then this branch's
pointer is rebased onto the merged commit before this one goes in.