### PR TITLE
feat(layers): draw a style's contours per fragment instead of tracing them

### DIFF
--- a/all/modules/graphics/ViewState.i
+++ b/all/modules/graphics/ViewState.i
@@ -72,6 +72,7 @@
 %ignore carto::ViewState::getRTEModelviewProjectionMat;
 %ignore carto::ViewState::getRTESkyProjectionMat;
 %ignore carto::ViewState::setScreenSize;
+%ignore carto::ViewState::setTerrainCameraReference; // renderer plumbing, published every frame
 %ignore carto::ViewState::clampZoom;
 %ignore carto::ViewState::clampFocusPos;
 %ignore carto::ViewState::getFocusPosNormal;

--- a/all/native/datasources/ContourTileDataSource.cpp
+++ b/all/native/datasources/ContourTileDataSource.cpp
@@ -467,7 +467,11 @@ namespace carto {
     }
 
     void ContourTileDataSource::setLabelStubsEnabled(bool enabled) {
-        _labelStubs = enabled;
+        if (_labelStubs.exchange(enabled) == enabled) {
+            return; // re-setting the same value would throw away every tile, and every elevation
+                    // grid with them (ElevationManager listens on this source) - once a frame, if
+                    // the caller keeps the mode in step with a per-frame decision.
+        }
         notifyTilesChanged(false);
     }
 
@@ -740,6 +744,11 @@ namespace carto {
         // worth their cost depends on the style that draws them, so they are the app's to set
         // (setIntervalMultiplier); the defaults below are only a starting point.
         return _baseInterval * getIntervalMultiplier(zoom);
+    }
+
+    const std::vector<float>& ContourTileDataSource::getDivisorLadder() {
+        static const std::vector<float> ladder = { 10.0f, 20.0f, 50.0f, 100.0f, 200.0f, 250.0f, 500.0f, 1000.0f };
+        return ladder; // the divisors computeDiv can answer with, finest first
     }
 
     long long ContourTileDataSource::computeDiv(long long ele) {

--- a/all/native/datasources/ContourTileDataSource.h
+++ b/all/native/datasources/ContourTileDataSource.h
@@ -44,6 +44,13 @@ namespace carto {
     class ContourTileDataSource : public TileDataSource {
     public:
         /**
+         * The elevation divisors a contour feature can carry ('div'), coarsest last. They are the
+         * classes a style writes rules for, and what a per-fragment contour renderer draws bands
+         * for - see computeDiv, which picks the largest of them that divides the elevation.
+         */
+        static const std::vector<float>& getDivisorLadder();
+
+        /**
          * Constructs a ContourTileDataSource object.
          * @param dataSource The RGB-encoded elevation data source to generate contours from.
          * @param elevationDecoder The decoder used to convert RGB pixels to elevation. If null,

--- a/all/native/graphics/ViewState.cpp
+++ b/all/native/graphics/ViewState.cpp
@@ -82,7 +82,11 @@ namespace carto {
         }
     }
 
-    void ViewState::setTerrainMinCameraZ(double minCameraZ) {
+    void ViewState::setTerrainCameraReference(double terrainZ, double minCameraZ) {
+        if (terrainZ != _terrainCameraZ) {
+            _terrainCameraZ = terrainZ;
+            _cameraChanged = true; // the near plane is built on it
+        }
         _terrainMinCameraZ = minCameraZ;
     }
 
@@ -801,7 +805,19 @@ namespace carto {
         // The FAR plane is theirs too - see calculateViewDistance, which is also what the tile
         // walk stops at, so the view and the tiles fetched for it always agree.
         double viewDistance = calculateViewDistance(options);
-        float terrainNear = static_cast<float>(calculateCameraDistance() / 50.0);
+        // Tangram's near is a fiftieth of the camera's distance to what it looks at, and their
+        // camera is held a distance away from the TERRAIN (view.cpp: the depth at the screen
+        // centre against minCameraDist). Ours is held a clearance above the terrain UNDER it, so at
+        // a low tilt the focus is kilometres away while the ground is a couple of hundred metres
+        // below - a fiftieth of the focus distance then parks the near plane in front of the ground
+        // at the bottom of the screen and cuts it away. Take the smaller of the two distances: over
+        // flat ground with the focus close they are the same, and it is only the close-to-terrain
+        // case that spends depth precision.
+        double cameraDistance = calculateCameraDistance();
+        if (_terrainCameraZ != 0 && _cameraPos(2) > _terrainCameraZ) {
+            cameraDistance = std::min(cameraDistance, _cameraPos(2) - _terrainCameraZ);
+        }
+        float terrainNear = static_cast<float>(cameraDistance / 50.0);
         if (viewDistance > 0) {
             float viewDistanceFactor = 1.0f;
             bool absoluteViewDistance = false;

--- a/all/native/graphics/ViewState.h
+++ b/all/native/graphics/ViewState.h
@@ -208,12 +208,14 @@ namespace carto {
         void setTerrainHeightRange(float minZ, float maxZ);
 
         /**
-         * Sets the minimum camera height (in internal units) imposed by the terrain
-         * clearance, or 0 to disable the terrain zoom bound. Published once per frame
-         * by the renderer from the elevation under the camera.
-         * @param minCameraZ The minimum camera height, 0 to disable.
+         * Sets the terrain reference under the camera (in internal units), published once
+         * per frame by the renderer: the ground height there, and the minimum camera height
+         * the clearance imposes. The height bounds the near plane (the ground cannot be
+         * further than that below the camera), the minimum drives the terrain zoom bound.
+         * @param terrainZ The terrain height under the camera.
+         * @param minCameraZ The minimum camera height, 0 to disable the zoom bound.
          */
-        void setTerrainMinCameraZ(double minCameraZ);
+        void setTerrainCameraReference(double terrainZ, double minCameraZ);
         /**
          * Returns the maximum zoom allowed by the terrain clearance, or infinity when
          * no terrain bound is active. Evaluated against the CURRENT camera state, so it
@@ -482,6 +484,7 @@ namespace carto {
         float _terrainHeightMin = 0.0f;
         float _terrainHeightMax = 0.0f;
         double _terrainMinCameraZ = 0.0; // 0 = no terrain zoom bound
+        double _terrainCameraZ = 0.0; // terrain height under the camera, 0 = unknown
     
         int _fovY;
         float _halfFOVY;

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -12,6 +12,7 @@
 #include "core/MapRange.h"
 #include "core/MapVec.h"
 #include "components/Exceptions.h"
+#include "utils/Const.h"
 #include "utils/Log.h"
 
 #include <algorithm>
@@ -871,12 +872,24 @@ namespace carto {
 
         std::vector<ContourClass> classes;
         if (terrainActive && style.shaderCapable) {
+            // A style width is in unscaled-DPI units and reaches device pixels through three steps
+            // of the traced path, so the bands take the same three or they draw the same style
+            // thinner than the geometry they replace (measured 3.2x on a 288-dpi 1648-high screen).
+            // The steps are, in order: the width table of GLTileRenderer::renderTileGeometry, the
+            // half-unit AA margin lineVsh puts on every line, and lineFsh's uAntialiasScale.
+            float normResolution = viewState.getNormalizedResolution();
+            float tileSize = 256.0f; // what the decoder builds its tiles at, and what vt divides by
+            if (auto settings = decoder->getSymbolizerContextSettings()) {
+                tileSize = settings->getTileSize();
+            }
+            float pixelsPerUnit = (normResolution > 0.0f ? std::max(1.0f, viewState.getHeight() / normResolution) : 1.0f);
             classes.reserve(style.classes.size());
             for (const mvt::ContourLineClass& styleClass : style.classes) {
                 ContourClass contourClass;
                 contourClass.interval = styleClass.divisor;
                 contourClass.color = Color(styleClass.color.value());
-                contourClass.halfWidth = styleClass.width * 0.5f;
+                float units = 0.25f * normResolution * styleClass.width / tileSize;
+                contourClass.halfWidth = (units > 0.0f ? (units - 1.0f) * 0.5f + 1.0f : 0.0f) * pixelsPerUnit;
                 classes.push_back(contourClass);
             }
         } else if (terrainActive && !style.rejectReason.empty() && style.rejectReason != _contourRejectReason) {

--- a/all/native/layers/CompositeVectorTileLayer.cpp
+++ b/all/native/layers/CompositeVectorTileLayer.cpp
@@ -15,8 +15,13 @@
 #include "utils/Log.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <cmath>
 #include <variant>
+
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+#endif
 
 #include <mapnikvt/Value.h>
 #include <mapnikvt/LayerConfigResolver.h>
@@ -816,6 +821,76 @@ namespace carto {
         }
     }
 
+    bool CompositeVectorTileLayer::shaderContoursAllowed() {
+        // OPT-IN, because as it stands it is SLOWER than the geometry it replaces: measured on a
+        // Crosscall at the city camera, 9.2 fps against 12.0, GPU layers 56 ms against 21 - the
+        // paint is an EXTRA full-cover surface pass whose fragment shader reconstructs the DEM
+        // (nine taps) and runs the hillshade lighting before the bands, and that costs more than
+        // the geometry it saves (10.1M indices against 22.0M). Tangram pays none of it because
+        // their contours are a block inside the earth draw that runs anyway, not a pass on top -
+        // which is where this has to move before it can be the default.
+        //   adb shell setprop debug.carto.shadercontours 1
+#ifdef __ANDROID__
+        static const bool allowed = [] {
+            char property[PROP_VALUE_MAX] = { 0 };
+            if (__system_property_get("debug.carto.shadercontours", property) > 0) {
+                return std::atoi(property) != 0;
+            }
+            return false;
+        }();
+        return allowed;
+#else
+        return false;
+#endif
+    }
+
+    void CompositeVectorTileLayer::applyContourPaint(const ExternalSource& source, const std::shared_ptr<MBVectorTileDecoder>& decoder, const ViewState& viewState) {
+        auto contourSource = std::dynamic_pointer_cast<ContourTileDataSource>(source.dataSource);
+        auto childLayer = std::dynamic_pointer_cast<TileLayer>(source.childLayer);
+        if (!contourSource || !childLayer || !decoder) {
+            return;
+        }
+
+        // The lines are a function of the elevation alone, so a style that only asks for a colour,
+        // a width and an opacity per 'div' can be painted per fragment on the terrain instead of
+        // traced into a tile set of its own - which is a second set of tiles to fetch, decode,
+        // tesselate and draw. Anything the shader cannot reproduce keeps the traced path.
+        mvt::ResolvedContourStyle style;
+        bool terrainActive = shaderContoursAllowed();
+        if (terrainActive) {
+            terrainActive = false;
+            if (auto options = getOptions()) {
+                if (auto terrainOptions = options->getTerrainOptions()) {
+                    terrainActive = terrainOptions->isEnabled();
+                }
+            }
+        }
+        if (terrainActive) {
+            style = decoder->resolveContourStyle(source.name, viewState.getZoom(), ContourTileDataSource::getDivisorLadder());
+        }
+
+        std::vector<ContourClass> classes;
+        if (terrainActive && style.shaderCapable) {
+            classes.reserve(style.classes.size());
+            for (const mvt::ContourLineClass& styleClass : style.classes) {
+                ContourClass contourClass;
+                contourClass.interval = styleClass.divisor;
+                contourClass.color = Color(styleClass.color.value());
+                contourClass.halfWidth = styleClass.width * 0.5f;
+                classes.push_back(contourClass);
+            }
+        } else if (terrainActive && !style.rejectReason.empty() && style.rejectReason != _contourRejectReason) {
+            Log::Infof("CompositeVectorTileLayer: '%s' contours stay traced geometry: %s",
+                       source.name.c_str(), style.rejectReason.c_str());
+        }
+        _contourRejectReason = style.rejectReason;
+
+        // The traced geometry and the painted bands are the same lines: exactly one of them draws.
+        // With the bands on, the source only has to emit the label stubs the text rules need.
+        childLayer->setTerrainContourPaint(classes);
+        contourSource->setLabelStubsEnabled(!classes.empty());
+    }
+
     bool CompositeVectorTileLayer::renderComposite(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState, bool terrain) {
         auto decoder = std::dynamic_pointer_cast<MBVectorTileDecoder>(getTileDecoder());
 
@@ -839,6 +914,7 @@ namespace carto {
                 continue;
             }
             bool visible = true;
+            applyContourPaint(*source, decoder, viewState);
             // Raster/hillshade children are gated by their config symbolizer's zoom/nuti visibility.
             // Vector children have no config symbolizer (they are styled by normal line/text rules,
             // which the child's own decode already zoom-filters), so they always draw.

--- a/all/native/layers/CompositeVectorTileLayer.h
+++ b/all/native/layers/CompositeVectorTileLayer.h
@@ -19,6 +19,7 @@
 namespace carto {
     class TileDataSource;
     class VectorTileDecoder;
+    class MBVectorTileDecoder;
     class ElevationDecoder;
     namespace mvt { struct ResolvedLayerConfig; }
 
@@ -197,6 +198,13 @@ namespace carto {
             bool maxOverzoomLevelSet = false;
             int maxOverzoomLevel = 0;
         };
+
+        // Picks the shader contours over the traced ones for a contour slot when the style's line
+        // rules can be painted as elevation bands, and keeps the source's label stubs in step.
+        static bool shaderContoursAllowed();
+        void applyContourPaint(const ExternalSource& source, const std::shared_ptr<MBVectorTileDecoder>& decoder, const ViewState& viewState);
+        std::string _contourRejectReason; // logged once, on change
+
 
         // One ordered draw step after the layer's own group-0 render: either an external
         // raster/hillshade child, or an internal VectorTileLayer rendering a later style-layer

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -1038,15 +1038,17 @@ namespace carto {
         // value pushed before it existed would be lost, with the paint silently never drawing.
         bool changed = (classes != _contourPaintClasses);
         _contourPaintClasses = classes;
+        // The bands are composited into the ground/drape surface pass that already runs, which is
+        // where tangram computes them too - an extra pass of their own measured a third SLOWER
+        // than the traced geometry they replace (docs/rendering/07-hillshade-contours.md).
         _tileRenderer->setContourClasses(_contourPaintClasses);
-        // The paint carries nothing but the contours: opacity 0 makes the shading it would
-        // otherwise compute transparent, and the bands composite over it. alwaysSurface keeps it
-        // a screen-resolution pass whatever the fills do with the drape.
-        _tileRenderer->setTerrainPaint(!_contourPaintClasses.empty(), false, 1.0f, false, false, 0.0f, 0.0f,
-                                       contourPaintFingerprint(), true);
         if (changed) {
             redraw();
         }
+    }
+
+    void TileLayer::setContourBandsForSurface(const std::vector<ContourClass>& classes) {
+        _tileRenderer->setContourClasses(classes);
     }
 
     bool TileLayer::isTerrainContourPaintActive() const {

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -1033,6 +1033,41 @@ namespace carto {
         _tileRenderer->setTerrainPaintTiles(tileIds);
     }
 
+    void TileLayer::setTerrainContourPaint(const std::vector<ContourClass>& classes) {
+        // Re-applied every frame, not only on a change: the vt renderer is created lazily and a
+        // value pushed before it existed would be lost, with the paint silently never drawing.
+        bool changed = (classes != _contourPaintClasses);
+        _contourPaintClasses = classes;
+        _tileRenderer->setContourClasses(_contourPaintClasses);
+        // The paint carries nothing but the contours: opacity 0 makes the shading it would
+        // otherwise compute transparent, and the bands composite over it. alwaysSurface keeps it
+        // a screen-resolution pass whatever the fills do with the drape.
+        _tileRenderer->setTerrainPaint(!_contourPaintClasses.empty(), false, 1.0f, false, false, 0.0f, 0.0f,
+                                       contourPaintFingerprint(), true);
+        if (changed) {
+            redraw();
+        }
+    }
+
+    bool TileLayer::isTerrainContourPaintActive() const {
+        return !_contourPaintClasses.empty();
+    }
+
+    std::size_t TileLayer::contourPaintFingerprint() const {
+        // A paint has no per-tile fingerprint: its appearance rides the drape stack signature, so
+        // every value the bands are drawn with has to land in here (see drapeStackSignature).
+        std::size_t fingerprint = 0;
+        auto mix = [&fingerprint](std::size_t value) {
+            fingerprint ^= value + 0x9e3779b9 + (fingerprint << 6) + (fingerprint >> 2);
+        };
+        for (const ContourClass& contourClass : _contourPaintClasses) {
+            mix(std::hash<float>()(contourClass.interval));
+            mix(std::hash<float>()(contourClass.halfWidth));
+            mix(static_cast<std::size_t>(contourClass.color.getARGB()));
+        }
+        return fingerprint;
+    }
+
     std::size_t TileLayer::drapeStackSignature() const {
         return static_cast<std::size_t>(reinterpret_cast<std::uintptr_t>(this));
     }

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -1051,25 +1051,6 @@ namespace carto {
         _tileRenderer->setContourClasses(classes);
     }
 
-    bool TileLayer::isTerrainContourPaintActive() const {
-        return !_contourPaintClasses.empty();
-    }
-
-    std::size_t TileLayer::contourPaintFingerprint() const {
-        // A paint has no per-tile fingerprint: its appearance rides the drape stack signature, so
-        // every value the bands are drawn with has to land in here (see drapeStackSignature).
-        std::size_t fingerprint = 0;
-        auto mix = [&fingerprint](std::size_t value) {
-            fingerprint ^= value + 0x9e3779b9 + (fingerprint << 6) + (fingerprint >> 2);
-        };
-        for (const ContourClass& contourClass : _contourPaintClasses) {
-            mix(std::hash<float>()(contourClass.interval));
-            mix(std::hash<float>()(contourClass.halfWidth));
-            mix(static_cast<std::size_t>(contourClass.color.getARGB()));
-        }
-        return fingerprint;
-    }
-
     std::size_t TileLayer::drapeStackSignature() const {
         return static_cast<std::size_t>(reinterpret_cast<std::uintptr_t>(this));
     }

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -439,6 +439,13 @@ namespace carto {
          */
         void setTerrainContourPaint(const std::vector<ContourClass>& classes);
         bool isTerrainContourPaintActive() const;
+        const std::vector<ContourClass>& getTerrainContourClasses() const { return _contourPaintClasses; }
+        /**
+         * Pushes contour classes to THIS layer's renderer without adopting them: the bands are
+         * composited by whichever layer draws the terrain surface, which is not the layer whose
+         * style they came from.
+         */
+        void setContourBandsForSurface(const std::vector<ContourClass>& classes);
         std::size_t contourPaintFingerprint() const;
 
         bool prepareTerrainDrapeFrame(float deltaSeconds, const ViewState& viewState);

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -14,6 +14,7 @@
 #include "components/DirectorPtr.h"
 #include "datasources/TileDataSource.h"
 #include "layers/Layer.h"
+#include "renderers/ContourClass.h"
 
 #include <vt/TileId.h>
 
@@ -422,10 +423,23 @@ namespace carto {
         // EVERY tile of the shared drape and reports none of them. The owner needs both facts - a
         // stack of nothing but such layers has to be given the terrain's own cover, and every tile
         // of that cover must expect this layer's content or a tile baked without it looks finished.
-        virtual bool paintsEveryDrapeTile() const { return false; }
+        virtual bool paintsEveryDrapeTile() const { return _contourPaintClasses.empty() ? false : true; }
         // The terrain cover a paint layer draws itself on when nothing bakes it. Ignored by
         // layers that are not paints.
         virtual void setTerrainPaintTiles(const std::vector<vt::TileId>& tileIds);
+
+        /**
+         * Draws this layer's contour lines as elevation bands on the terrain instead of as
+         * geometry: one class per elevation divisor, evaluated from the style every frame
+         * (mvt::resolveContourStyle). An empty list turns it off, which is what a style the
+         * shader cannot express falls back to.
+         *
+         * The paint always draws as a SURFACE pass, at this layer's place in the order, and is
+         * never baked into the drape - a contour is a hairline and a bake resamples it.
+         */
+        void setTerrainContourPaint(const std::vector<ContourClass>& classes);
+        bool isTerrainContourPaintActive() const;
+        std::size_t contourPaintFingerprint() const;
 
         bool prepareTerrainDrapeFrame(float deltaSeconds, const ViewState& viewState);
         void setExternalDrapeTarget(bool enabled);
@@ -457,7 +471,10 @@ namespace carto {
         std::shared_ptr<DataSourceListener> _dataSourceListener;
 
         std::shared_ptr<TileRenderer> _tileRenderer;
-    
+        // Non-empty while the contours of this layer are painted per fragment instead of drawn as
+        // geometry (see setTerrainContourPaint).
+        std::vector<ContourClass> _contourPaintClasses;
+
         FetchingTileTasks _fetchingTileTasks;
         
     private:

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -423,7 +423,11 @@ namespace carto {
         // EVERY tile of the shared drape and reports none of them. The owner needs both facts - a
         // stack of nothing but such layers has to be given the terrain's own cover, and every tile
         // of that cover must expect this layer's content or a tile baked without it looks finished.
-        virtual bool paintsEveryDrapeTile() const { return _contourPaintClasses.empty() ? false : true; }
+        // Contour classes are NOT this: they are composited into the surface pass and bake nothing,
+        // so a layer carrying them is still an ordinary tile layer. Claiming otherwise took its
+        // tiles out of the completeness mask and re-baked the whole drape every frame - measured on
+        // a Crosscall, 96 bakes per interval against 21 and 31.4M indices against 15.4M.
+        virtual bool paintsEveryDrapeTile() const { return false; }
         // The terrain cover a paint layer draws itself on when nothing bakes it. Ignored by
         // layers that are not paints.
         virtual void setTerrainPaintTiles(const std::vector<vt::TileId>& tileIds);
@@ -434,11 +438,10 @@ namespace carto {
          * (mvt::resolveContourStyle). An empty list turns it off, which is what a style the
          * shader cannot express falls back to.
          *
-         * The paint always draws as a SURFACE pass, at this layer's place in the order, and is
+         * The bands are composited into the surface pass that draws the ground anyway and are
          * never baked into the drape - a contour is a hairline and a bake resamples it.
          */
         void setTerrainContourPaint(const std::vector<ContourClass>& classes);
-        bool isTerrainContourPaintActive() const;
         const std::vector<ContourClass>& getTerrainContourClasses() const { return _contourPaintClasses; }
         /**
          * Pushes contour classes to THIS layer's renderer without adopting them: the bands are
@@ -446,7 +449,6 @@ namespace carto {
          * style they came from.
          */
         void setContourBandsForSurface(const std::vector<ContourClass>& classes);
-        std::size_t contourPaintFingerprint() const;
 
         bool prepareTerrainDrapeFrame(float deltaSeconds, const ViewState& viewState);
         void setExternalDrapeTarget(bool enabled);

--- a/all/native/layers/VectorLayer.cpp
+++ b/all/native/layers/VectorLayer.cpp
@@ -683,20 +683,30 @@ namespace carto {
             return false;
         }
 
-        // Warm up the elevation grid cache over the visible area (this runs on a background
+        // Warm up the elevation grid cache where the elements ARE (this runs on a background
         // thread and may block on IO): element draw data is then built with complete heights
         // in one pass, avoiding transient half-draped geometry (e.g. near-vertical line
         // segments between vertices with and without loaded elevation data).
+        // Sampling the visible ENVELOPE instead is what this used to do, and in terrain mode the
+        // envelope reaches the view distance: its corners are hundreds of km away, off the DEM
+        // coverage, so every fetch task blocked on ~15 elevation tile requests that could only
+        // fail (measured on a Crosscall: 15 failing HTTP round trips per startup, re-issued
+        // whenever the failure markers expired).
         if (auto options = layer->getOptions()) {
             if (auto terrainOptions = options->getTerrainOptions()) {
                 if (terrainOptions->isEnabled() && !isCanceled()) {
                     const std::shared_ptr<ElevationManager>& elevationManager = terrainOptions->getElevationManager();
-                    const MapBounds& bounds = cullState->getEnvelope().getBounds();
-                    for (int yi = 0; yi <= 3; yi++) {
-                        for (int xi = 0; xi <= 3; xi++) {
-                            double x = bounds.getMin().getX() + (bounds.getMax().getX() - bounds.getMin().getX()) * xi / 3.0;
-                            double y = bounds.getMin().getY() + (bounds.getMax().getY() - bounds.getMin().getY()) * yi / 3.0;
-                            elevationManager->getElevationMeters(x, y, ElevationManager::LoadMode::ALLOW_LOAD);
+                    std::shared_ptr<Projection> projection = layer->_dataSource->getProjection();
+                    for (const std::shared_ptr<VectorElement>& element : vectorData->getElements()) {
+                        if (isCanceled()) {
+                            break;
+                        }
+                        MapBounds bounds = element->getBounds();
+                        for (int i = 0; i < 4; i++) {
+                            MapPos pos((i & 1) ? bounds.getMax().getX() : bounds.getMin().getX(),
+                                       (i & 2) ? bounds.getMax().getY() : bounds.getMin().getY());
+                            MapPos internalPos = projection->toInternal(pos);
+                            elevationManager->getElevationMeters(internalPos.getX(), internalPos.getY(), ElevationManager::LoadMode::ALLOW_LOAD);
                         }
                     }
                 }

--- a/all/native/renderers/ContourClass.h
+++ b/all/native/renderers/ContourClass.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_CONTOURCLASS_H_
+#define _CARTO_CONTOURCLASS_H_
+
+#include "graphics/Color.h"
+
+namespace carto {
+
+    /**
+     * One elevation class of the contour lines drawn per fragment on the terrain: the lines whose
+     * height is a multiple of 'interval', in this colour and width. A style layer resolves to a
+     * list of them (mvt::resolveContourStyle), a HillshadeRasterTileLayer configures a single one.
+     * Internal class, not exposed in the public API.
+     */
+    struct ContourClass {
+        float interval = 0.0f;   // metres between the lines of the class
+        Color color;             // straight colour, opacity in the alpha channel
+        float halfWidth = 0.0f;  // half stroke width, screen pixels
+
+        bool operator == (const ContourClass& other) const {
+            return interval == other.interval && halfWidth == other.halfWidth && color == other.color;
+        }
+        bool operator != (const ContourClass& other) const { return !(*this == other); }
+    };
+
+}
+
+#endif

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -2277,6 +2277,16 @@ namespace carto {
                                 break;
                             }
                         }
+                        {
+                            std::vector<ContourClass> contourBands;
+                            for (const std::shared_ptr<TileLayer>& tileLayer : groundLayers) {
+                                if (!tileLayer->getTerrainContourClasses().empty()) {
+                                    contourBands = tileLayer->getTerrainContourClasses();
+                                    break;
+                                }
+                            }
+                            groundDrawer->setContourBandsForSurface(contourBands);
+                        }
                         int groundDraws = groundDrawer->renderTerrainGround(groundColor);
                         FRAME_PROF_ADD(drapeMs, profGroundStart);
                         FRAME_PROF_GPU_END();
@@ -2896,6 +2906,18 @@ namespace carto {
                     glDepthFunc(GL_LEQUAL);
                     glDepthMask(GL_TRUE);
                     glDisable(GL_CULL_FACE); // displaced surfaces can face away near ridge crests
+                    // The contour bands belong to the layer whose STYLE they came from, but they
+                    // are composited by the layer that draws the surface - hand them over.
+                    {
+                        std::vector<ContourClass> contourBands;
+                        for (const std::shared_ptr<TileLayer>& tileLayer : drapeLayers) {
+                            if (!tileLayer->getTerrainContourClasses().empty()) {
+                                contourBands = tileLayer->getTerrainContourClasses();
+                                break;
+                            }
+                        }
+                        drapeLayers.front()->setContourBandsForSurface(contourBands);
+                    }
                     for (auto it = drapedTiles.begin(); it != drapedTiles.end(); it++) {
                         // Every drape tile gets a surface, always. The surface is the terrain's
                         // only depth writer, so a tile skipped because its bake has not landed

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1990,7 +1990,7 @@ namespace carto {
                     }
 
                     // Camera terrain-following. The clearance is expressed as a BOUND on the
-                    // zoom (ViewState::setTerrainMinCameraZ -> getTerrainMaxZoom), which every
+                    // zoom (ViewState::setTerrainCameraReference -> getTerrainMaxZoom), which every
                     // zoom path clamps against, rather than as a corrective zoom-out issued
                     // after the camera has already broken through. A corrective event fights
                     // whatever is driving the camera down - the pinch gesture, the double-tap
@@ -2013,7 +2013,7 @@ namespace carto {
                         double minCameraZ = terrainZ + cameraClearance * elevationManager->getDisplayScale(cameraPos(1));
                         {
                             std::lock_guard<std::recursive_mutex> lock(_mutex);
-                            _viewState.setTerrainMinCameraZ(minCameraZ);
+                            _viewState.setTerrainCameraReference(terrainZ, minCameraZ);
                         }
                         // The correction has to LAND on the shell, and it has to have a dead band.
                         // Zooming out scales the camera-to-focus vector, so the camera height it
@@ -2046,7 +2046,7 @@ namespace carto {
                         }
                     } else {
                         std::lock_guard<std::recursive_mutex> lock(_mutex);
-                        _viewState.setTerrainMinCameraZ(0);
+                        _viewState.setTerrainCameraReference(0, 0);
                     }
                 }
             }
@@ -2058,7 +2058,7 @@ namespace carto {
                 }
             }
             std::lock_guard<std::recursive_mutex> lock(_mutex);
-            _viewState.setTerrainMinCameraZ(0); // release the terrain zoom bound
+            _viewState.setTerrainCameraReference(0, 0); // release the terrain zoom bound
         }
 
         // Cross-layer terrain draping. Every drapeable tile layer bakes into ONE texture per

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -499,7 +499,7 @@ namespace carto {
         }
     }
 
-    void TileRenderer::setTerrainPaint(bool enabled, bool fullDetail, float heightScale, bool exaggerateHeightScale, bool legacyHeightScale, float contrast, float opacity, std::size_t fingerprint) {
+    void TileRenderer::setTerrainPaint(bool enabled, bool fullDetail, float heightScale, bool exaggerateHeightScale, bool legacyHeightScale, float contrast, float opacity, std::size_t fingerprint, bool alwaysSurface) {
         std::lock_guard<std::mutex> lock(_mutex);
 
         _terrainPaintEnabled = enabled;
@@ -513,6 +513,7 @@ namespace carto {
             paint.contrast = contrast;
             paint.opacity = opacity;
             paint.fingerprint = fingerprint;
+            paint.alwaysSurface = alwaysSurface;
             tileRenderer->setTerrainPaint(paint);
             tileRenderer->setTerrainPaintOnGround(isTerrainPaintOnGroundForced());
             tileRenderer->setTerrainDemTaps(terrainDemTaps());

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -181,6 +181,58 @@ namespace carto {
         std::lock_guard<std::mutex> lock(_mutex);
         _normalMapContourWidth = width;
     }
+    void TileRenderer::setContourClasses(const std::vector<ContourClass>& classes) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _contourClasses = classes;
+        if (_contourClasses.size() > MAX_CONTOUR_CLASSES) {
+            // Finest first, and the fine ones are the ones that merge into a wash when there are
+            // too many of them - so an over-long list loses its finest classes, not its index lines.
+            _contourClasses.erase(_contourClasses.begin(), _contourClasses.begin() + (_contourClasses.size() - MAX_CONTOUR_CLASSES));
+        }
+    }
+    void TileRenderer::uploadContourClasses(unsigned int shaderProgram) const {
+        std::array<float, MAX_CONTOUR_CLASSES * 4> colors = { };
+        std::array<float, MAX_CONTOUR_CLASSES> intervals = { };
+        std::array<float, MAX_CONTOUR_CLASSES> halfWidths = { };
+        std::size_t count = 0;
+        auto add = [&](float interval, const Color& color, float halfWidth) {
+            if (!(interval > 0.0f) || !(halfWidth > 0.0f) || color.getA() == 0 || count >= MAX_CONTOUR_CLASSES) {
+                return;
+            }
+            colors[count * 4 + 0] = color.getR() / 255.0f;
+            colors[count * 4 + 1] = color.getG() / 255.0f;
+            colors[count * 4 + 2] = color.getB() / 255.0f;
+            colors[count * 4 + 3] = color.getA() / 255.0f;
+            intervals[count] = interval;
+            halfWidths[count] = halfWidth;
+            count++;
+        };
+        if (_contourClasses.empty()) {
+            add(_normalMapContourInterval, _normalMapContourColor, _normalMapContourWidth);
+        } else {
+            for (const ContourClass& contourClass : _contourClasses) {
+                add(contourClass.interval, contourClass.color, contourClass.halfWidth);
+            }
+        }
+        // getUniformLoc returns 0 for a uniform the compiler dropped, and 0 is a valid location.
+        GLint colorsLoc = glGetUniformLocation(shaderProgram, "u_contourColors");
+        GLint intervalsLoc = glGetUniformLocation(shaderProgram, "u_contourIntervals");
+        GLint halfWidthsLoc = glGetUniformLocation(shaderProgram, "u_contourHalfWidths");
+        GLint countLoc = glGetUniformLocation(shaderProgram, "u_contourClassCount");
+        if (colorsLoc >= 0) {
+            glUniform4fv(colorsLoc, static_cast<GLsizei>(MAX_CONTOUR_CLASSES), colors.data());
+        }
+        if (intervalsLoc >= 0) {
+            glUniform1fv(intervalsLoc, static_cast<GLsizei>(MAX_CONTOUR_CLASSES), intervals.data());
+        }
+        if (halfWidthsLoc >= 0) {
+            glUniform1fv(halfWidthsLoc, static_cast<GLsizei>(MAX_CONTOUR_CLASSES), halfWidths.data());
+        }
+        if (countLoc >= 0) {
+            glUniform1f(countLoc, static_cast<float>(count));
+        }
+    }
+
     void TileRenderer::setNormalIlluminationDirection(MapVec direction) {
         std::lock_guard<std::mutex> lock(_mutex);
         _normalIlluminationDirection = direction;
@@ -1394,9 +1446,7 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
                     glUniform1f(glGetUniformLocation(shaderProgram, "u_elevationEncoded"), _normalMapElevationEncoded ? 1.0f : 0.0f);
                     glUniform2f(glGetUniformLocation(shaderProgram, "u_elevationDecode"), vt::NormalMapBuilder::ELEVATION_SCALE, vt::NormalMapBuilder::ELEVATION_OFFSET);
                     glUniform1f(glGetUniformLocation(shaderProgram, "u_contrast"), _hillshadeIntensity);
-                    glUniform4f(glGetUniformLocation(shaderProgram, "u_contourColor"), _normalMapContourColor.getR() / 255.0f, _normalMapContourColor.getG() / 255.0f, _normalMapContourColor.getB() / 255.0f, _normalMapContourColor.getA() / 255.0f);
-                    glUniform1f(glGetUniformLocation(shaderProgram, "u_contourInterval"), _normalMapContourInterval);
-                    glUniform1f(glGetUniformLocation(shaderProgram, "u_contourWidth"), _normalMapContourWidth);
+                    uploadContourClasses(shaderProgram);
                     // Current fractional map zoom, for per-zoom custom normal-map shaders (getMapZoom()).
                     glUniform1f(glGetUniformLocation(shaderProgram, "u_zoom"), viewState.zoom);
             });

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -196,6 +196,13 @@ namespace carto {
                 bands.push_back(band);
             }
             tileRenderer->setContourBands(bands);
+#ifdef __ANDROID__
+            static const bool muted = [] {
+                char property[PROP_VALUE_MAX] = { 0 };
+                return __system_property_get("debug.carto.contourmute", property) > 0 && std::atoi(property) != 0;
+            }();
+            tileRenderer->setContourBandsMuted(muted);
+#endif
         }
         if (_contourClasses.size() > MAX_CONTOUR_CLASSES) {
             // Finest first, and the fine ones are the ones that merge into a wash when there are

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -184,6 +184,19 @@ namespace carto {
     void TileRenderer::setContourClasses(const std::vector<ContourClass>& classes) {
         std::lock_guard<std::mutex> lock(_mutex);
         _contourClasses = classes;
+        if (std::shared_ptr<vt::GLTileRenderer> tileRenderer = (_vtRenderer ? _vtRenderer->getTileRenderer() : std::shared_ptr<vt::GLTileRenderer>())) {
+            std::vector<vt::GLTileRenderer::ContourBand> bands;
+            bands.reserve(classes.size());
+            for (const ContourClass& contourClass : classes) {
+                vt::GLTileRenderer::ContourBand band;
+                band.interval = contourClass.interval;
+                band.color = vt::Color(contourClass.color.getR() / 255.0f, contourClass.color.getG() / 255.0f,
+                                       contourClass.color.getB() / 255.0f, contourClass.color.getA() / 255.0f);
+                band.halfWidth = contourClass.halfWidth;
+                bands.push_back(band);
+            }
+            tileRenderer->setContourBands(bands);
+        }
         if (_contourClasses.size() > MAX_CONTOUR_CLASSES) {
             // Finest first, and the fine ones are the ones that merge into a wash when there are
             // too many of them - so an over-long list loses its finest classes, not its index lines.

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -8,6 +8,7 @@
 #define _CARTO_TILERENDERER_H_
 
 #include "graphics/Color.h"
+#include "renderers/ContourClass.h"
 #include "components/StyleEnvironment.h"
 #include "graphics/ViewState.h"
 #include "renderers/utils/GLResource.h"
@@ -45,17 +46,6 @@ namespace carto {
     
     class TileRenderer {
     public:
-        /**
-         * One elevation class of the contour lines drawn per fragment: the lines whose height is
-         * a multiple of 'interval', in this colour and width. A style layer resolves to a list of
-         * them (mvt::resolveContourStyle); a HillshadeRasterTileLayer configures a single one.
-         */
-        struct ContourClass {
-            float interval = 0.0f;   // metres between the lines of the class
-            Color color;             // straight colour, opacity in the alpha channel
-            float halfWidth = 0.0f;  // half stroke width, screen pixels
-        };
-
         TileRenderer();
         virtual ~TileRenderer();
     
@@ -155,7 +145,10 @@ namespace carto {
         // textures survive a parameter change.
         // The terrain tiles a paint draws itself on when there is no drape to bake into.
         void setTerrainPaintTiles(const std::vector<vt::TileId>& tileIds);
-        void setTerrainPaint(bool enabled, bool fullDetail, float heightScale, bool exaggerateHeightScale, bool legacyHeightScale, float contrast, float opacity, std::size_t fingerprint);
+        // 'alwaysSurface' draws the paint as a terrain surface pass at this layer's place in the
+        // order even when the fills are draped, and keeps it out of the bake - what a hairline
+        // needs (see vt::GLTileRenderer::TerrainPaint::alwaysSurface).
+        void setTerrainPaint(bool enabled, bool fullDetail, float heightScale, bool exaggerateHeightScale, bool legacyHeightScale, float contrast, float opacity, std::size_t fingerprint, bool alwaysSurface = false);
 
         bool onDrawFrame(float deltaSeconds, const ViewState& viewState);
         bool onDrawFrame3D(float deltaSeconds, const ViewState& viewState);

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -45,6 +45,17 @@ namespace carto {
     
     class TileRenderer {
     public:
+        /**
+         * One elevation class of the contour lines drawn per fragment: the lines whose height is
+         * a multiple of 'interval', in this colour and width. A style layer resolves to a list of
+         * them (mvt::resolveContourStyle); a HillshadeRasterTileLayer configures a single one.
+         */
+        struct ContourClass {
+            float interval = 0.0f;   // metres between the lines of the class
+            Color color;             // straight colour, opacity in the alpha channel
+            float halfWidth = 0.0f;  // half stroke width, screen pixels
+        };
+
         TileRenderer();
         virtual ~TileRenderer();
     
@@ -69,6 +80,14 @@ namespace carto {
         void setNormalMapContourInterval(float interval);
         void setNormalMapContourColor(const Color& color);
         void setNormalMapContourWidth(float width);
+        /**
+         * Sets the contour classes drawn per fragment, finest interval first. An empty list falls
+         * back to the single class the setNormalMapContour* values describe. Called every frame by
+         * the layer that owns the contours, because a class is the style's line rule evaluated at
+         * the current zoom and nuti parameter state.
+         */
+        void setContourClasses(const std::vector<ContourClass>& classes);
+        static constexpr std::size_t MAX_CONTOUR_CLASSES = 6; // CONTOUR_CLASSES in GLTileRendererShaders.h
         void setNormalIlluminationMapRotationEnabled(bool enabled);
         void setNormalIlluminationDirection(MapVec direction);
         void setHillshadeMethod(int method);
@@ -160,6 +179,8 @@ namespace carto {
         struct LabelOcclusionState;
 
         bool initializeRenderer();
+        // Pushes the contour classes (or the single layer-configured one) into the shader.
+        void uploadContourClasses(unsigned int shaderProgram) const;
         bool isPlanarTerrainMode() const;
         bool isPlanarProjectionMode() const;
         // Tangram-model measurement switch, read once from debug.carto.depthshift (Android only).
@@ -223,6 +244,10 @@ namespace carto {
         float _normalMapContourInterval = 0.0f; // meters; <= 0 disables contour lines
         Color _normalMapContourColor;
         float _normalMapContourWidth = 0.75f; // contour half-width in screen pixels
+        // Style-driven contour classes (one per elevation divisor, finest first). When this is
+        // non-empty it REPLACES the three values above: they are the single-class case a
+        // HillshadeRasterTileLayer configures by hand, and the shader only knows the classes.
+        std::vector<ContourClass> _contourClasses;
         std::optional<std::regex> _rendererLayerFilter;
         std::optional<std::regex> _clickHandlerLayerFilter;
 

--- a/all/native/renderers/cameraevents/CameraZoomEvent.cpp
+++ b/all/native/renderers/cameraevents/CameraZoomEvent.cpp
@@ -99,8 +99,14 @@ namespace carto {
         // Clamping the REQUESTED zoom makes the gesture come to rest against the terrain;
         // letting it through and correcting the camera afterwards makes the two fight
         // every frame, which is what made zooming jump back and forth.
+        // The terrain bound STOPS a zoom in; it never drives a zoom OUT from here. Clamping a
+        // zoom-in request to below the current zoom - which happens whenever the camera is already
+        // inside the clearance shell - scales the map about the PIVOT, and with the pivot under the
+        // fingers that throws the map sideways: the pinch that jumps somewhere else. Getting back
+        // onto the shell is MapRenderer's per-frame correction, which zooms about the focus and so
+        // moves nothing sideways.
         MapRange zoomRange = options.getZoomRange();
-        float maxZoom = std::min(zoomRange.getMax(), viewState.getTerrainMaxZoom());
+        float maxZoom = std::min(zoomRange.getMax(), std::max(viewState.getTerrainMaxZoom(), viewState.getZoom()));
         float zoom = GeneralUtils::Clamp(viewState.getZoom() + _zoomDelta, viewState.getMinZoom(), maxZoom);
         double scale = std::pow(2.0f, viewState.getZoom() - zoom);
         cglib::mat4x4<double> shiftTransform = projectionSurface->calculateTranslateMatrix(focusPos, targetPos, 1.0 - scale);

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -19,6 +19,17 @@
 namespace carto {
 
     static const std::size_t DEFAULT_CACHE_CAPACITY = 64 * 1024 * 1024;
+    // Grids the cache must hold whatever the source resolution is. A fixed byte budget is really a
+    // tile budget the DEM raster size decides: a 512x512 RGB source is 768 KB per grid, so 64 MB
+    // is 85 grids - while one terrain view asked for 122-167 distinct grids (the cover pyramid,
+    // TileLayer::TERRAIN_COVER_TILE_BUDGET tiles collapsing onto ~160 DEM tiles once clamped, plus
+    // the contour source's finer tiles and the border prefetch). Every grid past the limit evicted
+    // one still in use and was decoded again on the next pass. Measured on a Crosscall at the demo
+    // camera, per startup: 85 grids = 1525 loads of 167 tiles and 32 s of WEBP decode, 128 grids =
+    // 189 loads of 157, 192 grids = 157 loads of 157 and 3.1 s of decode.
+    // An app that cannot spend the memory (144 MB here, 36 MB for a 256x256 source) sets its own
+    // number with TerrainOptions::setElevationCacheCapacity, which then wins over this rule.
+    static const std::size_t MIN_CACHED_GRIDS = 192;
     static const int FAILED_TILE_TTL_MILLISECONDS = 30 * 1000;
     static const int MAX_ANCESTOR_SEARCH_DEPTH = 8;
     static const std::size_t MAX_PREFETCH_QUEUE_SIZE = 64;
@@ -141,6 +152,7 @@ namespace carto {
 
     void ElevationManager::setCacheCapacity(std::size_t capacityInBytes) {
         std::lock_guard<std::mutex> lock(_mutex);
+        _gridCacheCapacityFixed = true;
         _gridCache.resize(capacityInBytes);
     }
 
@@ -316,6 +328,16 @@ namespace carto {
         {
             std::lock_guard<std::mutex> lock(_mutex);
             if (grid) {
+                // Grow the budget to the source's own grid size before inserting, so the cache is
+                // a tile count rather than a byte count the raster resolution decides (see
+                // MIN_CACHED_GRIDS). Only ever grows, and a caller that set its own capacity keeps it.
+                std::size_t minCapacity = grid->getDataSize() * MIN_CACHED_GRIDS;
+                if (!_gridCacheCapacityFixed && _gridCache.capacity() < minCapacity) {
+                    Log::Infof("ElevationManager: elevation grid cache %d -> %d MB (%d grids of %d KB)",
+                               static_cast<int>(_gridCache.capacity() >> 20), static_cast<int>(minCapacity >> 20),
+                               static_cast<int>(MIN_CACHED_GRIDS), static_cast<int>(grid->getDataSize() >> 10));
+                    _gridCache.resize(minCapacity);
+                }
                 _gridCache.put(grid->getTile().getTileId(), grid, grid->getDataSize());
                 if (grid->getTile() != tile) {
                     // Loaded an ancestor (replace-with-parent); also mark the requested tile as resolved via ancestor

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -258,6 +258,7 @@ namespace carto {
         mutable unsigned int _changeLogFirstVersion = 1; // earliest version still covered by the log
 
         mutable cache::timed_lru_cache<long long, std::shared_ptr<ElevationTileGrid> > _gridCache;
+        bool _gridCacheCapacityFixed = false; // set through setCacheCapacity: the app's number wins over the grid-count rule
         mutable std::map<long long, std::shared_future<std::shared_ptr<ElevationTileGrid> > > _pendingLoads; // single-flight de-duplication of concurrent loads
         mutable std::mutex _mutex;
 

--- a/all/native/ui/TouchHandler.cpp
+++ b/all/native/ui/TouchHandler.cpp
@@ -277,20 +277,17 @@ namespace carto {
             _mapRenderer->getAnimationHandler().stopTilt();
             _mapRenderer->getAnimationHandler().stopZoom();
             
-            if (_options->getPivotMode() != PivotMode::PIVOT_MODE_TOUCHPOINT || isValidScreenPosition(screenPos, viewState)) {
-                updateGestureAnchorHeight(screenPos, viewState);
-                MapPos targetPos = (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT ? mapScreenPosition(screenPos, viewState) : projectionSurface->calculateMapPos(viewState.getFocusPos()));
+            updateGestureAnchorHeight(screenPos, viewState);
 
-                CameraZoomEvent cameraZoomTargetEvent;
-                cameraZoomTargetEvent.setZoomDelta(delta * WHEEL_TICK_TO_ZOOM_DELTA);
-                cameraZoomTargetEvent.setTargetPos(targetPos);
-                _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, 0, true);
+            CameraZoomEvent cameraZoomTargetEvent;
+            cameraZoomTargetEvent.setZoomDelta(delta * WHEEL_TICK_TO_ZOOM_DELTA);
+            cameraZoomTargetEvent.setTargetPos(calculatePivotPos(screenPos, viewState));
+            _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, 0, true);
 
-                DirectorPtr<MapEventListener> mapEventListener = _mapEventListener;
+            DirectorPtr<MapEventListener> mapEventListener = _mapEventListener;
 
-                if (mapEventListener) {
-                    mapEventListener->onMapInteraction(std::make_shared<MapInteractionInfo>(false, true, false, false));
-                }
+            if (mapEventListener) {
+                mapEventListener->onMapInteraction(std::make_shared<MapInteractionInfo>(false, true, false, false));
             }
         }
     }
@@ -354,76 +351,103 @@ namespace carto {
     
     void TouchHandler::singlePointerPan(const ScreenPos& screenPos, const ViewState& viewState) {
         if (_options->isUserInput()) {
-            std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
-            if (!projectionSurface) {
-                return;
-            }
-            
             _mapRenderer->getAnimationHandler().stopPan();
             _mapRenderer->getAnimationHandler().stopRotation();
             _mapRenderer->getAnimationHandler().stopTilt();
             _mapRenderer->getAnimationHandler().stopZoom();
-            
-            double panScale = _panScale.load();
-            if (_options->getPanningSpeedMode() != PanningSpeedMode::PANNING_SPEED_MODE_MAP && panScale > 0) {
-                // The pan travels the SCREEN delta at the scale the gesture started with. Grabbing
-                // the world exactly - the other mode - re-derives that scale from wherever the
-                // finger is now, so a drag that starts near the camera and travels up the screen
-                // speeds up as it goes, which is not something the hand asked for.
-                float dx = screenPos.getX() - _prevScreenPos1.getX();
-                float dy = screenPos.getY() - _prevScreenPos1.getY();
-                _prevScreenPos1 = screenPos;
-                if (dx == 0 && dy == 0) {
-                    return;
-                }
 
-                cglib::vec3<double> focusPos = viewState.getFocusPos();
-                MapPos focusMapPos = projectionSurface->calculateMapPos(focusPos);
-                cglib::vec3<double> normal = projectionSurface->calculateNormal(focusMapPos);
-                // NOT '== 0': looking straight down, this cross product is meant to collapse and
-                // hand over to the up vector - but a tilt REACHED BY GESTURE is vertical only to
-                // within rounding, so it comes out at ~1e-16 instead of 0, the hand-over is missed,
-                // and unit() then turns pure floating point noise into a unit vector pointing
-                // anywhere. That is a pan that goes sideways when the finger goes up. Setting the
-                // tilt to 90 outright happens to build the camera exactly vertical, which is why
-                // only the gesture shows it.
-                cglib::vec3<double> right = cglib::vector_product(viewState.calculateViewDir(), normal);
-                if (cglib::length(right) < VIEW_AXIS_EPSILON) {
-                    right = cglib::vector_product(viewState.getUpVec(), normal); // straight up or down
-                }
-                if (cglib::length(right) < VIEW_AXIS_EPSILON) {
-                    return;
-                }
-                right = cglib::unit(right);
-                cglib::vec3<double> forward = cglib::vector_product(normal, right);
-                if (cglib::length(forward) < VIEW_AXIS_EPSILON) {
-                    return;
-                }
-                forward = cglib::unit(forward);
-
-                // Dragging the world down brings what was beyond the top edge into view, i.e. the
-                // camera goes forward; dragging it right takes the camera left.
-                cglib::vec3<double> offset = forward * (dy * panScale) + right * (-dx * panScale);
-                CameraPanEvent cameraEvent;
-                cameraEvent.setPosDelta(std::make_pair(focusMapPos, projectionSurface->calculateMapPos(focusPos + offset)));
-                _cameraEvents |= CAMERA_PAN;
-                _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
-                return;
-            }
-
-            if (isValidScreenPosition(screenPos, viewState) && isValidScreenPosition(_prevScreenPos1, viewState)) {
-                MapPos currentPos = mapScreenPosition(screenPos, viewState);
-                MapPos prevPos = mapScreenPosition(_prevScreenPos1, viewState);
-
-                CameraPanEvent cameraEvent;
-                cameraEvent.setPosDelta(std::make_pair(currentPos, prevPos));
-                _cameraEvents |= CAMERA_PAN;
-                _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
-            }
+            panBetween(_prevScreenPos1, screenPos, viewState);
         }
         _prevScreenPos1 = screenPos;
     }
-    
+
+    /**
+     * Move the map so that what was under prevScreenPos ends up under screenPos - the one pan
+     * both the one-finger drag and the two-finger gesture go through, so they cannot disagree
+     * about the speed mode or about what a grazing ray is allowed to do.
+     */
+    void TouchHandler::panBetween(const ScreenPos& prevScreenPos, const ScreenPos& screenPos, const ViewState& viewState) {
+        std::shared_ptr<ProjectionSurface> projectionSurface = viewState.getProjectionSurface();
+        if (!projectionSurface) {
+            return;
+        }
+
+        float dx = screenPos.getX() - prevScreenPos.getX();
+        float dy = screenPos.getY() - prevScreenPos.getY();
+        if (dx == 0 && dy == 0) {
+            return;
+        }
+
+        double panScale = _panScale.load();
+        if (_options->getPanningSpeedMode() != PanningSpeedMode::PANNING_SPEED_MODE_MAP && panScale > 0) {
+            // The pan travels the SCREEN delta at the scale the gesture started with. Grabbing
+            // the world exactly - the other mode - re-derives that scale from wherever the
+            // finger is now, so a drag that starts near the camera and travels up the screen
+            // speeds up as it goes, which is not something the hand asked for.
+            cglib::vec3<double> focusPos = viewState.getFocusPos();
+            MapPos focusMapPos = projectionSurface->calculateMapPos(focusPos);
+            cglib::vec3<double> normal = projectionSurface->calculateNormal(focusMapPos);
+            // NOT '== 0': looking straight down, this cross product is meant to collapse and
+            // hand over to the up vector - but a tilt REACHED BY GESTURE is vertical only to
+            // within rounding, so it comes out at ~1e-16 instead of 0, the hand-over is missed,
+            // and unit() then turns pure floating point noise into a unit vector pointing
+            // anywhere. That is a pan that goes sideways when the finger goes up. Setting the
+            // tilt to 90 outright happens to build the camera exactly vertical, which is why
+            // only the gesture shows it.
+            cglib::vec3<double> right = cglib::vector_product(viewState.calculateViewDir(), normal);
+            if (cglib::length(right) < VIEW_AXIS_EPSILON) {
+                right = cglib::vector_product(viewState.getUpVec(), normal); // straight up or down
+            }
+            if (cglib::length(right) < VIEW_AXIS_EPSILON) {
+                return;
+            }
+            right = cglib::unit(right);
+            cglib::vec3<double> forward = cglib::vector_product(normal, right);
+            if (cglib::length(forward) < VIEW_AXIS_EPSILON) {
+                return;
+            }
+            forward = cglib::unit(forward);
+
+            // Dragging the world down brings what was beyond the top edge into view, i.e. the
+            // camera goes forward; dragging it right takes the camera left.
+            cglib::vec3<double> offset = forward * (dy * panScale) + right * (-dx * panScale);
+            CameraPanEvent cameraEvent;
+            cameraEvent.setPosDelta(std::make_pair(focusMapPos, projectionSurface->calculateMapPos(focusPos + offset)));
+            _cameraEvents |= CAMERA_PAN;
+            _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
+            return;
+        }
+
+        if (!isValidScreenPosition(screenPos, viewState) || !isValidScreenPosition(prevScreenPos, viewState)) {
+            return;
+        }
+        MapPos currentPos = mapScreenPosition(screenPos, viewState);
+        MapPos prevPos = mapScreenPosition(prevScreenPos, viewState);
+
+        if (viewState.getTilt() < PAN_CLAMP_MAX_TILT) {
+            // Tangram's guard (inputHandler.cpp getTranslation): near the horizon the two rays run
+            // almost parallel to the ground and their hit points fly apart, so a finger travel of a
+            // few pixels comes out as kilometres. Cap the travel at what those pixels are worth at
+            // the map scale - the pan stops grabbing exactly, which is the point.
+            cglib::vec3<double> pos0 = projectionSurface->calculatePosition(currentPos);
+            cglib::vec3<double> pos1 = projectionSurface->calculatePosition(prevPos);
+            double travel = projectionSurface->calculateDistance(pos0, pos1);
+            // What a pixel is worth at the focus - their pixelsPerMeter, which is the map scale
+            // and knows nothing about where on the screen the finger is.
+            double unitsPerPixel = 2.0 * viewState.calculateCameraDistance() * viewState.getTanHalfFOVY() / std::max(1, viewState.getHeight());
+            double limit = std::sqrt(static_cast<double>(dx) * dx + static_cast<double>(dy) * dy) * unitsPerPixel;
+            if (limit > 0 && travel > limit) {
+                cglib::mat4x4<double> transform = projectionSurface->calculateTranslateMatrix(pos0, pos1, limit / travel);
+                prevPos = projectionSurface->calculateMapPos(cglib::transform_point(pos0, transform));
+            }
+        }
+
+        CameraPanEvent cameraEvent;
+        cameraEvent.setPosDelta(std::make_pair(currentPos, prevPos));
+        _cameraEvents |= CAMERA_PAN;
+        _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
+    }
+
     void TouchHandler::singlePointerLook(const ScreenPos& screenPos, const ViewState& viewState) {
         if (_options->isUserInput()) {
             _mapRenderer->getAnimationHandler().stopPan();
@@ -475,18 +499,19 @@ namespace carto {
             _mapRenderer->getAnimationHandler().stopTilt();
             _mapRenderer->getAnimationHandler().stopZoom();
             
-            if (isValidScreenPosition(screenPos, viewState) && isValidScreenPosition(_prevScreenPos1, viewState)) {
-                float dpi = _options->getDPI();
-                cglib::vec2<float> tempSwipe1(screenPos.getX() - _prevScreenPos1.getX(), screenPos.getY() - _prevScreenPos1.getY());
-                _swipe1 += tempSwipe1 * (1.0f / dpi);
+            // No ground hit required: this zoom is a vertical drag about the FOCUS, and gating it
+            // on one killed the gesture wherever the fingers' rays miss - a low camera over
+            // terrain, where the ground under half the screen is past the far plane.
+            float dpi = _options->getDPI();
+            cglib::vec2<float> tempSwipe1(screenPos.getX() - _prevScreenPos1.getX(), screenPos.getY() - _prevScreenPos1.getY());
+            _swipe1 += tempSwipe1 * (1.0f / dpi);
 
-                float delta = INCHES_TO_ZOOM_DELTA * (screenPos.getY() - _prevScreenPos1.getY()) / _options->getDPI();
+            float delta = INCHES_TO_ZOOM_DELTA * (screenPos.getY() - _prevScreenPos1.getY()) / dpi;
 
-                CameraZoomEvent cameraEvent;
-                cameraEvent.setZoomDelta(delta);
-                _cameraEvents |= CAMERA_ZOOM;
-                _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
-            }
+            CameraZoomEvent cameraEvent;
+            cameraEvent.setZoomDelta(delta);
+            _cameraEvents |= CAMERA_ZOOM;
+            _mapRenderer->calculateCameraEvent(cameraEvent, 0, true);
         }
         _prevScreenPos1 = screenPos;
     }
@@ -668,50 +693,47 @@ namespace carto {
             _mapRenderer->getAnimationHandler().stopTilt();
             _mapRenderer->getAnimationHandler().stopZoom();
 
-            if (isValidScreenPosition(screenPos1, viewState) && isValidScreenPosition(_prevScreenPos1, viewState)
-            &&  isValidScreenPosition(screenPos2, viewState) && isValidScreenPosition(_prevScreenPos2, viewState)) {
-                cglib::vec3<double> currentPos1 = projectionSurface->calculatePosition(mapScreenPosition(screenPos1, viewState));
-                cglib::vec3<double> currentPos2 = projectionSurface->calculatePosition(mapScreenPosition(screenPos2, viewState));
-                cglib::vec3<double> currentVec = currentPos2 - currentPos1;
-                double currentDist = projectionSurface->calculateDistance(currentPos1, currentPos2);
-                cglib::mat4x4<double> currentTranslateTransform = projectionSurface->calculateTranslateMatrix(currentPos1, currentPos2, 0.5f);
-                MapPos currentMiddlePos = projectionSurface->calculateMapPos(cglib::transform_point(currentPos1, currentTranslateTransform));
+            // The scale and the angle are what the FINGERS did, taken from the SCREEN - which is
+            // where a pinch and a two-finger turn happen, and how tangram takes them (inputHandler
+            // handlePinchGesture/handleRotateGesture, fed by the platform's gesture detector).
+            // Deriving them from where the two rays meet the ground instead - what this did - hands
+            // a grazing ray straight to the camera: a low camera over terrain puts one finger's hit
+            // kilometres away, so a pinch of a few pixels comes out as a wild zoom or spin, and
+            // where the ray missed the ground altogether the whole gesture was dropped and the map
+            // could not be zoomed at all.
+            cglib::vec2<float> currentVec(screenPos2.getX() - screenPos1.getX(), screenPos2.getY() - screenPos1.getY());
+            cglib::vec2<float> prevVec(_prevScreenPos2.getX() - _prevScreenPos1.getX(), _prevScreenPos2.getY() - _prevScreenPos1.getY());
+            double currentDist = cglib::length(currentVec);
+            double prevDist = cglib::length(prevVec);
 
-                cglib::vec3<double> prevPos1 = projectionSurface->calculatePosition(mapScreenPosition(_prevScreenPos1, viewState));
-                cglib::vec3<double> prevPos2 = projectionSurface->calculatePosition(mapScreenPosition(_prevScreenPos2, viewState));
-                cglib::vec3<double> prevVec = prevPos2 - prevPos1;
-                double prevDist = projectionSurface->calculateDistance(prevPos1, prevPos2);
-                cglib::mat4x4<double> prevTranslateTransform = projectionSurface->calculateTranslateMatrix(prevPos1, prevPos2, 0.5f);
-                MapPos prevMiddlePos = projectionSurface->calculateMapPos(cglib::transform_point(prevPos1, prevTranslateTransform));
+            ScreenPos currentMiddlePos((screenPos1.getX() + screenPos2.getX()) * 0.5f, (screenPos1.getY() + screenPos2.getY()) * 0.5f);
+            ScreenPos prevMiddlePos((_prevScreenPos1.getX() + _prevScreenPos2.getX()) * 0.5f, (_prevScreenPos1.getY() + _prevScreenPos2.getY()) * 0.5f);
 
-                MapPos pivotPos = (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT ? currentMiddlePos : projectionSurface->calculateMapPos(viewState.getFocusPos()));
+            MapPos pivotPos = calculatePivotPos(currentMiddlePos, viewState);
 
-                if (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT) {
-                    CameraPanEvent cameraPanEvent;
-                    cameraPanEvent.setPosDelta(std::make_pair(currentMiddlePos, prevMiddlePos));
-                    _cameraEvents |= CAMERA_PAN;
-                    _mapRenderer->calculateCameraEvent(cameraPanEvent, 0, true);
-                }
-            
-                if (scale && prevDist > 0 && currentDist > 0) {
-                    float ratio = static_cast<float>(prevDist / currentDist);
-                    CameraZoomEvent cameraZoomTargetEvent;
-                    cameraZoomTargetEvent.setScale(ratio);
-                    cameraZoomTargetEvent.setTargetPos(pivotPos);
-                    _cameraEvents |= CAMERA_ZOOM;
-                    _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, 0, true);
-                }
-    
-                if (rotate && _options->isRotationGestures() && cglib::norm(prevVec) > 0 && cglib::norm(currentVec) > 0) {
-                    cglib::vec3<double> axis = cglib::vector_product(cglib::unit(currentVec), cglib::unit(prevVec));
-                    float angle = std::asin(std::max(-1.0f, std::min(1.0f, static_cast<float>(cglib::length(axis)))));
-                    float dir = cglib::dot_product(axis, projectionSurface->calculateNormal(pivotPos)) > 0 ? 1 : -1;
-                    CameraRotationEvent cameraRotateTargetEvent;
-                    cameraRotateTargetEvent.setRotationDelta(static_cast<float>(angle * dir * Const::RAD_TO_DEG));
-                    cameraRotateTargetEvent.setTargetPos(pivotPos);
-                    _cameraEvents |= CAMERA_ROTATE;
-                    _mapRenderer->calculateCameraEvent(cameraRotateTargetEvent, 0, true);
-                }
+            if (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT) {
+                panBetween(prevMiddlePos, currentMiddlePos, viewState);
+            }
+
+            if (scale && prevDist > 0 && currentDist > 0) {
+                CameraZoomEvent cameraZoomTargetEvent;
+                cameraZoomTargetEvent.setScale(static_cast<float>(prevDist / currentDist));
+                cameraZoomTargetEvent.setTargetPos(pivotPos);
+                _cameraEvents |= CAMERA_ZOOM;
+                _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, 0, true);
+            }
+
+            if (rotate && _options->isRotationGestures() && prevDist > 0 && currentDist > 0) {
+                // Signed angle from the previous finger vector to the current one. Screen y points
+                // down, which is what turns a clockwise turn of the fingers into a positive map
+                // rotation - the same sign the ground-derived cross product produced.
+                double cross = static_cast<double>(prevVec(0)) * currentVec(1) - static_cast<double>(prevVec(1)) * currentVec(0);
+                double dot = static_cast<double>(prevVec(0)) * currentVec(0) + static_cast<double>(prevVec(1)) * currentVec(1);
+                CameraRotationEvent cameraRotateTargetEvent;
+                cameraRotateTargetEvent.setRotationDelta(static_cast<float>(std::atan2(cross, dot) * Const::RAD_TO_DEG));
+                cameraRotateTargetEvent.setTargetPos(pivotPos);
+                _cameraEvents |= CAMERA_ROTATE;
+                _mapRenderer->calculateCameraEvent(cameraRotateTargetEvent, 0, true);
             }
         }
     
@@ -730,11 +752,10 @@ namespace carto {
         }
 
         updateGestureAnchorHeight(screenPos, viewState);
-        MapPos targetPos = (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT ? mapScreenPosition(screenPos, viewState) : projectionSurface->calculateMapPos(viewState.getFocusPos()));
 
         CameraZoomEvent cameraZoomTargetEvent;
         cameraZoomTargetEvent.setZoomDelta(1.0f);
-        cameraZoomTargetEvent.setTargetPos(targetPos);
+        cameraZoomTargetEvent.setTargetPos(calculatePivotPos(screenPos, viewState));
         _mapRenderer->calculateCameraEvent(cameraZoomTargetEvent, ZOOM_GESTURE_ANIMATION_DURATION.count() / 1000.0f, true);
 
         DirectorPtr<MapEventListener> mapEventListener = _mapEventListener;
@@ -840,7 +861,11 @@ namespace carto {
         if (!viewState.getProjectionSurface()) {
             return false;
         }
-        cglib::vec3<double> pos = viewState.screenToWorld(cglib::vec2<float>(screenPos.getX(), screenPos.getY()), 0);
+        // The plane the gesture is actually anchored to (mapScreenPosition uses the same one).
+        // Testing the SEA LEVEL plane instead reported a touch as valid, or as past the far plane,
+        // for a surface no gesture ever uses - in the mountains the two are hundreds of metres and,
+        // at a low tilt, kilometres of ray apart.
+        cglib::vec3<double> pos = viewState.screenToWorld(cglib::vec2<float>(screenPos.getX(), screenPos.getY()), _gestureAnchorHeight.load());
         if (std::isnan(cglib::norm(pos))) {
             return false;
         }
@@ -906,6 +931,19 @@ namespace carto {
     MapPos TouchHandler::mapScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const {
         cglib::vec3<double> pos = viewState.screenToWorld(cglib::vec2<float>(screenPos.getX(), screenPos.getY()), _gestureAnchorHeight.load());
         return viewState.getProjectionSurface()->calculateMapPos(pos);
+    }
+
+    /**
+     * The point a zoom or a rotation turns about: what is under the fingers when the map is
+     * there, the focus otherwise. A missing ground hit must NOT cancel the gesture - that is what
+     * left the map frozen with the camera close to the terrain, where half the screen is sky or
+     * ground past the far plane.
+     */
+    MapPos TouchHandler::calculatePivotPos(const ScreenPos& screenPos, const ViewState& viewState) const {
+        if (_options->getPivotMode() == PivotMode::PIVOT_MODE_TOUCHPOINT && isValidScreenPosition(screenPos, viewState)) {
+            return mapScreenPosition(screenPos, viewState);
+        }
+        return viewState.getProjectionSurface()->calculateMapPos(viewState.getFocusPos());
     }
 
     double TouchHandler::calculateTerrainHeight(const ScreenPos& screenPos, const ViewState& viewState) const {
@@ -995,7 +1033,9 @@ namespace carto {
         // two-finger rotation are map gestures, and this control scheme has neither.
         _gestureMode = (_options->getFreeRoamMode() == FreeRoamMode::FREE_ROAM_MODE_FIRST_PERSON ? DUAL_POINTER_MOVE : DUAL_POINTER_GUESS);
         ScreenPos middlePos((screenPos1.getX() + screenPos2.getX()) * 0.5f, (screenPos1.getY() + screenPos2.getY()) * 0.5f);
-        updateGestureAnchorHeight(middlePos, _mapRenderer->getViewState());
+        ViewState viewState = _mapRenderer->getViewState();
+        updateGestureAnchorHeight(middlePos, viewState);
+        updatePanScale(middlePos, viewState); // the two-finger pan goes through the same speed mode
     }
 
     void TouchHandler::registerOnTouchListener(const std::shared_ptr<OnTouchListener>& listener) {
@@ -1069,6 +1109,8 @@ namespace carto {
     // A full turn takes about two swipes across a phone, which is what a look control wants.
 
     const float TouchHandler::INCHES_TO_ZOOM_DELTA = 1.0f;
+
+    const float TouchHandler::PAN_CLAMP_MAX_TILT = 15.0f; // tangram's pitch > 75 degrees
         
     const std::chrono::milliseconds TouchHandler::DUAL_KINETIC_HOLD_DURATION = std::chrono::milliseconds(100);
 

--- a/all/native/ui/TouchHandler.h
+++ b/all/native/ui/TouchHandler.h
@@ -107,6 +107,7 @@ namespace carto {
         float calculateRotatingScalingFactor(const ScreenPos& screenPos1, const ScreenPos& screenPos2) const;
 
         void singlePointerPan(const ScreenPos& screenPos, const ViewState& viewState);
+        void panBetween(const ScreenPos& prevScreenPos, const ScreenPos& screenPos, const ViewState& viewState);
         void singlePointerLook(const ScreenPos& screenPos, const ViewState& viewState);
         double calculatePanScale(const ScreenPos& screenPos, const ViewState& viewState) const;
         void updatePanScale(const ScreenPos& screenPos, const ViewState& viewState);
@@ -121,6 +122,7 @@ namespace carto {
         bool isValidScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const;
         cglib::ray3<double> calculateScreenRay(const ScreenPos& screenPos, const ViewState& viewState) const;
         MapPos mapScreenPosition(const ScreenPos& screenPos, const ViewState& viewState) const;
+        MapPos calculatePivotPos(const ScreenPos& screenPos, const ViewState& viewState) const;
         double calculateTerrainHeight(const ScreenPos& screenPos, const ViewState& viewState) const;
         void updateGestureAnchorHeight(const ScreenPos& screenPos, const ViewState& viewState);
 
@@ -155,6 +157,11 @@ namespace carto {
 
         // Determines how finger sliding distance will be converted to zoom delta
         static const float INCHES_TO_ZOOM_DELTA;
+
+        // Below this tilt a grabbed pan is capped at what the finger travel is worth at the
+        // map scale - tangram's guard against a near-horizontal view (inputHandler.cpp
+        // getTranslation, `m_view.getPitch() > 75 degrees`; their pitch is 90 - our tilt).
+        static const float PAN_CLAMP_MAX_TILT;
         
         // Determines how long it takes to cancel kinetic zoom and rotation after one
         // pointer is lifted but the other one is not

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -322,6 +322,15 @@ namespace carto {
         return mvt::resolveLayerConfig(*_map, layerName, viewZoom, _parameterStore);
     }
 
+    mvt::ResolvedContourStyle MBVectorTileDecoder::resolveContourStyle(const std::string& layerName, float viewZoom, const std::vector<float>& divisors) const {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (!_map) {
+            return mvt::ResolvedContourStyle();
+        }
+        return mvt::resolveContourStyle(*_map, layerName, viewZoom, divisors, _parameterStore);
+    }
+
     std::vector<int> MBVectorTileDecoder::getStyleLayerZoomRange(const std::string& layerName) const {
         std::lock_guard<std::mutex> lock(_mutex);
 

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -231,7 +231,7 @@ namespace carto {
         std::string _selectionParameter; // the one that selects a feature, if the style has one
         // Its value, hashed: the tiles read it while they are drawn, so setting the selection is a
         // style-byte rewrite rather than a decode. Shared with every tile this decoder built.
-        std::shared_ptr<std::atomic<std::uint64_t>> _selectionState = std::make_shared<std::atomic<std::uint64_t>>(0);
+        std::shared_ptr<std::atomic<std::uint64_t> > _selectionState = std::make_shared<std::atomic<std::uint64_t> >(0);
         std::shared_ptr<const mvt::Map> _map;
         std::shared_ptr<const mvt::Map::Settings> _mapSettings;
         std::shared_ptr<const mvt::SymbolizerContext> _symbolizerContext;

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -21,6 +21,7 @@
 #include <mapnikvt/Value.h>
 #include <mapnikvt/NutiParameterStore.h>
 #include <mapnikvt/LayerConfigResolver.h>
+#include <mapnikvt/ContourStyleResolver.h>
 
 namespace carto {
     namespace mvt {
@@ -136,6 +137,15 @@ namespace carto {
          * @return The resolved configuration (visible flag + evaluated property values).
          */
         mvt::ResolvedLayerConfig resolveLayerConfig(const std::string& layerName, float viewZoom) const;
+
+        /**
+         * Resolves the LINE rules of a style layer into per-elevation-divisor contour classes at
+         * the given view zoom and parameter state, and says whether they can be drawn as bands in
+         * the terrain shader at all (mvt::resolveContourStyle). Used by CompositeVectorTileLayer
+         * to choose between the shader contours and the traced ones.
+         * Note: for internal use, not exposed to the public API.
+         */
+        mvt::ResolvedContourStyle resolveContourStyle(const std::string& layerName, float viewZoom, const std::vector<float>& divisors) const;
 
         /**
          * Returns the { minZoom, maxZoom } range over which the named style layer's config

--- a/docs/rendering/03-vt-renderer.md
+++ b/docs/rendering/03-vt-renderer.md
@@ -204,6 +204,14 @@ reason.
 
 ## Lines over terrain
 
+**A line is never draped.** Roads, contours, any hairline: they are drawn as geometry on the terrain
+(or, for contours, computed per screen fragment in the paint's surface pass), and never baked into a
+drape texture. The drape is one fixed-resolution texture per tile resampled onto the surface, so a
+baked line is magnified into a soft band close up and aliased into mush at a grazing angle — the
+stretched, blurry look. Fills survive that and are what the drape is for
+(`TerrainOptions.DrapeFillsEnabled` on, `DrapeLinesEnabled` off; see
+[07-hillshade-contours.md](07-hillshade-contours.md#never-bake-a-line-into-the-drape--a-contour-or-a-road)).
+
 A line is a chain of quads whose width is an offset along a per-vertex binormal, and three things
 about that offset are easy to get wrong. All three were, and the symptoms all looked like terrain or
 depth bugs rather than line bugs.

--- a/docs/rendering/04-terrain.md
+++ b/docs/rendering/04-terrain.md
@@ -12,6 +12,16 @@ with a `LoadMode` (`CACHED_ONLY` never blocks). Every consumer — the mesh, lab
 placement, billboard occlusion — must go through it, or two parts of the frame disagree about where
 the ground is.
 
+**The grid cache is a tile count, not a byte budget.** A grid is the source raster (768 KB for a
+512×512 RGB DEM, 192 KB for a 256×256 one), so a fixed 64 MB meant 85 grids for one source and 340
+for another. One terrain view needs 122–167 of them — the cover pyramid, the contour source's finer
+tiles, the border prefetch — and every grid past the limit evicted one still in use, which was then
+decoded again on the next pass: **1525 loads of 167 distinct tiles, 32 s of WEBP decode per
+startup** on a Crosscall. The cache now grows on the first decoded grid to hold `MIN_CACHED_GRIDS`
+(192) of them, i.e. 144 MB for a 512² source and 36 MB for a 256² one; 192 was the first value where
+loads equalled distinct tiles (128 still re-decoded ~20%). `TerrainOptions::setElevationCacheCapacity`
+still wins over the rule, for an app that cannot spend the memory.
+
 `setSurfaceResolution` caps the elevation level to what the mesh can express (roughly one texel per
 half surface cell), which costs about two zoom levels of detail. That cap is right for geometry and
 wrong for per-fragment shading, which is why the terrain paint can opt out of it

--- a/docs/rendering/04-terrain.md
+++ b/docs/rendering/04-terrain.md
@@ -151,6 +151,17 @@ floored at 1/16 of an internal unit — gave centimetre near planes next to a sl
 of 10⁴–10⁶, and NDC depth so non-linear that a constant-NDC bias was worth hundreds of metres at
 range. That is the mechanism behind every see-through this project has had.
 
+"Camera height" is the smaller of the distance to the **focus** and the height above the **terrain
+under the camera** (`ViewState::setTerrainCameraReference`, published every frame by the renderer
+next to the clearance). Tangram's `m_pos.z` is the distance to what the camera looks at and their
+camera is held a distance away from the terrain itself (the depth at the screen centre against
+`minCameraDist`); ours is held a *clearance above the ground under it*, so at a low tilt the focus
+is kilometres away while the ground is a couple of hundred metres below — and a fiftieth of the
+focus distance then parks the near plane in front of the ground at the bottom of the screen and
+cuts it away. Over flat ground with the focus close the two distances are the same; the cost of the
+smaller one is bounded by 1/sin(tilt) (2× at tilt 30), so the depth budget is only spent in the
+close-to-terrain case that needs it.
+
 The floor is a floor and the ground walk is a **ceiling** too, but only when the view is pitched
 away from the camera geometry — free roam looking up, or a first person camera
 ([13-celestial.md](13-celestial.md#seeing-them-free-roam)). The walk takes the near plane from
@@ -163,6 +174,37 @@ direction at all.
 Their far plane (`2·height/cos(pitch + fovy/2)`) is available as
 `TerrainOptions::ViewDistanceFactor` but changes nothing at the cameras tested: the ground-derived far is
 already inside the bound it gives.
+
+## The camera against the terrain
+
+`TerrainOptions::CameraClearance` keeps the camera a height above the ground under it. It is a
+**bound on the zoom** (`ViewState::getTerrainMaxZoom`, clamped in `CameraZoomEvent::calculate`)
+plus a per-frame correction in `MapRenderer` for the paths that lower the camera without zooming —
+panning into a hillside, tilting, a DEM tile arriving. Three rules keep a gesture against that
+bound from throwing the map somewhere else:
+
+- **The bound stops a zoom in; it never drives a zoom out.** A zoom event scales the map about its
+  pivot, and with the pivot under the fingers, clamping a zoom-*in* request to below the current
+  zoom scales the map the other way about that point — the map jumps sideways, once per pinch tick.
+  Getting back onto the shell is the renderer's correction, which zooms about the focus and moves
+  nothing sideways.
+- **A zoom is never cancelled for want of a ground hit.** `TouchHandler::calculatePivotPos` falls
+  back to the focus when the ray under the fingers misses the anchor plane or lands past the far
+  plane. Close to the terrain the far plane is short and half the screen is sky, so requiring a hit
+  (which the pinch, the wheel and the double tap all did) left the map unable to zoom out at all —
+  the "I have to pan somewhere else before I can move" symptom.
+- **The scale and the angle come from the SCREEN, not from the ground.** A pinch and a two-finger
+  turn are what the fingers did (tangram: `InputHandler::handlePinchGesture` /
+  `handleRotateGesture`, fed by the platform gesture detector). Taking them from where the two rays
+  meet the ground makes a grazing ray — a low camera, a finger near the horizon — into most of the
+  answer. The pan is still world-anchored (that is the point of a map pan) and goes through one
+  path for both gestures, `TouchHandler::panBetween`, which honours `PanningSpeedMode` and, below
+  tilt 15, caps the travel at what the finger's pixels are worth at the map scale — tangram's
+  `getTranslation` guard for a near-horizontal view.
+
+`isValidScreenPosition` tests the plane the gesture is actually anchored to (the terrain height
+under the touch, `_gestureAnchorHeight`), not sea level: in the mountains the two are hundreds of
+metres, and at a low tilt kilometres of ray, apart.
 
 ## The surface shader
 

--- a/docs/rendering/07-hillshade-contours.md
+++ b/docs/rendering/07-hillshade-contours.md
@@ -78,7 +78,8 @@ per elevation divisor, the coarsest match winning, which is what a `#contour [di
 
 ### NEVER bake a line into the drape — a contour or a road
 
-The block is compiled **only into the paint's SURFACE pass** (`PAINT_SURFACE`), never into the drape
+The block is compiled into passes that draw **screen fragments** — the paint's surface pass
+(`PAINT_SURFACE`) and the ground/drape surface draw (`CONTOUR_BANDS`) — and never into the drape
 bake, and that is deliberate. The drape is one texture per tile at a fixed resolution, mapped onto
 the surface afterwards, so anything baked into it is resampled: magnified into a soft band where the
 tile is close and large on screen, minified into aliasing (or mipmap mush) at a grazing angle. A fill
@@ -86,8 +87,8 @@ survives that; a hairline does not. It is the same reason `TerrainOptions.DrapeL
 by default — fills are draped, lines are not. If a contour or a road ever looks stretched or blurry
 on a slope, this is the first thing to check.
 
-The consequence is that a contour paint has to draw as a surface even when the fills are draped, at
-its own place in the layer order — not be folded into the bake with them.
+The consequence is that contours have to be drawn by a surface pass even when the fills are draped —
+not folded into the bake with them.
 
 **Measurement warning.** The old "contours measured free: 7.25 fps without against 7.57 with" line
 was taken with the drape ON, where this block is not compiled at all: it compared two frames that
@@ -130,21 +131,26 @@ Four things this got wrong first, all worth remembering:
   a frame by this decision, that threw away every contour tile *and* every elevation grid
   (`ElevationManager` listens on the same source) every frame.
 
-**It is opt-in (`adb shell setprop debug.carto.shadercontours 1`) because it is currently SLOWER
-than the geometry it replaces.** Crosscall, city camera, interleaved pairs:
+**Where the bands are drawn decides whether this pays at all.** Crosscall, city camera, interleaved
+pairs, `adb shell setprop debug.carto.shadercontours 1`:
 
-| | fps | GPU layers | geom draws | geom indices | surface draws |
-|---|---|---|---|---|---|
-| traced geometry | 12.0 / 11.8 | 21 ms | 612 | 22.0M | 265 |
-| painted per fragment | 9.2 / 9.1 | **56 ms** | 272 | 10.1M | **582** |
+| | fps | GPU total | GPU layers | GPU drape | geom draws | geom indices |
+|---|---|---|---|---|---|---|
+| traced geometry | 12.2 / 12.1 | 33 ms | 21 ms | 4 ms | 636 | 22.6M |
+| bands in a paint PASS of their own | 9.2 / 9.1 | 68 ms | 56 ms | 5 ms | 272 | 10.1M |
+| bands in the GROUND draw | **13.1 / 13.3** | 39 ms | 15 ms | 19 ms | 384 | 14.7M |
 
-Half the geometry, and a third slower. The paint is an **extra full-cover surface pass**, and its
-fragment shader reconstructs the DEM (a nine-tap stencil) and runs the hillshade lighting before it
-gets to the bands. Tangram pays none of that because their contours are a block inside the earth
-draw that runs anyway (`res/scenes/hillshade.yaml`), not a pass on top. **The fix is to fold the
-bands into the terrain ground draw** — one pass, no extra fragments — and only then make it the
-default. Until that lands the traced path stays, and the machinery above is exercised with the
-property.
+A pass of its own is a third SLOWER than the geometry it replaces, with half the geometry: it is an
+extra full-cover surface pass whose fragment shader reconstructs the DEM (a nine-tap stencil) and
+runs the hillshade lighting before it gets to the bands. Composited into the ground/drape surface
+pass that already runs — tangram's arrangement — the same bands are **+8%** instead, because the
+band costs `fract()` and `fwidth()` on a height the vertex stage already computed and no texture
+fetch at all. Note where the cost moved: the layer pass drops 21 → 15 ms with the contour geometry
+gone, the surface pass rises 4 → 19 ms, and the frame still wins.
+
+Still opt-in: the gain is real but modest, and the lines are not pixel-identical to the traced
+ones. Worth re-measuring at a mountain camera, where the contour geometry is much denser than in a
+valley, before making it the default.
 
 ## Which contours a traced tile carries, and which of them are drawn
 

--- a/docs/rendering/07-hillshade-contours.md
+++ b/docs/rendering/07-hillshade-contours.md
@@ -155,30 +155,59 @@ per-class work — 2.2 ms per class per frame originally, **1.6 ms** after the t
 several times a multiply, coverage in `mediump` with the branch as a `mix`). It is still **linear in
 the number of classes**, so a style with more of them pays more.
 
-**The way to make it independent of the count is a level LUT, and it is the next step.** Every
-divisor in play is a multiple of the finest one, so the lines of *every* class sit at multiples of
-that base interval:
+**The level LUT removes the count from the cost** (`CONTOUR_LUT`, `GLTileRenderer::
+buildContourLut`). Every divisor in play is a multiple of the finest one, so the lines of *every*
+class sit at multiples of that base interval, and one index — the nearest base level — names the
+class the fragment belongs to:
 
 ```
-levelF = e * u_contourInvBase;          // e = vTerrainMeters
-level  = floor(levelF + 0.5);           // nearest base level
-distPx = abs(e - level * u_contourBase) * pxPerMetre;
-idx    = mod(level, u_contourLutSize);  // which class owns that level
-vec4 c = texture2D(u_contourLut, vec2((idx + 0.5) / u_contourLutSize, 0.25));   // rgb + alpha
-float halfWidth = texture2D(u_contourLut, vec2((idx + 0.5) / u_contourLutSize, 0.75)).r;
+level    = floor(e * u_contourLutParams.x + 0.5);              // e = vTerrainMeters, x = 1/base
+distPx   = abs(e - level * u_contourLutParams.y) * pxPerMetre; // y = base
+u        = fract(level * u_contourLutParams.z) + 0.5 * u_contourLutParams.z;  // z = 1/size
+vec4 cls = texture2D(u_contourLut, vec2(u, 0.25));  // rgb + opacity
+vec4 row = texture2D(u_contourLut, vec2(u, 0.75));  // r = half-width, g = interval
 ```
 
-Two fetches and no loop, so **two classes and ten cost the same** — tangram's cost without
-tangram's two-band limit. The LUT is `lcm(intervals) / base` texels wide (20 for
-`50·100·250·500·1000`, 100 when a 10 m class is in play), `NEAREST` filtered, two rows, rebuilt only
-when the resolved classes change — a zoom band or a nuti parameter, so rarely. Which class owns a
-level is decided on the CPU while building it (the coarsest divisor that divides the level wins),
-which is also where the "coarsest match wins" rule stops costing anything per fragment. Keep the
-unrolled path as the fallback for a style whose `lcm/base` exceeds the texture width cap.
+`fract(level / size)` is the level index modulo the table width, so the width never has to be a
+uniform. The table is `lcm(intervals) / base` texels wide (20 for the demo's
+`50·100·200·250·500·1000` at z13.6, 100 when a 10 m class is in play, cap 256), `NEAREST`, two
+rows, and is rebuilt only when the resolved classes actually change — the layer re-applies them
+every frame, so `setContourBands` compares before rebuilding or it re-uploads the texture 60 times
+a second. Which class owns a level is decided on the CPU while building it (the coarsest divisor
+that divides the level wins), which is where the "coarsest match wins" rule stops costing anything
+per fragment. The unrolled loop stays as the fallback for a style whose intervals are not multiples
+of the finest one (`20·50` alone has no common base under the cap).
 
-Still opt-in: the gain is real but modest, and the lines are not pixel-identical to the traced
-ones. Worth re-measuring at a mountain camera, where the contour geometry is much denser than in a
-valley, before making it the default.
+Measured on the Crosscall, mountain camera 45.244172/5.760595 z13.6 t35, six classes, two
+interleaved pairs — the same binary with `buildContourLut` forced to bail is the other arm:
+
+| | GPU surface pass | fps |
+|---|---|---|
+| unrolled loop, 6 classes | 18.9 / 18.6 ms | 18.4 / 18.5 |
+| level LUT | **13.3 / 10.1 ms** | **20.0 / 20.0** |
+
+The two LUT arms differ by 3 ms of device drift and the loop arms by 0.3, so read the direction and
+the size, not the third digit: the six-class cost collapses to roughly what one class used to cost,
+and a style with twelve classes would now measure the same.
+
+Two things the bands got wrong against the traced lines, both fixed with them:
+
+- **A style width is in unscaled-DPI units and reaches device pixels through three steps**, so
+  taking it as pixels drew the same style 3.2× too thin on a 288-dpi 1648-high screen. The steps,
+  in order, are the width table of `renderTileGeometry` (`0.25 · normalizedResolution · width /
+  tileSize`), the half-unit AA margin `lineVsh` puts on every line (`(units - 1) · 0.5 + 1`), and
+  `lineFsh`'s `uAntialiasScale` (`screenHeight / normalizedResolution`). `applyContourPaint` walks
+  the same three. The band's coverage ramp is `clamp(halfWidth - distPx, 0, 1)` for the same
+  reason — that is `lineFsh`'s ramp, one device pixel wide.
+- **One class set covers the whole screen**, where the traced path gets its distance LOD for free
+  from the divisor ladder picking a coarser set a zoom down. Without that, the far half of a tilted
+  view is a solid wash of merged lines. Each class now fades out where its own spacing drops below
+  a few pixels (`smoothstep(2, 5, spacingPx)`, the interval carried in the LUT's second row) — the
+  thresholds are chosen, not ported: tangram has no equivalent, its contours are per raster tile
+  and take the tile's zoom.
+
+Still opt-in. What is left before it can be the default: the index lines are lighter than the
+traced ones close up, and the cost has only been measured at one camera.
 
 ## Which contours a traced tile carries, and which of them are drawn
 

--- a/docs/rendering/07-hillshade-contours.md
+++ b/docs/rendering/07-hillshade-contours.md
@@ -206,8 +206,33 @@ Two things the bands got wrong against the traced lines, both fixed with them:
   thresholds are chosen, not ported: tangram has no equivalent, its contours are per raster tile
   and take the tile's zoom.
 
-Still opt-in. What is left before it can be the default: the index lines are lighter than the
-traced ones close up, and the cost has only been measured at one camera.
+**A band-carrying layer is NOT a terrain paint.** `paintsEveryDrapeTile()` returned true whenever a
+layer had contour classes — correct when the bands were baked into the drape, wrong since they moved
+into the surface pass, where they bake nothing. It took the layer's tiles out of the drape
+completeness mask, so the whole drape re-baked every frame: measured against the packaged style,
+**96 bakes per interval against 21, 31.4M geometry indices against 15.4M**, 10.8 fps against ~17.
+It is the first thing to check when the bands are slower than the geometry they replace.
+
+With the app's own packaged style, after that fix, the bands win — Crosscall, 25 s scripted zoom
+(`--es anim zoom`), two interleaved pairs:
+
+| | avg frame | fps |
+|---|---|---|
+| traced geometry | 96.3 / 97.4 ms | 10.38 / 10.26 |
+| shader bands | **93.1 / 94.0 ms** | **10.64 / 10.74** |
+
+**Measure this on a scripted camera, never on a static one.** A rich style at a static camera never
+settles here — frame rate swings 9 to 24 fps second to second for three minutes in BOTH arms, and
+two static runs "showed" a 4 fps regression that a repeatable sweep says is a 3 ms/frame gain. The
+same trap invalidates the per-interval `RenderStats` counters: they are sums per SECOND, so the
+faster arm reports more draws and more indices for the same scene. Divide by the frame count in the
+same interval, or compare nothing.
+
+To check the traced geometry really is gone, mute the bands (`debug.carto.contourmute 1`) and look:
+the contour lines must vanish and their labels must stay.
+
+Still opt-in. What is left: the index lines are lighter than the traced ones close up, and the win
+is small enough that it has only been shown at one camera on one device.
 
 ## Which contours a traced tile carries, and which of them are drawn
 

--- a/docs/rendering/07-hillshade-contours.md
+++ b/docs/rendering/07-hillshade-contours.md
@@ -73,8 +73,26 @@ port described in [04-terrain.md](04-terrain.md#the-elevation-texture).
 
 Drawn as a fragment block on the terrain draw, from the same DEM: distance to the nearest contour in
 metres divided by the per-pixel elevation change (`fwidth`), giving a screen-width anti-aliased line
-(`u_contourInterval`, `u_contourWidth`, `u_contourColor`). Measured **free**: 7.25 fps without
-contours against 7.57 with.
+(`u_contourIntervals`, `u_contourHalfWidths`, `u_contourColors`, `u_contourClassCount` — one class
+per elevation divisor, the coarsest match winning, which is what a `#contour [div=N]` style says).
+
+### NEVER bake a line into the drape — a contour or a road
+
+The block is compiled **only into the paint's SURFACE pass** (`PAINT_SURFACE`), never into the drape
+bake, and that is deliberate. The drape is one texture per tile at a fixed resolution, mapped onto
+the surface afterwards, so anything baked into it is resampled: magnified into a soft band where the
+tile is close and large on screen, minified into aliasing (or mipmap mush) at a grazing angle. A fill
+survives that; a hairline does not. It is the same reason `TerrainOptions.DrapeLinesEnabled` is off
+by default — fills are draped, lines are not. If a contour or a road ever looks stretched or blurry
+on a slope, this is the first thing to check.
+
+The consequence is that a contour paint has to draw as a surface even when the fills are draped, at
+its own place in the layer order — not be folded into the bake with them.
+
+**Measurement warning.** The old "contours measured free: 7.25 fps without against 7.57 with" line
+was taken with the drape ON, where this block is not compiled at all: it compared two frames that
+both had no contours in them. Any number for per-fragment contours has to come from a run whose
+screenshot shows the lines.
 
 Turning them on for a layer that would otherwise fall back to its own DEM tile set moved render
 tiles 494 → 216 and `layers` 18.4 → 16.1 ms.

--- a/docs/rendering/07-hillshade-contours.md
+++ b/docs/rendering/07-hillshade-contours.md
@@ -148,6 +148,34 @@ band costs `fract()` and `fwidth()` on a height the vertex stage already compute
 fetch at all. Note where the cost moved: the layer pass drops 21 → 15 ms with the contour geometry
 gone, the surface pass rises 4 → 19 ms, and the frame still wins.
 
+**Where the remaining cost is, and how to remove it.** Split measured with the block compiled but
+the class count at zero: the varying and the derivatives are **~1 ms**, everything else is the
+per-class work — 2.2 ms per class per frame originally, **1.6 ms** after the three optimisations
+(count compiled in so the loop unrolls, `1/interval` as a uniform because a per-fragment divide is
+several times a multiply, coverage in `mediump` with the branch as a `mix`). It is still **linear in
+the number of classes**, so a style with more of them pays more.
+
+**The way to make it independent of the count is a level LUT, and it is the next step.** Every
+divisor in play is a multiple of the finest one, so the lines of *every* class sit at multiples of
+that base interval:
+
+```
+levelF = e * u_contourInvBase;          // e = vTerrainMeters
+level  = floor(levelF + 0.5);           // nearest base level
+distPx = abs(e - level * u_contourBase) * pxPerMetre;
+idx    = mod(level, u_contourLutSize);  // which class owns that level
+vec4 c = texture2D(u_contourLut, vec2((idx + 0.5) / u_contourLutSize, 0.25));   // rgb + alpha
+float halfWidth = texture2D(u_contourLut, vec2((idx + 0.5) / u_contourLutSize, 0.75)).r;
+```
+
+Two fetches and no loop, so **two classes and ten cost the same** — tangram's cost without
+tangram's two-band limit. The LUT is `lcm(intervals) / base` texels wide (20 for
+`50·100·250·500·1000`, 100 when a 10 m class is in play), `NEAREST` filtered, two rows, rebuilt only
+when the resolved classes change — a zoom band or a nuti parameter, so rarely. Which class owns a
+level is decided on the CPU while building it (the coarsest divisor that divides the level wins),
+which is also where the "coarsest match wins" rule stops costing anything per fragment. Keep the
+unrolled path as the fallback for a style whose `lcm/base` exceeds the texture width cap.
+
 Still opt-in: the gain is real but modest, and the lines are not pixel-identical to the traced
 ones. Worth re-measuring at a mountain camera, where the contour geometry is much denser than in a
 valley, before making it the default.

--- a/docs/rendering/07-hillshade-contours.md
+++ b/docs/rendering/07-hillshade-contours.md
@@ -102,6 +102,50 @@ setters — those only reach a stand-alone layer. The style properties are
 `hillshade-contour-interval`, `hillshade-contour-width`, `hillshade-contour-color`
 ([09-composite-layer.md](09-composite-layer.md)).
 
+### Contours from the style, painted per fragment (opt-in, and not yet worth it)
+
+`mvt::resolveContourStyle` reads the `#contour` layer's LINE rules and answers with one class per
+elevation divisor — `{divisor, colour × opacity, width}` — evaluated at the current view zoom and
+nuti parameter state, or with `shaderCapable = false` and a reason. `CompositeVectorTileLayer::
+applyContourPaint` then either paints those classes (`ContourClass`, `TileLayer::
+setTerrainContourPaint`, source switched to `setLabelStubsEnabled` so the labels stay real
+features) or leaves the traced geometry alone. Everything the shader cannot reproduce falls back:
+a dash, an offset, an arrow, casing, a filter on a field other than `div`/`stub`, a line property
+that reads the feature.
+
+Four things this got wrong first, all worth remembering:
+
+- **A `#contour` layer carries more than lines.** Its `ContourConfigSymbolizer` configures the
+  source and draws nothing, and its text rules are the labels — both have to be skipped, not
+  treated as "something the shader cannot draw".
+- **`Rule::getReferencedSymbolizerFields` is per RULE.** A contour rule usually carries the text
+  symbolizer beside the line one, so it reports `ele` from `text-name: [ele]+' m'` and rejects a
+  line that reads nothing. Ask the line symbolizer's own properties, and ignore `view::zoom`,
+  `nuti::` and `zoom`, which the resolver evaluates itself.
+- **"The last matching rule wins" is wrong.** A style whose base rule is `line-width: 0` with the
+  real widths in nested `[div>=N]` blocks resolves to width 0 for every class that way. Every
+  matching rule paints in order and a zero-width one paints nothing, so the class is the last match
+  that would actually draw a line.
+- **`setLabelStubsEnabled` notified tiles-changed even when the value was unchanged.** Called once
+  a frame by this decision, that threw away every contour tile *and* every elevation grid
+  (`ElevationManager` listens on the same source) every frame.
+
+**It is opt-in (`adb shell setprop debug.carto.shadercontours 1`) because it is currently SLOWER
+than the geometry it replaces.** Crosscall, city camera, interleaved pairs:
+
+| | fps | GPU layers | geom draws | geom indices | surface draws |
+|---|---|---|---|---|---|
+| traced geometry | 12.0 / 11.8 | 21 ms | 612 | 22.0M | 265 |
+| painted per fragment | 9.2 / 9.1 | **56 ms** | 272 | 10.1M | **582** |
+
+Half the geometry, and a third slower. The paint is an **extra full-cover surface pass**, and its
+fragment shader reconstructs the DEM (a nine-tap stencil) and runs the hillshade lighting before it
+gets to the bands. Tangram pays none of that because their contours are a block inside the earth
+draw that runs anyway (`res/scenes/hillshade.yaml`), not a pass on top. **The fix is to fold the
+bands into the terrain ground draw** — one pass, no extra fragments — and only then make it the
+default. Until that lands the traced path stays, and the machinery above is exercised with the
+property.
+
 ## Which contours a traced tile carries, and which of them are drawn
 
 Two separate decisions, and confusing them empties the map.

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -96,6 +96,57 @@ The GPU is not the limit: `PROF GPU` with content puts the layers at 29–43 ms 
 So the lever is **fewer draws and fewer layers**, which is [07-hillshade-contours.md](07-hillshade-contours.md)
 and [09-composite-layer.md](09-composite-layer.md), not micro-optimisation.
 
+### A city pans slower than a mountain, and it is fragments
+
+Same build, same camera settings (z16.22, tilt 26), panning north — Grenoble against the
+Saint-Eynard ridge, on a Crosscall:
+
+| | fps | CPU frame | GPU total | GPU layers | draws/frame | indices/frame |
+|---|---|---|---|---|---|---|
+| city | 12.0–13.7 | 34 ms | 33 ms | **21 ms** | 48 | 1.65M |
+| mountain | 18.2–19.6 | 31 ms | 18 ms | **9 ms** | 35–48 | 1.3–1.6M |
+
+The CPU frame is the same and the draw/index counts match in the closest pair, so the 2.4× is
+**per-fragment**: dense city content covers the whole screen where the mountain view is mostly
+terrain surface. Of it, **contours are 45%** — `--es contour false` takes the city from 12.1 to
+17.6 fps (repeated, interleaved), GPU layers 21.3 → 13.6 ms, render tiles 805 → 380 and draws
+602 → 430 per interval, because the `#contour` slot is a second tile set drawn over the first.
+
+## Starting up in terrain mode
+
+Measured on a Crosscall at the demo's default camera (Grenoble, z16.22, terrain + contours, warm
+caches), with temporary probes in `TileLayer::FetchTaskBase::run`, `PersistentCacheTileDataSource::
+loadTile`, `ElevationManager::loadTileGrid` and `VectorTileLayer::FetchTask::loadTile`. The vector
+tiles were never the cost: 66 decodes, 5–6 s of thread time. Elevation was, three times over.
+
+| per startup | before | after |
+|---|---|---|
+| DEM HTTP requests | 79–94, of which **15 could only fail** | **0–1** |
+| DEM grid decodes | 1525 loads of 167 distinct tiles (32 s) | 157 of 157 (3.1 s) |
+| 90% of the content on screen | 6.4–7.6 s | **4.3–4.4 s** |
+
+1. **The elevation grid LRU held 85 tiles and the view needed 167** — a byte budget behaving as a
+   tile budget the DEM raster size decides. Fixed in [04-terrain.md](04-terrain.md#elevation-data).
+2. **The on-disk tile cache defaults to 50 MB and one terrain view's DEM pyramid does not fit.**
+   Two consecutive starts at the *same* camera missed on **different** tiles (their miss sets did
+   not intersect): the cache was evicting exactly what the next start needed, so ~65 tiles were
+   re-downloaded every time at 400–800 ms each. This is an app-side setting —
+   `PersistentCacheTileDataSource::setCapacity`; the demo now asks for 600 MB for the DEM and
+   200 MB per other source (`DemoConfig.DEM_PERSISTENT_CACHE_MB`, `--es demCacheMb`).
+3. **The element elevation warm-up sampled the view envelope**, whose corners are off the DEM in
+   terrain mode: 15 guaranteed 404s per startup. See
+   [12-vector-elements.md](12-vector-elements.md#terrain-interaction).
+
+What is left, in order: **contour tile generation** (44 child fetches, 6–22 s of thread time — the
+`#contour` slot is a whole second tile set, which is what [07-hillshade-contours.md](07-hillshade-contours.md)
+would remove by computing contours in the terrain fragment shader), the network itself, and the
+decode pool (`Options::setTileThreadPoolSize`, default **1**; tangram runs 2). Raising the pool was
+measured as no win *while* the network dominated — retake it now that it does not.
+
+Unrelated but on the same path: the first `loadTile` on a persistent cache runs `loadTileInfo`, a
+full-table scan of the cache DB, on the tile thread — **1.4 s** on the first (cold page cache) run
+of a 52 MB DB.
+
 ## Style load and tile decode (off the render thread, but in front of the user)
 
 Measured on a Crosscall HLTE556N with the demo's bundled style project (`--es style assets`:

--- a/docs/rendering/11-tangram-diff.md
+++ b/docs/rendering/11-tangram-diff.md
@@ -14,7 +14,9 @@ and *still different*, the latter with the reason it is not simply copied.
 | terrain surface | ONE shared static 64-grid VBO for every tile, per-tile uniforms (`core/src/style/rasterStyle.cpp:61`) | same shared grid (`buildCompiledTerrainGridSurfaces`), resolution = `MeshResolution` | **ported** |
 | content on terrain | displaced per vertex, one `texture2D` fetch (`res/scenes/terrain-3d.yaml`) | same | **ported** |
 | content depth | `gl_Position.z += (proxy − layer)·(2⁻¹⁹·w + depth_shift)`, `depth_shift` a flat 0.02, `proxy *= 48` for the raster | same, with the shift derived from the stack's ordinal span so the *budget* matches | **ported** ([05](05-depth-model.md)) |
-| near plane | `m_pos.z / 50` (`core/src/view/view.cpp:452`) | same in terrain mode | **ported** |
+| near plane | `m_pos.z / 50` (`core/src/view/view.cpp:452`), with the camera held a distance from the TERRAIN | `min(focus distance, height over the terrain under the camera) / 50` — their rule against our clearance model ([04](04-terrain.md#near-and-far-planes)) | **ported with a difference** |
+| pinch / rotate gesture | scale and angle from the platform gesture detector, i.e. the SCREEN (`core/src/util/inputHandler.cpp`) | same; the pan stays world-anchored and is capped below tilt 15 by their `getTranslation` guard ([04](04-terrain.md#the-camera-against-the-terrain)) | **ported** |
+| camera against the terrain | zoom-out push from the depth at the screen centre, eye lifted to elevation + 2 m (`core/src/view/view.cpp:404`) | clearance over the ground under the camera, as a zoom bound plus a per-frame correction | **different** |
 | per-layer depth pre-pass, stencil tile masks | none anywhere in `core/src` | none (shared ground) | **ported** |
 | map background | the framebuffer clear colour (`core/src/map.cpp`) | global terrain base fill before all layers; no per-tile background meshes | **ported** |
 | contour labels | generated from the elevation texture, no contour geometry (`core/src/style/contourTextStyle.cpp`) | label stubs in `ContourTileDataSource`, same algorithm | **ported** ([07](07-hillshade-contours.md)) |

--- a/docs/rendering/12-vector-elements.md
+++ b/docs/rendering/12-vector-elements.md
@@ -55,6 +55,15 @@ lines on shoulders when it was tried.
 If a vector line disappears into the terrain or shows through it, read
 [05-depth-model.md](05-depth-model.md) before touching any constant here.
 
+**3. The elevation warm-up.** `VectorLayer::FetchTask::loadElements` loads the elevation under the
+elements before their draw data is built, on the fetch thread, so a line is not drawn half draped
+(vertices with and without heights give near-vertical segments). It samples the bounds of each
+loaded element. It used to sample a 4×4 grid over the **cull envelope** instead, and in terrain mode
+that envelope reaches the view distance: its corners land hundreds of km away, off the DEM coverage,
+so every fetch task blocked on elevation tiles that could only 404 — measured on a Crosscall, 15
+failing HTTP round trips per startup, re-issued each time the failure markers expired
+(`FAILED_TILE_TTL_MILLISECONDS`, 30 s) while panning.
+
 ## Picking
 
 `MapRenderer::calculateRayIntersectedElements` turns a screen position into a world ray and asks

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoConfig.java
@@ -116,6 +116,16 @@ public final class DemoConfig {
     // TILE SOURCES
     // =============================================================================================
 
+    /** On-disk cache per tile source, MB (PersistentCacheTileDataSource.setCapacity).
+     *  '--es cacheMb 100'. */
+    public static int PERSISTENT_CACHE_MB = 200;
+    /** Same for the DEM, which needs far more of it: one terrain view asks for a whole pyramid of
+     *  elevation tiles, and at the SDK default of 50 MB it does not fit. Measured on the Crosscall
+     *  at the default camera, terrain on: 64-70 DEM tiles re-downloaded on EVERY start (25-50 s of
+     *  network), and two consecutive starts missed on DIFFERENT tiles - the cache was evicting
+     *  exactly what the next start needed. '--es demCacheMb 200'. */
+    public static int DEM_PERSISTENT_CACHE_MB = 600;
+
     /** Master vector tile source of the base map. */
     public static String VECTOR_URL = "https://tiles.akylas.fr/data/france/{z}/{x}/{y}.pbf";
     public static int VECTOR_MIN_ZOOM = 0;
@@ -842,6 +852,8 @@ public final class DemoConfig {
         STYLE_DIR_NAME = DemoCfg.cfgStr("styleDir", STYLE_DIR_NAME);
         STYLE_ZIP_NAME = DemoCfg.cfgStr("styleZip", STYLE_ZIP_NAME);
         STYLE_ASSETS_PATH = DemoCfg.cfgStr("styleAssets", STYLE_ASSETS_PATH);
+        PERSISTENT_CACHE_MB = DemoCfg.cfgInt("cacheMb", PERSISTENT_CACHE_MB);
+        DEM_PERSISTENT_CACHE_MB = DemoCfg.cfgInt("demCacheMb", DEM_PERSISTENT_CACHE_MB);
 
         // camera
         START_LON = DemoCfg.cfgFloat("lon", (float) START_LON);

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -1408,8 +1408,11 @@ public class DemoMap {
      * Free roam and how far above the horizon the view may look.
      *
      * A NEGATIVE tilt is the look up: the camera stays where the tilt geometry put it and only the
-     * view pitches, so nothing about zoom or the visible tiles changes. A map stops at the horizon
-     * by default (tilt range 0..90), which is why this has to be asked for.
+     * view pitches, so nothing about zoom or the visible tiles changes.
+     *
+     * A map stops at 30: below that the camera grazes the terrain and at 0 it looks along the
+     * ground from under it. Only the two modes that are ABOUT looking up - free roam and the star
+     * sky - get the full range.
      */
     public void applyLookRange() {
         Options options = mapView.getOptions();
@@ -1417,7 +1420,9 @@ public class DemoMap {
         options.setPanningSpeedMode(panningSpeedMode(DemoConfig.PANNING_SPEED_MODE));
         options.setFreeRoamLookSensitivity(DemoConfig.FREE_ROAM_LOOK_SENSITIVITY);
         options.setFreeRoamMoveSpeed(DemoConfig.FREE_ROAM_MOVE_SPEED);
-        options.setTiltRange(new com.carto.core.MapRange(-Math.max(30f, DemoConfig.LOOK_UP_LIMIT), 90f));
+        boolean lookUp = !"off".equals(DemoConfig.FREE_ROAM_MODE) || DemoConfig.STAR_SKY;
+        float minTilt = lookUp ? -Math.max(30f, DemoConfig.LOOK_UP_LIMIT) : 30f;
+        options.setTiltRange(new com.carto.core.MapRange(minTilt, 90f));
     }
 
     /** "map" / "anchored" / "constant" -> the SDK enum. */
@@ -1550,6 +1555,7 @@ public class DemoMap {
         }
         setMapLayerOpacity(0f);
         rebuildLayers();
+        applyLookRange(); // back to a map: the tilt stops at 30 again
         mapView.requestRender();
     }
 

--- a/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/akylas/cartotest/demo/DemoMap.java
@@ -1125,7 +1125,9 @@ public class DemoMap {
         if (cachedVector == null) {
             HTTPTileDataSource source = new HTTPTileDataSource(DemoConfig.VECTOR_MIN_ZOOM, DemoConfig.VECTOR_MAX_ZOOM, DemoConfig.VECTOR_URL);
             source.setHTTPHeaders(userAgentHeaders());
-            cachedVector = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.VECTOR_CACHE_DB));
+            PersistentCacheTileDataSource cache = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.VECTOR_CACHE_DB));
+            cache.setCapacity(DemoConfig.PERSISTENT_CACHE_MB * 1024L * 1024L);
+            cachedVector = cache;
         }
         return cachedVector;
     }
@@ -1138,7 +1140,9 @@ public class DemoMap {
         if (cachedDem == null) {
             HTTPTileDataSource source = new HTTPTileDataSource(DemoConfig.DEM_MIN_ZOOM, DemoConfig.DEM_MAX_ZOOM, DemoConfig.DEM_URL);
             source.setEncoding(DemoConfig.DEM_ENCODING);
-            cachedDem = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.DEM_CACHE_DB));
+            PersistentCacheTileDataSource cache = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.DEM_CACHE_DB));
+            cache.setCapacity(DemoConfig.DEM_PERSISTENT_CACHE_MB * 1024L * 1024L);
+            cachedDem = cache;
         }
         return cachedDem;
     }
@@ -1147,7 +1151,9 @@ public class DemoMap {
         if (cachedRaster == null) {
             HTTPTileDataSource source = new HTTPTileDataSource(DemoConfig.RASTER_MIN_ZOOM, DemoConfig.RASTER_MAX_ZOOM, DemoConfig.RASTER_URL);
             source.setHTTPHeaders(userAgentHeaders());
-            cachedRaster = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.RASTER_CACHE_DB));
+            PersistentCacheTileDataSource cache = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.RASTER_CACHE_DB));
+            cache.setCapacity(DemoConfig.PERSISTENT_CACHE_MB * 1024L * 1024L);
+            cachedRaster = cache;
         }
         return cachedRaster;
     }
@@ -1157,7 +1163,9 @@ public class DemoMap {
         if (cachedContourTiles == null) {
             HTTPTileDataSource source = new HTTPTileDataSource(DemoConfig.CONTOUR_TILES_MIN_ZOOM, DemoConfig.CONTOUR_TILES_MAX_ZOOM, DemoConfig.CONTOUR_TILES_URL);
             source.setHTTPHeaders(userAgentHeaders());
-            cachedContourTiles = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.CONTOUR_TILES_CACHE_DB));
+            PersistentCacheTileDataSource cache = new PersistentCacheTileDataSource(source, cacheDbPath(DemoConfig.CONTOUR_TILES_CACHE_DB));
+            cache.setCapacity(DemoConfig.PERSISTENT_CACHE_MB * 1024L * 1024L);
+            cachedContourTiles = cache;
         }
         return cachedContourTiles;
     }

--- a/scripts/ios-dev/CartoDemo/DemoMap.m
+++ b/scripts/ios-dev/CartoDemo/DemoMap.m
@@ -919,17 +919,22 @@ static const DemoFeature LAYER_ORDER[] = {
  * Free roam and how far above the horizon the view may look.
  *
  * A NEGATIVE tilt is the look up: the camera stays where the tilt geometry put it and only the view
- * pitches, so nothing about zoom or the visible tiles changes. A map stops at the horizon by
- * default (tilt range 0..90), which is why this has to be asked for.
+ * pitches, so nothing about zoom or the visible tiles changes.
+ *
+ * A map stops at 30: below that the camera grazes the terrain and at 0 it looks along the ground
+ * from under it. Only the two modes that are ABOUT looking up - free roam and the star sky - get
+ * the full range.
  */
 - (void)applyLookRange {
     NTOptions *options = [self.mapView getOptions];
-    [options setFreeRoamMode:[self freeRoamMode:[DemoConfig stringFor:@"freeRoam"]]];
+    NSString *freeRoam = [DemoConfig stringFor:@"freeRoam"];
+    [options setFreeRoamMode:[self freeRoamMode:freeRoam]];
     [options setPanningSpeedMode:[self panningSpeedMode:[DemoConfig stringFor:@"panSpeed"]]];
     [options setFreeRoamLookSensitivity:[DemoConfig floatFor:@"lookSensitivity"]];
     [options setFreeRoamMoveSpeed:[DemoConfig floatFor:@"moveSpeed"]];
-    [options setTiltRange:[[NTMapRange alloc] initWithMin:-fmaxf(30, [DemoConfig floatFor:@"lookUp"])
-                                                      max:90]];
+    BOOL lookUp = ![freeRoam isEqualToString:@"off"] || [DemoConfig boolFor:@"starSky"];
+    float minTilt = lookUp ? -fmaxf(30, [DemoConfig floatFor:@"lookUp"]) : 30;
+    [options setTiltRange:[[NTMapRange alloc] initWithMin:minTilt max:90]];
 }
 
 - (enum NTPanningSpeedMode)panningSpeedMode:(NSString *)name {
@@ -1325,6 +1330,7 @@ static const DemoFeature LAYER_ORDER[] = {
     }
     [self setMapLayerOpacity:0];
     [self rebuildLayers];
+    [self applyLookRange]; // back to a map: the tilt stops at 30 again
     [self requestRender];
 }
 


### PR DESCRIPTION
## Summary

**Parked, not proposed for merge.** Pushed so the work and the measurements survive — see the
verdict in the submodule PR.

The SDK half of per-fragment contours: `CompositeVectorTileLayer::applyContourPaint` resolves the
`#contour` layer's line rules into elevation classes every frame and either hands them to the layer
that draws the terrain surface (the source then emits only the label stubs the text rules need) or
leaves the traced geometry alone when the shader cannot reproduce the style.

Also carries two fixes that are worth having on their own and only bite when the bands are on:

- **The bands forced the whole drape to re-bake every frame.** `paintsEveryDrapeTile()` returned
  true for any layer holding contour classes — right when the bands were baked into the drape, wrong
  once they moved into the surface pass, where they bake nothing. 96 bakes per interval against 21.
- **The band width did not match the traced line.** A style width is in unscaled-DPI units and
  reaches device pixels through three steps of the traced path; the bands took it as pixels and drew
  the same style 3.2× too thin.

## Why it is parked

3.5% of a frame, ~1 s of process CPU and 1.5 s earlier contours on a real style, for ~1000 lines
across two repos — and the bands and the geometry do not currently draw the same map (contour ink
0.54% against 0.17% at the same camera, unexplained). Numbers in
https://github.com/farfromrefug/mobile-carto-libs/pull/39.

## Testing

- `clang++ -fsyntax-only` clean on every touched translation unit.
- Device-verified on a Crosscall, opt-in behind `debug.carto.shadercontours 1` (off by default).

## Depends on

https://github.com/farfromrefug/mobile-carto-libs/pull/39