### PR TITLE
perf(vectortiles): cut the style symbolizer context from 277 ms to 27 ms

### DIFF
--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -600,10 +600,9 @@ namespace carto {
             }
             _pixelScale = pixelScale;
             // The glyph render size is picked from it when a tile is decoded, so the glyph/stroke
-            // maps have to go. The compiled map does not depend on it - reloading the style here
-            // cost a full parse + compile (~0.5 s for a 23-layer style) on every layer that joins
-            // a map, which is where this fires.
-            _assetPackageSymbolizerContexts.clear();
+            // maps have to go - but only those. Dropping the whole context reloaded the style's
+            // fonts too (~134 ms of a cold start, and this fires when a layer joins a map).
+            resetSymbolizerContextRasterMaps();
             updateSymbolizerContext();
         }
         notifyDecoderChanged();
@@ -853,8 +852,27 @@ namespace carto {
         _styleAssetPackage = assetPackage;
         _map = map;
         _mapSettings = std::make_shared<mvt::Map::Settings>(_map->getSettings());
+        // Both are properties of the compiled map alone, and classifying the parameters is ~38 ms
+        // on a 23-layer style - updateSymbolizerContext also runs when only the pixel scale or a
+        // fallback font changed, and the map is the same one there.
+        _liveParameters = mvt::resolveLiveNutiParameters(*_map);
+        _selectionParameter = _map->getSelectionParameter() ? _map->getSelectionParameter()->name : std::string();
 
         updateSymbolizerContext();
+    }
+
+    void MBVectorTileDecoder::resetSymbolizerContextRasterMaps() {
+        // The stroke and glyph maps hold output rasterized at one pixel scale; the font and bitmap
+        // managers hold the decoded fonts and bitmaps, which do not depend on it.
+        for (auto it = _assetPackageSymbolizerContexts.begin(); it != _assetPackageSymbolizerContexts.end(); it++) {
+            const std::shared_ptr<const mvt::SymbolizerContext>& symbolizerContext = it->second;
+            if (!symbolizerContext) {
+                continue;
+            }
+            auto strokeMap = std::make_shared<vt::StrokeMap>(STROKEMAP_SIZE, STROKEMAP_SIZE);
+            auto glyphMap = std::make_shared<vt::GlyphMap>(GLYPHMAP_SIZE, GLYPHMAP_SIZE);
+            it->second = std::make_shared<mvt::SymbolizerContext>(symbolizerContext->getBitmapManager(), symbolizerContext->getFontManager(), strokeMap, glyphMap, symbolizerContext->getSettings());
+        }
     }
 
     void MBVectorTileDecoder::updateSymbolizerContext() {
@@ -939,8 +957,6 @@ namespace carto {
             _parameterStore = std::make_shared<mvt::NutiParameterStore>();
         }
         updateParameterStore();
-        _liveParameters = mvt::resolveLiveNutiParameters(*_map);
-        _selectionParameter = _map->getSelectionParameter() ? _map->getSelectionParameter()->name : std::string();
         updateSelectionState();
 
         _symbolizerContextSettings = std::make_shared<mvt::SymbolizerContext::Settings>(symbolizerContext->getSettings().getTileSize(), _parameterStore, symbolizerContext->getSettings().getFallbackFont(), _pixelScale, _selectionState);

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -898,9 +898,22 @@ namespace carto {
 
                 for (const std::string& assetName : assetPackage->getAssetNames()) {
                     if (assetName.size() > fontPrefix.size() && assetName.substr(0, fontPrefix.size()) == fontPrefix) {
-                        if (std::shared_ptr<BinaryData> fontData = assetPackage->loadAsset(assetName)) {
-                            fontManager->loadFontData(*fontData->getDataPtr());
+                        // Deferred: reading a font's name means decompressing it, and a style
+                        // packs far more fonts than it uses - the bundled one carries 15 and asks
+                        // for 4. The hint is the file name, which is what a font is normally
+                        // called; a style whose files say otherwise still resolves, by the sweep
+                        // in FontManager, and only pays for it then.
+                        std::string hintName = FileUtils::GetFileName(assetName);
+                        std::size_t extPos = hintName.rfind('.');
+                        if (extPos != std::string::npos) {
+                            hintName = hintName.substr(0, extPos);
                         }
+                        fontManager->addPendingFontData(hintName, [assetPackage, assetName]() {
+                            if (std::shared_ptr<BinaryData> fontData = assetPackage->loadAsset(assetName)) {
+                                return *fontData->getDataPtr();
+                            }
+                            return std::vector<unsigned char>();
+                        });
                     }
                 }
             }

--- a/all/native/vectortiles/MBVectorTileDecoder.h
+++ b/all/native/vectortiles/MBVectorTileDecoder.h
@@ -204,6 +204,8 @@ namespace carto {
     protected:
         void updateCurrentStyleSet(const std::variant<std::shared_ptr<CompiledStyleSet>, std::shared_ptr<CartoCSSStyleSet> >& styleSet);
         void updateSymbolizerContext();
+        // Drops what a pixel-scale change invalidates, and only that - see setPixelScale.
+        void resetSymbolizerContextRasterMaps();
         void updateParameterStore();
         void updateSelectionState();
         bool setStyleParameterInternal(const std::string& param, const std::string& value);

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -374,6 +374,29 @@ joins a map — so every startup paid the ~0.5 s twice. Split into `updateSymbol
 (fonts, bitmap/stroke/glyph maps, settings), the second pass is **~100–130 ms**. `addFallbackFont`
 took the same path. `setCartoCSSLayerNamesIgnored` genuinely changes compilation and still reloads.
 
+**…and that second pass then cost 133 ms for nothing.** Two things were being redone that a pixel
+scale cannot change:
+
+- `setPixelScale` cleared the whole `_assetPackageSymbolizerContexts` entry, so the style's fonts
+  were decoded again — **75 ms for the 15 fonts** of the bundled project (1.1 MB of woff2) plus
+  27 ms for the system fallback. Only the **stroke and glyph maps** hold anything rasterized at a
+  pixel scale; the font and bitmap managers do not. `resetSymbolizerContextRasterMaps` now replaces
+  those two and keeps the managers.
+- `mvt::resolveLiveNutiParameters` ran on every `updateSymbolizerContext` — **38 ms** on the
+  23-layer style — although it is a property of the compiled map alone. It moved next to
+  `_map`'s assignment, with `getSelectionParameter`.
+
+Measured on the Crosscall, three interleaved pairs, the whole `setPixelScale` call: **133.5–133.9 →
+0.5 ms**, spread under 0.5 ms. It does *not* show up end to end — surface-created → first tile
+request varies by ±150 ms on this device, which swamps it — so this is CPU removed from the startup
+path, not a startup number.
+
+Where the rest of a cold style load goes today (same device, bundled `assets` project, 23 layers):
+parse + compile + translate **251 ms**, first symbolizer context **143 ms** (of which 75 ms is
+fonts). The largest untouched item is the eager font load: every font in the package is decoded at
+load whether the style uses it or not, and `FontManager` already has a lazy loader hook for the
+system fonts.
+
 **Decoding a tile: 120–150 ms mean, ~0.5 s worst** at a z16 city camera. Section split (probe
 overhead ~30%, so read the shares, not the absolutes):
 
@@ -530,6 +553,7 @@ a feature-id vertex attribute in `vt` and shader support — not done.
 | an off-screen, already-anchored label defers its re-anchor | 1.60 → 1.70 fps — small, most dirty labels do hold a placement |
 | label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
 | `setPixelScale` rebuilds only the symbolizer context, not the compiled map | startup style cost 2 × 0.5–0.7 s → one load plus a ~0.1 s context rebuild |
+| `setPixelScale` keeps the fonts and bitmaps, drops only the rasterized maps; live-parameter classification moved to where the map changes | the whole call **133.5–133.9 → 0.5 ms**, interleaved ×3 |
 | CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
 | CartoCSS compile: skip a zoom whose predicate results repeat, reuse the trial property set | compile 157 → 129 ms, `buildMap` → 220 ms |
 | CartoCSS compile: field and predicate bitmasks on the property set, evaluate each property once | compile 175.4 → 117.4 ms paired (same style, later and bigger than the rows above) |

--- a/docs/rendering/10-performance.md
+++ b/docs/rendering/10-performance.md
@@ -393,9 +393,28 @@ path, not a startup number.
 
 Where the rest of a cold style load goes today (same device, bundled `assets` project, 23 layers):
 parse + compile + translate **251 ms**, first symbolizer context **143 ms** (of which 75 ms is
-fonts). The largest untouched item is the eager font load: every font in the package is decoded at
-load whether the style uses it or not, and `FontManager` already has a lazy loader hook for the
-system fonts.
+fonts).
+
+**The style's fonts are decoded when they are asked for, not when it loads.** Registering a font
+means reading its name table, and a **woff2 has to be decompressed to be read at all** — measured
+per font on the Crosscall, and the cost tracks the compression, not the typeface: `osm.ttf`
+(69 KB, plain TTF) **0.1 ms**, a 26 KB woff2 **1.1 ms**, a 180 KB woff2 **11.4 ms**. The bundled
+project packs 15 fonts and asks for **4** (DIN Pro Medium / Medium Italic / Bold, and `osm` for the
+icon glyphs; `Arial` resolves to the system Roboto), so 10 were decompressed for nothing — and the
+four NotoSans among them are 43 ms of the 62.
+
+`FontManager::addPendingFontData` takes a font plus a **hint name** — the file name — and decodes it
+only when a request normalizes to that hint (`DINPro-MediumItalic.woff2` ↔ `DIN Pro Medium Italic`,
+the same normalization `SystemFontUtils` uses for `/system/fonts`). A request matching no hint falls
+to the `FontDataLoader`, and only then sweeps every font still pending and registers the names they
+really carry — so a package whose file names disagree with its font names resolves exactly as eager
+loading did, once. **Symbolizer context 98 → 27 ms**, three interleaved pairs.
+
+The order matters and cost a round: with the sweep *before* the loader, resolving the default
+fallback font — `Arial`, which no style package carries — swept all 15 on every context build and
+the change measured exactly nothing. The one behaviour difference left: a name the `FontDataLoader`
+also answers now resolves from there rather than from a package font whose *file* name did not
+match. Eagerly loaded fonts always won that; hinted ones still do.
 
 **Decoding a tile: 120–150 ms mean, ~0.5 s worst** at a z16 city camera. Section split (probe
 overhead ~30%, so read the shares, not the absolutes):
@@ -554,6 +573,7 @@ a feature-id vertex attribute in `vt` and shader support — not done.
 | label lines tesselated for reading, not for painting (no lattice split, surface-cell step) | **1.75 → 2.10 fps**, `prepare` 157 → 72 ms |
 | `setPixelScale` rebuilds only the symbolizer context, not the compiled map | startup style cost 2 × 0.5–0.7 s → one load plus a ~0.1 s context rebuild |
 | `setPixelScale` keeps the fonts and bitmaps, drops only the rasterized maps; live-parameter classification moved to where the map changes | the whole call **133.5–133.9 → 0.5 ms**, interleaved ×3 |
+| a style's fonts are decoded on first use, matched by file name (the bundled project packs 15 and asks for 4) | symbolizer context **98 → 27 ms**, interleaved ×3 |
 | CartoCSS compile: per-zoom predicate memo, field-bucketed property insert, interned field ids | compile 264 → 157 ms, `buildMap` 362 → 261 ms (23-layer style, device) |
 | CartoCSS compile: skip a zoom whose predicate results repeat, reuse the trial property set | compile 157 → 129 ms, `buildMap` → 220 ms |
 | CartoCSS compile: field and predicate bitmasks on the property set, evaluate each property once | compile 175.4 → 117.4 ms paired (same style, later and bigger than the rows above) |


### PR DESCRIPTION
## Summary

Two independent fixes to the same thing: what a style load pays before the first tile can be decoded. Nothing about the compiled map changes — this is all in the symbolizer context.

- **`setPixelScale` no longer reloads the style's fonts.** It cleared the whole cached `SymbolizerContext`, so the fonts were decoded again. Only the **stroke and glyph maps** hold anything rasterized at a pixel scale; the font and bitmap managers do not. `VectorTileLayer` calls `setPixelScale` when a layer joins a map, so this was on every startup.
- **`resolveLiveNutiParameters` no longer runs on every context build.** 38 ms on the 23-layer style, and it is a property of the compiled map alone — it moved next to `_map`'s assignment, with `getSelectionParameter`.
- **A style's fonts are decoded on first use.** Registering a font means reading its name table, and a woff2 must be decompressed to be read at all. The bundled project packs 15 fonts and asks for 4.

## What it measures

Crosscall / Adreno 610, bundled `assets` style project (23 layers, 461 nutiparameters), three interleaved pairs each:

| | before | after |
|---|---|---|
| the whole `setPixelScale` call | 133.5–133.9 ms | **0.5 ms** |
| first symbolizer context build | 98 ms | **27 ms** |

A cold style load for that project was ~528 ms (compile 251 + context 143 + a second context 134); it is now ~278 ms, and the compile is the whole of what is left.

**This does not show up end to end.** Surface-created → first tile request varies by ±150 ms on this device, which swamps it — I measured that A/B and it came back flat. This is CPU removed from the startup path, not a startup number.

## Testing

`clang++ -fsyntax-only` clean on `MBVectorTileDecoder.cpp`. Built through `scripts/android-dev` and run on device at `--es style assets --es lon 5.724 --es lat 45.188 --es zoom 15 --es tilt 45`.

The DIN Pro faces, their italics and the `osm.ttf` icon glyphs all render as before; screenshot diff against the eager build is 1.75%, where two identical runs already differ by 1.06% (label placement, not fonts).

Worth a reviewer's eye on device: a style whose font **files** are named unlike the fonts inside them (that takes the sweep path in the vt PR), and a `setPixelScale` change at runtime — a DPI change should still re-rasterize glyphs and strokes at the new scale.

## Depends on

https://github.com/farfromrefug/mobile-carto-libs/pull/42 — merge it first, then rebase this pointer bump onto the merged commit.