### PR TITLE
perf(terrain): make a terrain start stop refetching its elevation

### DIFF
--- a/all/native/layers/VectorLayer.cpp
+++ b/all/native/layers/VectorLayer.cpp
@@ -683,20 +683,30 @@ namespace carto {
             return false;
         }
 
-        // Warm up the elevation grid cache over the visible area (this runs on a background
+        // Warm up the elevation grid cache where the elements ARE (this runs on a background
         // thread and may block on IO): element draw data is then built with complete heights
         // in one pass, avoiding transient half-draped geometry (e.g. near-vertical line
         // segments between vertices with and without loaded elevation data).
+        // Sampling the visible ENVELOPE instead is what this used to do, and in terrain mode the
+        // envelope reaches the view distance: its corners are hundreds of km away, off the DEM
+        // coverage, so every fetch task blocked on ~15 elevation tile requests that could only
+        // fail (measured on a Crosscall: 15 failing HTTP round trips per startup, re-issued
+        // whenever the failure markers expired).
         if (auto options = layer->getOptions()) {
             if (auto terrainOptions = options->getTerrainOptions()) {
                 if (terrainOptions->isEnabled() && !isCanceled()) {
                     const std::shared_ptr<ElevationManager>& elevationManager = terrainOptions->getElevationManager();
-                    const MapBounds& bounds = cullState->getEnvelope().getBounds();
-                    for (int yi = 0; yi <= 3; yi++) {
-                        for (int xi = 0; xi <= 3; xi++) {
-                            double x = bounds.getMin().getX() + (bounds.getMax().getX() - bounds.getMin().getX()) * xi / 3.0;
-                            double y = bounds.getMin().getY() + (bounds.getMax().getY() - bounds.getMin().getY()) * yi / 3.0;
-                            elevationManager->getElevationMeters(x, y, ElevationManager::LoadMode::ALLOW_LOAD);
+                    std::shared_ptr<Projection> projection = layer->_dataSource->getProjection();
+                    for (const std::shared_ptr<VectorElement>& element : vectorData->getElements()) {
+                        if (isCanceled()) {
+                            break;
+                        }
+                        MapBounds bounds = element->getBounds();
+                        for (int i = 0; i < 4; i++) {
+                            MapPos pos((i & 1) ? bounds.getMax().getX() : bounds.getMin().getX(),
+                                       (i & 2) ? bounds.getMax().getY() : bounds.getMin().getY());
+                            MapPos internalPos = projection->toInternal(pos);
+                            elevationManager->getElevationMeters(internalPos.getX(), internalPos.getY(), ElevationManager::LoadMode::ALLOW_LOAD);
                         }
                     }
                 }

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -19,6 +19,17 @@
 namespace carto {
 
     static const std::size_t DEFAULT_CACHE_CAPACITY = 64 * 1024 * 1024;
+    // Grids the cache must hold whatever the source resolution is. A fixed byte budget is really a
+    // tile budget the DEM raster size decides: a 512x512 RGB source is 768 KB per grid, so 64 MB
+    // is 85 grids - while one terrain view asked for 122-167 distinct grids (the cover pyramid,
+    // TileLayer::TERRAIN_COVER_TILE_BUDGET tiles collapsing onto ~160 DEM tiles once clamped, plus
+    // the contour source's finer tiles and the border prefetch). Every grid past the limit evicted
+    // one still in use and was decoded again on the next pass. Measured on a Crosscall at the demo
+    // camera, per startup: 85 grids = 1525 loads of 167 tiles and 32 s of WEBP decode, 128 grids =
+    // 189 loads of 157, 192 grids = 157 loads of 157 and 3.1 s of decode.
+    // An app that cannot spend the memory (144 MB here, 36 MB for a 256x256 source) sets its own
+    // number with TerrainOptions::setElevationCacheCapacity, which then wins over this rule.
+    static const std::size_t MIN_CACHED_GRIDS = 192;
     static const int FAILED_TILE_TTL_MILLISECONDS = 30 * 1000;
     static const int MAX_ANCESTOR_SEARCH_DEPTH = 8;
     static const std::size_t MAX_PREFETCH_QUEUE_SIZE = 64;
@@ -141,6 +152,7 @@ namespace carto {
 
     void ElevationManager::setCacheCapacity(std::size_t capacityInBytes) {
         std::lock_guard<std::mutex> lock(_mutex);
+        _gridCacheCapacityFixed = true;
         _gridCache.resize(capacityInBytes);
     }
 
@@ -316,6 +328,16 @@ namespace carto {
         {
             std::lock_guard<std::mutex> lock(_mutex);
             if (grid) {
+                // Grow the budget to the source's own grid size before inserting, so the cache is
+                // a tile count rather than a byte count the raster resolution decides (see
+                // MIN_CACHED_GRIDS). Only ever grows, and a caller that set its own capacity keeps it.
+                std::size_t minCapacity = grid->getDataSize() * MIN_CACHED_GRIDS;
+                if (!_gridCacheCapacityFixed && _gridCache.capacity() < minCapacity) {
+                    Log::Infof("ElevationManager: elevation grid cache %d -> %d MB (%d grids of %d KB)",
+                               static_cast<int>(_gridCache.capacity() >> 20), static_cast<int>(minCapacity >> 20),
+                               static_cast<int>(MIN_CACHED_GRIDS), static_cast<int>(grid->getDataSize() >> 10));
+                    _gridCache.resize(minCapacity);
+                }
                 _gridCache.put(grid->getTile().getTileId(), grid, grid->getDataSize());
                 if (grid->getTile() != tile) {
                     // Loaded an ancestor (replace-with-parent); also mark the requested tile as resolved via ancestor

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -258,6 +258,7 @@ namespace carto {
         mutable unsigned int _changeLogFirstVersion = 1; // earliest version still covered by the log
 
         mutable cache::timed_lru_cache<long long, std::shared_ptr<ElevationTileGrid> > _gridCache;
+        bool _gridCacheCapacityFixed = false; // set through setCacheCapacity: the app's number wins over the grid-count rule
         mutable std::map<long long, std::shared_future<std::shared_ptr<ElevationTileGrid> > > _pendingLoads; // single-flight de-duplication of concurrent loads
         mutable std::mutex _mutex;
 

--- a/docs/rendering/04-terrain.md
+++ b/docs/rendering/04-terrain.md
@@ -12,6 +12,16 @@ with a `LoadMode` (`CACHED_ONLY` never blocks). Every consumer — the mesh, lab
 placement, billboard occlusion — must go through it, or two parts of the frame disagree about where
 the ground is.
 
+**The grid cache is a tile count, not a byte budget.** A grid is the source raster (768 KB for a
+512×512 RGB DEM, 192 KB for a 256×256 one), so a fixed 64 MB meant 85 grids for one source and 340
+for another. One terrain view needs 122–167 of them — the cover pyramid, the contour source's finer
+tiles, the border prefetch — and every grid past the limit evicted one still in use, which was then
+decoded again on the next pass: **1525 loads of 167 distinct tiles, 32 s of WEBP decode per
+startup** on a Crosscall. The cache now grows on the first decoded grid to hold `MIN_CACHED_GRIDS`
+(192) of them, i.e. 144 MB for a 512² source and 36 MB for a 256² one; 192 was the first value where
+loads equalled distinct tiles (128 still re-decoded ~20%). `TerrainOptions::setElevationCacheCapacity`
+still wins over the rule, for an app that cannot spend the memory.
+
 `setSurfaceResolution` caps the elevation level to what the mesh can express (roughly one texel per
 half surface cell), which costs about two zoom levels of detail. That cap is right for geometry and
 wrong for per-fragment shading, which is why the terrain paint can opt out of it

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -96,6 +96,57 @@ The GPU is not the limit: `PROF GPU` with content puts the layers at 29–43 ms 
 So the lever is **fewer draws and fewer layers**, which is [07-hillshade-contours.md](07-hillshade-contours.md)
 and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 
+### A city pans slower than a mountain, and it is fragments
+
+Same build, same camera settings (z16.22, tilt 26), panning north — Grenoble against the
+Saint-Eynard ridge, on a Crosscall:
+
+| | fps | CPU frame | GPU total | GPU layers | draws/frame | indices/frame |
+|---|---|---|---|---|---|---|
+| city | 12.0–13.7 | 34 ms | 33 ms | **21 ms** | 48 | 1.65M |
+| mountain | 18.2–19.6 | 31 ms | 18 ms | **9 ms** | 35–48 | 1.3–1.6M |
+
+The CPU frame is the same and the draw/index counts match in the closest pair, so the 2.4× is
+**per-fragment**: dense city content covers the whole screen where the mountain view is mostly
+terrain surface. Of it, **contours are 45%** — `--es contour false` takes the city from 12.1 to
+17.6 fps (repeated, interleaved), GPU layers 21.3 → 13.6 ms, render tiles 805 → 380 and draws
+602 → 430 per interval, because the `#contour` slot is a second tile set drawn over the first.
+
+## Starting up in terrain mode
+
+Measured on a Crosscall at the demo's default camera (Grenoble, z16.22, terrain + contours, warm
+caches), with temporary probes in `TileLayer::FetchTaskBase::run`, `PersistentCacheTileDataSource::
+loadTile`, `ElevationManager::loadTileGrid` and `VectorTileLayer::FetchTask::loadTile`. The vector
+tiles were never the cost: 66 decodes, 5–6 s of thread time. Elevation was, three times over.
+
+| per startup | before | after |
+|---|---|---|
+| DEM HTTP requests | 79–94, of which **15 could only fail** | **0–1** |
+| DEM grid decodes | 1525 loads of 167 distinct tiles (32 s) | 157 of 157 (3.1 s) |
+| 90% of the content on screen | 6.4–7.6 s | **4.3–4.4 s** |
+
+1. **The elevation grid LRU held 85 tiles and the view needed 167** — a byte budget behaving as a
+   tile budget the DEM raster size decides. Fixed in [04-terrain.md](04-terrain.md#elevation-data).
+2. **The on-disk tile cache defaults to 50 MB and one terrain view's DEM pyramid does not fit.**
+   Two consecutive starts at the *same* camera missed on **different** tiles (their miss sets did
+   not intersect): the cache was evicting exactly what the next start needed, so ~65 tiles were
+   re-downloaded every time at 400–800 ms each. This is an app-side setting —
+   `PersistentCacheTileDataSource::setCapacity`; the demo now asks for 600 MB for the DEM and
+   200 MB per other source (`DemoConfig.DEM_PERSISTENT_CACHE_MB`, `--es demCacheMb`).
+3. **The element elevation warm-up sampled the view envelope**, whose corners are off the DEM in
+   terrain mode: 15 guaranteed 404s per startup. See
+   [12-vector-elements.md](12-vector-elements.md#terrain-interaction).
+
+What is left, in order: **contour tile generation** (44 child fetches, 6–22 s of thread time — the
+`#contour` slot is a whole second tile set, which is what [07-hillshade-contours.md](07-hillshade-contours.md)
+would remove by computing contours in the terrain fragment shader), the network itself, and the
+decode pool (`Options::setTileThreadPoolSize`, default **1**; tangram runs 2). Raising the pool was
+measured as no win *while* the network dominated — retake it now that it does not.
+
+Unrelated but on the same path: the first `loadTile` on a persistent cache runs `loadTileInfo`, a
+full-table scan of the cache DB, on the tile thread — **1.4 s** on the first (cold page cache) run
+of a 52 MB DB.
+
 ## Style load and tile decode (off the render thread, but in front of the user)
 
 Measured on a Crosscall HLTE556N with the demo's bundled style project (`--es style assets`:

--- a/docs/rendering/12-vector-elements.md
+++ b/docs/rendering/12-vector-elements.md
@@ -55,6 +55,15 @@ lines on shoulders when it was tried.
 If a vector line disappears into the terrain or shows through it, read
 [05-depth-model.md](05-depth-model.md) before touching any constant here.
 
+**3. The elevation warm-up.** `VectorLayer::FetchTask::loadElements` loads the elevation under the
+elements before their draw data is built, on the fetch thread, so a line is not drawn half draped
+(vertices with and without heights give near-vertical segments). It samples the bounds of each
+loaded element. It used to sample a 4×4 grid over the **cull envelope** instead, and in terrain mode
+that envelope reaches the view distance: its corners land hundreds of km away, off the DEM coverage,
+so every fetch task blocked on elevation tiles that could only 404 — measured on a Crosscall, 15
+failing HTTP round trips per startup, re-issued each time the failure markers expired
+(`FAILED_TILE_TTL_MILLISECONDS`, 30 s) while panning.
+
 ## Picking
 
 `MapRenderer::calculateRayIntersectedElements` turns a screen position into a world ray and asks

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -116,6 +116,16 @@ public final class DemoConfig {
     // TILE SOURCES
     // =============================================================================================
 
+    /** On-disk cache per tile source, MB (PersistentCacheTileDataSource.setCapacity).
+     *  '--es cacheMb 100'. */
+    public static int PERSISTENT_CACHE_MB = 200;
+    /** Same for the DEM, which needs far more of it: one terrain view asks for a whole pyramid of
+     *  elevation tiles, and at the SDK default of 50 MB it does not fit. Measured on the Crosscall
+     *  at the default camera, terrain on: 64-70 DEM tiles re-downloaded on EVERY start (25-50 s of
+     *  network), and two consecutive starts missed on DIFFERENT tiles - the cache was evicting
+     *  exactly what the next start needed. '--es demCacheMb 200'. */
+    public static int DEM_PERSISTENT_CACHE_MB = 600;
+
     /** Master vector tile source of the base map. */
     public static String VECTOR_URL = "https://tiles.akylas.fr/data/france/{z}/{x}/{y}.pbf";
     public static int VECTOR_MIN_ZOOM = 0;
@@ -842,6 +852,8 @@ public final class DemoConfig {
         STYLE_DIR_NAME = DemoCfg.cfgStr("styleDir", STYLE_DIR_NAME);
         STYLE_ZIP_NAME = DemoCfg.cfgStr("styleZip", STYLE_ZIP_NAME);
         STYLE_ASSETS_PATH = DemoCfg.cfgStr("styleAssets", STYLE_ASSETS_PATH);
+        PERSISTENT_CACHE_MB = DemoCfg.cfgInt("cacheMb", PERSISTENT_CACHE_MB);
+        DEM_PERSISTENT_CACHE_MB = DemoCfg.cfgInt("demCacheMb", DEM_PERSISTENT_CACHE_MB);
 
         // camera
         START_LON = DemoCfg.cfgFloat("lon", (float) START_LON);

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -1125,7 +1125,9 @@ public class DemoMap {
         if (cachedVector == null) {
             HTTPTileDataSource source = new HTTPTileDataSource(DemoConfig.VECTOR_MIN_ZOOM, DemoConfig.VECTOR_MAX_ZOOM, DemoConfig.VECTOR_URL);
             source.setHTTPHeaders(userAgentHeaders());
-            cachedVector = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.VECTOR_CACHE_DB));
+            PersistentCacheTileDataSource cache = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.VECTOR_CACHE_DB));
+            cache.setCapacity(DemoConfig.PERSISTENT_CACHE_MB * 1024L * 1024L);
+            cachedVector = cache;
         }
         return cachedVector;
     }
@@ -1138,7 +1140,9 @@ public class DemoMap {
         if (cachedDem == null) {
             HTTPTileDataSource source = new HTTPTileDataSource(DemoConfig.DEM_MIN_ZOOM, DemoConfig.DEM_MAX_ZOOM, DemoConfig.DEM_URL);
             source.setEncoding(DemoConfig.DEM_ENCODING);
-            cachedDem = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.DEM_CACHE_DB));
+            PersistentCacheTileDataSource cache = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.DEM_CACHE_DB));
+            cache.setCapacity(DemoConfig.DEM_PERSISTENT_CACHE_MB * 1024L * 1024L);
+            cachedDem = cache;
         }
         return cachedDem;
     }
@@ -1147,7 +1151,9 @@ public class DemoMap {
         if (cachedRaster == null) {
             HTTPTileDataSource source = new HTTPTileDataSource(DemoConfig.RASTER_MIN_ZOOM, DemoConfig.RASTER_MAX_ZOOM, DemoConfig.RASTER_URL);
             source.setHTTPHeaders(userAgentHeaders());
-            cachedRaster = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.RASTER_CACHE_DB));
+            PersistentCacheTileDataSource cache = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.RASTER_CACHE_DB));
+            cache.setCapacity(DemoConfig.PERSISTENT_CACHE_MB * 1024L * 1024L);
+            cachedRaster = cache;
         }
         return cachedRaster;
     }
@@ -1157,7 +1163,9 @@ public class DemoMap {
         if (cachedContourTiles == null) {
             HTTPTileDataSource source = new HTTPTileDataSource(DemoConfig.CONTOUR_TILES_MIN_ZOOM, DemoConfig.CONTOUR_TILES_MAX_ZOOM, DemoConfig.CONTOUR_TILES_URL);
             source.setHTTPHeaders(userAgentHeaders());
-            cachedContourTiles = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.CONTOUR_TILES_CACHE_DB));
+            PersistentCacheTileDataSource cache = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.CONTOUR_TILES_CACHE_DB));
+            cache.setCapacity(DemoConfig.PERSISTENT_CACHE_MB * 1024L * 1024L);
+            cachedContourTiles = cache;
         }
         return cachedContourTiles;
     }


### PR DESCRIPTION
## Summary

Three independent causes of "starting in terrain mode is slow — roads and contours take a long time
to appear", found by probing a Crosscall.

- **The elevation grid cache was sized in bytes, not in tiles.** One 512² grid is ~750 kB, so the
  default capacity held only a handful of them and a single tilted view evicted grids it was still
  using — the same DEM tile was fetched, decoded and thrown away repeatedly. It now takes a floor of
  192 grids (`MIN_CACHED_GRIDS`), and an explicit `setCacheCapacity` still wins.
- **Vector element elevation was warmed over the view envelope**, on a 4×4 grid, which at a tilted
  camera asks for DEM tiles far outside anything the elements occupy — 15 elevation requests per
  start that answered 404. It now samples each loaded element's own bounds.
- **The demo's tile caches were too small for a terrain view** (`PERSISTENT_CACHE_MB`,
  `DEM_PERSISTENT_CACHE_MB`, with `--es cacheMb` / `--es demCacheMb` to try other values).

Measured on the Crosscall, terrain start at the same camera:

| | before | after |
|---|---|---|
| DEM HTTP requests per start | 79–94 | **0–1** |
| 90% of content on screen | 6.4–7.6 s | **4.3–4.4 s** |

## Testing

- `clang++ -fsyntax-only` clean on `ElevationManager.cpp` and `VectorLayer.cpp`.
- Device-measured as above (`scripts/android-dev`, request counts from the tile-source probe,
  content settle from timed screenshots). Reproduce with
  `--es demo terrain --es lat 45.244172 --es lon 5.760595 --es zoom 13.6 --es tilt 35`.
- The cache floor raises steady-state memory for elevation grids by design: 192 grids is ~144 MB at
  512², ~36 MB at 256². Worth a reviewer's eye on whether the floor should scale with the device.