### PR TITLE
perf(labels): keep the 3D label batches across frames

### DIFF
--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -166,17 +166,20 @@ namespace carto {
                        (maskNs - lastMaskNs) / 1.0e6, (drapeNs - lastDrapeNs) / 1.0e6);
             lastMaskNs = maskNs; lastDrapeNs = drapeNs;
 
-            static long long lastLabelBuild = 0, lastLabelBatch = 0, lastLabelVerts = 0, lastLineLayouts = 0;
+            static long long lastLabelBuild = 0, lastLabelBatch = 0, lastLabelVerts = 0, lastLineLayouts = 0, lastLabelReplays = 0, lastLabelPatches = 0;
             long long labelBuild = RenderStats::labelVertexBuildNs.load();
             long long labelBatch = RenderStats::labelBatchNs.load();
             long long labelVerts = RenderStats::labelsDrawnVertices.load();
             long long lineLayouts = RenderStats::lineLayoutBuilds.load();
-            Log::Infof("RenderStats: labels built=%lld lineLayouts=%lld buildMs=%.1f batchMs=%.1f (per interval)",
+            long long labelReplays = RenderStats::labelBatchesReplayed.load();
+            long long labelPatches = RenderStats::labelBatchesPatched.load();
+            Log::Infof("RenderStats: labels built=%lld lineLayouts=%lld buildMs=%.1f batchMs=%.1f replayedBatches=%lld patchedBatches=%lld (per interval)",
                        labelVerts - lastLabelVerts, lineLayouts - lastLineLayouts,
                        (labelBuild - lastLabelBuild) / 1.0e6,
-                       (labelBatch - lastLabelBatch) / 1.0e6);
+                       (labelBatch - lastLabelBatch) / 1.0e6,
+                       labelReplays - lastLabelReplays, labelPatches - lastLabelPatches);
             lastLabelBuild = labelBuild; lastLabelBatch = labelBatch; lastLabelVerts = labelVerts;
-            lastLineLayouts = lineLayouts;
+            lastLineLayouts = lineLayouts; lastLabelReplays = labelReplays; lastLabelPatches = labelPatches;
 
             static long long lastPrep[4] = { 0 }, lastLabelSplit[2] = { 0 }, lastLabelXf = 0, lastLabelAttr = 0;
             const long long prep[4] = {

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -792,6 +792,7 @@ namespace carto {
             contentDepthShift = TERRAIN_TANGRAM_DEPTH_SHIFT;
         }
         tileRenderer->setTerrainContentDepthShift(contentDepthShift);
+        tileRenderer->setLabelBatchCaching(getLabelBatchCaching());
         // Metre-constant clearance for draped LINES over the shared ground (see applyDepthBias in
         // vt). A line chords over the relief between its own vertices; under a ground that writes
         // depth that sag is what cuts roads and contours into fragments. The quantity is metres of
@@ -1158,6 +1159,22 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
         return depthShift;
 #else
         return 0.0f;
+#endif
+    }
+
+    bool TileRenderer::getLabelBatchCaching() {
+#ifdef __ANDROID__
+        //   adb shell setprop debug.carto.labelcache 0   (rebuild the 3D label batches every frame)
+        static const bool enabled = [] {
+            char property[PROP_VALUE_MAX] = { 0 };
+            if (__system_property_get("debug.carto.labelcache", property) > 0) {
+                return std::atoi(property) != 0;
+            }
+            return true;
+        }();
+        return enabled;
+#else
+        return true;
 #endif
     }
 

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -169,6 +169,8 @@ namespace carto {
         bool isPlanarProjectionMode() const;
         // Tangram-model measurement switch, read once from debug.carto.depthshift (Android only).
         static float getTerrainContentDepthShift();
+        // Measurement switch for the kept 3D label batches, debug.carto.labelcache (Android only).
+        static bool getLabelBatchCaching();
         // tangram res/scenes/terrain-3d.yaml: depth_shift = -0.02*u_proj[2][3], and [2][3] is -1.
         static constexpr float TERRAIN_TANGRAM_DEPTH_SHIFT = 0.02f;
         // It is a per-step separation between coplanar style layers, not a budget to spread over

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -519,10 +519,50 @@ because the key moved), this rules out the source side entirely: the timed regio
 **writing into the batch arrays**, and copying N cached entries writes exactly the bytes the loop
 wrote. No cache of what goes into the batch can win.
 
-So the only remaining lever is not writing the batch at all: quantize the anchor, keep the arrays
-and their GL buffers across frames, and re-upload solely when the label set, placements, opacities
-or style slots change — for which step 1 has now removed the blocker. Everything cheaper than that
-has been measured and does not work.
+**Step 3, the batch kept across frames, is done — and there was a second view dependency the plan
+above missed.** `Label::setupCoordinateSystem` snaps the anchor to a quarter of the screen pixel
+grid (that is what keeps glyphs at a stable subpixel phase), and it did so by projecting the anchor
+with the view-projection and inverting it back. So the anchor moved on every camera translation
+whatever the scale did — and it cost a **4x4 double inverse per label per frame**, on the culler
+thread too. Both are fixed: `ViewState` now carries `viewProjMatrix`/`invViewProjMatrix`, and for
+the shader-cancel modes `labelVsh` does the snap itself on `anchorClip.xy` against
+`uLabelScreenSize`. The CPU anchor is then `placement->position − viewState.labelOrigin`, where
+`labelOrigin` is latched and only re-based once the camera has moved `LABEL_ORIGIN_LATCH_DISTANCE`
+(256 internal units, ~10 km); the residual rides in the label matrix, which already carried a
+translate. The culler keeps `viewState.origin` — its envelopes are camera-relative by construction.
+
+What survives a frame, then, is the whole 3D pass: `GLTileRenderer::LabelBatchCache` holds one
+`PersistentLabelBatch` per batch (its VBOs, its parameter tables, and the label matrix without the
+camera), and a hit re-issues the draws with new uniforms only. Validity is two counters, not a
+per-label scan:
+
+- `Label::getDrawGeneration()` — bumped by placement, layout and elevation changes, and by a label
+  appearing or disappearing. Only 3D-orientation labels bump it, and only while they are actually
+  drawn: measured over one city pan, **4184 re-anchors of unplaced labels against 24 of visible
+  ones**, so an unguarded counter is stale every frame for work no batch ever held.
+- `Label::getOpacityGeneration()` — a fade in progress. It does not invalidate: the batch keeps a
+  CPU copy of its attribs plus each label's vertex range, and `patchLabelBatchOpacities` rewrites
+  one byte per glyph of the labels that moved and `glBufferSubData`s the dirty span.
+
+Plus the view: `zoom`, `rotation`, `tilt` and `planarProjection` are baked into the buffers (the
+glyph scale, and the style functions that read `view::`). Everything else the camera does —
+position, **focus distance**, screen size — only reaches uniforms. That last one mattered: over
+terrain `focusDistance` changes on every frame, and while it was in the test the cache never once
+hit.
+
+**Measured** (Crosscall, assets style, 5.724/45.188 z15 t45, scripted pan, `debug.carto.labelcache`
+A/B): `pass3D labels3DMs` **67–76 → 25–33 ms/interval**, labels rebuilt 3900 → 1900 per interval,
+~200 batches a second replayed and ~80 patched. **Frame rate: unchanged** — three interleaved
+rounds gave medians 26.4/26.0/25.6 fps with the cache against 26.4/25.8/25.8 without. The pass is
+~1.5 ms of a ~38 ms frame, and this bench's run-to-run spread is larger than that. Screenshot diff
+against the cache off is 1.38% where two runs with it ON differ by 1.06% — no systematic shift.
+
+So it removes the work it was designed to remove and buys no frames at this camera. The label cost
+that is left is **2D**: `labels2DMs` is 48–94 ms/interval, dominated by `LINE` layout
+(`lineMs` 28 of `buildMs` 44), which follows the projected line and cannot be kept — see
+`updateLineVertexData`. Note also that only a style using `text-placement: nutibillboard` puts
+labels in the 3D pass at all; with the demo's inline style the 3D pass is 1.2 ms/interval and this
+whole mechanism measures nothing.
 
 ## Against tangram
 

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -472,10 +472,33 @@ zoom filter.
   batch writes the same bytes the loop did, so a source-side cache cannot win if the cost is the
   batch write.
 
-  What is left is the batch itself: give the vertex data a **quantized** anchor (absolute world
-  coordinates do not survive float32 — `WORLD_SIZE` is 2²⁰, so ~2 m of jitter at the world edge)
-  and keep it in a persistent buffer, re-uploading only when the label set, placements, scales or
-  opacities change. Not implemented.
+  What is left is the batch itself — and it has a prerequisite that has to come first.
+
+### A persistent label batch, and what blocks it
+
+The batch can only be kept across frames if nothing in it changes. Two things do:
+
+- **The anchor**, `placement->position − viewState.origin`, moves with the camera. Solvable: quantize
+  the origin to a grid and put it in `labelBatchParams.labelMatrix` (which already carries a
+  `translate`). Absolute world coordinates are not an option — `WORLD_SIZE` is 2²⁰, so float32
+  jitters ~2 m at the world edge, which is why the camera-relative form exists.
+- **The scale**, and this is the real blocker. `offsets` hold `cachedVertex * scale`, and `scale`
+  carries `calculateTerrainScaleFactor` = `depth / focusDistance`, quantized to ~1.09% steps. At z15
+  the view is ~1 km wide and a pan moves ~0.5 km/s, so a label 500 m out changes depth by ~18 m per
+  frame ≈ 3.6% — past the quantum. **Most labels change scale on most panned frames.**
+
+So a persistent buffer, or any cache of the scaled offsets, rebuilds constantly — which is what the
+reverted experiment above measured. The prerequisite is to stop scaling on the CPU: the perspective
+cancel is a division by view depth, and the vertex shader can do it from `gl_Position.w`, which is
+tangram's screen-space label model. CPU offsets then hold glyph units × zoom scale, constant through
+a pan, and the batch becomes reusable.
+
+The order to do it in, then: (1) move the perspective cancel into `labelVsh`, keeping
+`calculateTerrainScaleFactor` on the CPU **for the culler's envelopes only** (collision is decided in
+screen space and must not change); (2) quantize the batch anchor; (3) keep the batch arrays and GL
+buffers across frames, invalidated by the label set, placements, opacities, style slots and the
+anchor. Each step is separately measurable — (1) alone should show `transformMs` collapse. Nothing
+here is implemented.
 
 ## Against tangram
 

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -495,10 +495,22 @@ a pan, and the batch becomes reusable.
 
 The order to do it in, then: (1) move the perspective cancel into `labelVsh`, keeping
 `calculateTerrainScaleFactor` on the CPU **for the culler's envelopes only** (collision is decided in
-screen space and must not change); (2) quantize the batch anchor; (3) keep the batch arrays and GL
-buffers across frames, invalidated by the label set, placements, opacities, style slots and the
-anchor. Each step is separately measurable — (1) alone should show `transformMs` collapse. Nothing
-here is implemented.
+screen space and must not change); (2) cache the offsets, which step 1 has made view-independent;
+(3) quantize the batch anchor and keep the batch arrays and GL buffers across frames, invalidated by
+the label set, placements, opacities, style slots and the anchor.
+
+**Step 1 is done.** `Label::CAMERA_AXIS_DEPTH_OFFSET` (attribs[3] = 2) tells `labelVsh` to scale the
+offset by `clamp(anchorClip.w * uLabelDepthScale, 0.05, 8.0)` — clip `w` is the view depth the CPU
+factor was a ratio of, and `uLabelDepthScale` is 1 / camera-to-focus distance. The CPU then emits
+offsets divided by that factor, so what is in the buffer depends on the zoom and the style, not on
+where the camera is. It applies to `BILLBOARD_3D` and `LINE_BILLBOARD_3D` under a planar projection;
+callouts keep the CPU factor (their lift and shift are measured against the same scale), and `LINE`
+labels are view-dependent by construction.
+
+It changes no frame rate on its own — 27.0–27.5 fps against a 27.1 baseline, and the per-glyph loop
+still runs — which is the expected result: it is the enabler, not the win. One known cosmetic
+consequence to watch: label plates still take the CPU factor, which is quantized to ~1.09% steps
+where the shader's is exact, so a plate can be up to ~1% off its text.
 
 ## Against tangram
 

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -451,9 +451,31 @@ zoom filter.
   than on a large one, and up to **five times** what the single-raster build drew — a soft white
   glow instead of an outline, reported as "halo huge at radius 2, fine at 1". If halos ever look
   wrong again, check that term before the style.
-- **Vertex data.** Glyph quads are rebuilt from scratch for every visible label every frame and
-  uploaded as one batch (`labelVertexBuildNs`, `labelBatchNs`). A GPU-billboard path would remove
-  the per-frame world transform (`labelTransformNs`) — it is on the backlog, not implemented.
+- **Vertex data.** The glyph layout is already cached per label (`_cachedVertices`, `_cachedValid`)
+  and the shader already expands the billboard from `offsets` + `uLabelAxisX/Y`. What runs every
+  frame is re-emitting the **batch**: the anchor is camera-relative
+  (`placement->position − viewState.origin`), so every vertex changes as soon as the camera moves.
+
+  Measured on the city pan with draping on (Crosscall, 5.724/45.188 z15 t45, 27 fps, 28 frames per
+  interval): `pass3D labels3D` 82.9 ms/interval (2.96 ms/frame), `labels2D` 46.3 (1.65),
+  `buildMs` 45.7 (1.63), `batchMs` 21.6 (0.77), 3693 labels rebuilt (132/frame). The build splits
+  placement 4.4 / line 10.3 / transform 10.8 / attrib 13.9 ms per interval. That is ~4.6 ms of a
+  31.6 ms CPU frame, against a 37 ms wall frame and the 33.3 ms two-vsync boundary — the right size
+  to matter, which is why it was tried.
+
+  **Caching the two per-glyph loops does NOT help** (tried 2026-08-13, reverted): keeping the scaled
+  `offsets` and the per-frame `attribs` per label, keyed on scale / camera axes / style slots /
+  opacity, measured 26.6–27.4 fps against 27.1, with `transformMs` and `attribMs` unchanged. Two
+  reasons, and the first is visible in the code: `scale` carries
+  `calculateTerrainScaleFactor` = `depth / focusDistance`, which changes past its 1% quantum for
+  most labels on every panned frame, so the cache misses; and copying N cached entries into the
+  batch writes the same bytes the loop did, so a source-side cache cannot win if the cost is the
+  batch write.
+
+  What is left is the batch itself: give the vertex data a **quantized** anchor (absolute world
+  coordinates do not survive float32 — `WORLD_SIZE` is 2²⁰, so ~2 m of jitter at the world edge)
+  and keep it in a persistent buffer, re-uploading only when the label set, placements, scales or
+  opacities change. Not implemented.
 
 ## Against tangram
 

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -508,9 +508,21 @@ callouts keep the CPU factor (their lift and shift are measured against the same
 labels are view-dependent by construction.
 
 It changes no frame rate on its own — 27.0–27.5 fps against a 27.1 baseline, and the per-glyph loop
-still runs — which is the expected result: it is the enabler, not the win. One known cosmetic
-consequence to watch: label plates still take the CPU factor, which is quantized to ~1.09% steps
-where the shader's is exact, so a plate can be up to ~1% off its text.
+still runs — which is the expected result: it is the enabler, not the win. Device-checked: label
+sizes hold through tilt and pan. One cosmetic consequence: label plates still take the CPU factor,
+which is quantized to ~1.09% steps where the shader's is exact, so a plate can sit ~1% off its text.
+
+**Step 2 then measured nothing, and that settles the mechanism.** With the offsets now
+view-independent, caching them per label gave `transformMs` 10.3–11.4 ms/interval against a 9.6–10.8
+baseline and 24.9–27.0 fps against 27.1 — reverted. Together with the first attempt (which missed
+because the key moved), this rules out the source side entirely: the timed region is dominated by
+**writing into the batch arrays**, and copying N cached entries writes exactly the bytes the loop
+wrote. No cache of what goes into the batch can win.
+
+So the only remaining lever is not writing the batch at all: quantize the anchor, keep the arrays
+and their GL buffers across frames, and re-upload solely when the label set, placements, opacities
+or style slots change — for which step 1 has now removed the blocker. Everything cheaper than that
+has been measured and does not work.
 
 ## Against tangram
 

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -245,9 +245,32 @@ tiles were never the cost: 66 decodes, 5–6 s of thread time. Elevation was, th
 
 What is left, in order: **contour tile generation** (44 child fetches, 6–22 s of thread time — the
 `#contour` slot is a whole second tile set, which is what [07-hillshade-contours.md](07-hillshade-contours.md)
-would remove by computing contours in the terrain fragment shader), the network itself, and the
-decode pool (`Options::setTileThreadPoolSize`, default **1**; tangram runs 2). Raising the pool was
-measured as no win *while* the network dominated — retake it now that it does not.
+would remove by computing contours in the terrain fragment shader) and the network itself.
+
+**The decode pool changes almost nothing here.** `Options::setTileThreadPoolSize` retaken
+2026-08-13 now that the network no longer dominates — interleaved pairs, `--es tilePool 1|2`, warm
+caches, city camera:
+
+| | 3D | 2D (`--es terrain false`) |
+|---|---|---|
+| tiles decoded | 25 either way | 22 either way |
+| first→last decode, pool 1 | 2.98 / 3.20 s | 2.68 / 2.59 s |
+| first→last decode, pool 2 | 3.26 / 2.93 s | **2.22 / 2.17 s** |
+| pan fps, pool 1 | 26.7 median | 20.1–22.9 |
+| pan fps, pool 2 | 26.8 median | 19.8–22.8 |
+
+The pan is identical in both modes. Decode finishes at the same moment in 3D — 25 tiles land within
+~3 s of the first, paced by fetch and cache I/O rather than CPU, so a second thread has nothing to
+win — while in 2D, where the frame leaves more CPU over, it finishes ~18% sooner (2 of 2 pairs).
+Either setting is defensible; **1 remains the default** because the gain is confined to the load
+phase in 2D.
+
+Two metrics to avoid here, both of which produced a wrong answer first time round: fps measured
+*while tiles stream* (it conflates "did less work" with "ran faster" — the arm that gets more
+content on screen scores worse), and fps on a **static camera** after loading, which never settles
+([Getting a trustworthy number](#getting-a-trustworthy-number)). An earlier version of this section
+claimed pool 2 costs ~15% of the frame rate on that basis; time-to-content and a scripted pan do
+not support it.
 
 Unrelated but on the same path: the first `loadTile` on a persistent cache runs `loadTileInfo`, a
 full-table scan of the cache DB, on the tile thread — **1.4 s** on the first (cold page cache) run


### PR DESCRIPTION
## Summary

- Pointer bump for the vt change that keeps the 3D label batches across frames.
- `debug.carto.labelcache 0` (Android) rebuilds and re-uploads them every frame — the A/B switch the numbers below came from. `RenderStats` reports batches replayed and batches patched for a fade alone.
- `docs/rendering/06-labels.md` records the mechanism, the two things the earlier plan had wrong, and the result — including that the result is *no frame-rate change*.

## What the numbers say

Crosscall / Adreno 610, `--es style assets --es lon 5.724 --es lat 45.188 --es zoom 15 --es tilt 45`, scripted pan (`--es anim pan --es animDelay 22000 --es animDuration 25 --es animLonDelta 0.05`):

| | cache off | cache on |
|---|---|---|
| `pass3D labels3DMs` | 67-76 ms/interval | **25-33** |
| labels rebuilt | ~3900/interval | ~1900 |
| fps (3 interleaved rounds, medians) | 26.4 / 25.8 / 25.8 | 26.4 / 26.0 / 25.6 |

So the pass does ~60% less work, ~1.5 ms of a ~38 ms frame, and **the frame rate does not move** — that is under this bench's run-to-run spread. Kept anyway as CPU headroom, with the switch to turn it off.

## Two corrections to the plan this page carried

- **The scale was not the only thing keeping the batch camera-dependent.** The quarter-pixel anchor snap re-projected the anchor through the view-projection every frame, so the anchor vertex moved on any camera translation — and it cost a 4x4 double inverse per label per frame, on the culler thread too. Both are fixed in the vt PR.
- **`focusDistance` must not invalidate.** Over terrain it changes on every frame; while it was in the invalidation test the cache hit exactly zero times. It only ever reaches a uniform, which the replay recomputes.

## Where the label cost sits now

`labels2DMs` is **48-94 ms/interval** against the 3D pass's 25-33, dominated by `LINE` layout (`lineMs` 28 of `buildMs` 44). That run follows the line as the *current* camera projects it and cannot be kept across frames — tangram rebuilds it every frame too (`CurvedLabel::updateScreenTransform`). Any win there has to make the layout itself cheaper.

Also recorded, because it cost a full round: only a style using `text-placement: nutibillboard` puts labels in the 3D pass at all. With the demo's default inline style that pass is 1.2 ms/interval and this whole mechanism measures nothing — bench it with `--es style assets`.

## Testing

`clang++ -fsyntax-only` clean on the touched translation units; built through `scripts/android-dev` and run on device, numbers above. Screenshot diff cache-on vs cache-off is 1.38% where two runs with it on differ by 1.06% — no systematic shift.

A reviewer should still check on device: label sharpness under a slow pan (the subpixel snap moved to the shader) and plate fit under a strong tilt.

## Depends on

https://github.com/farfromrefug/mobile-carto-libs/pull/41 — merge it first, then rebase this pointer bump onto the merged commit.