### PR TITLE
revert(labels): keep the 3D label batches across frames (#83)

### DIFF
--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -166,20 +166,17 @@ namespace carto {
                        (maskNs - lastMaskNs) / 1.0e6, (drapeNs - lastDrapeNs) / 1.0e6);
             lastMaskNs = maskNs; lastDrapeNs = drapeNs;
 
-            static long long lastLabelBuild = 0, lastLabelBatch = 0, lastLabelVerts = 0, lastLineLayouts = 0, lastLabelReplays = 0, lastLabelPatches = 0;
+            static long long lastLabelBuild = 0, lastLabelBatch = 0, lastLabelVerts = 0, lastLineLayouts = 0;
             long long labelBuild = RenderStats::labelVertexBuildNs.load();
             long long labelBatch = RenderStats::labelBatchNs.load();
             long long labelVerts = RenderStats::labelsDrawnVertices.load();
             long long lineLayouts = RenderStats::lineLayoutBuilds.load();
-            long long labelReplays = RenderStats::labelBatchesReplayed.load();
-            long long labelPatches = RenderStats::labelBatchesPatched.load();
-            Log::Infof("RenderStats: labels built=%lld lineLayouts=%lld buildMs=%.1f batchMs=%.1f replayedBatches=%lld patchedBatches=%lld (per interval)",
+            Log::Infof("RenderStats: labels built=%lld lineLayouts=%lld buildMs=%.1f batchMs=%.1f (per interval)",
                        labelVerts - lastLabelVerts, lineLayouts - lastLineLayouts,
                        (labelBuild - lastLabelBuild) / 1.0e6,
-                       (labelBatch - lastLabelBatch) / 1.0e6,
-                       labelReplays - lastLabelReplays, labelPatches - lastLabelPatches);
+                       (labelBatch - lastLabelBatch) / 1.0e6);
             lastLabelBuild = labelBuild; lastLabelBatch = labelBatch; lastLabelVerts = labelVerts;
-            lastLineLayouts = lineLayouts; lastLabelReplays = labelReplays; lastLabelPatches = labelPatches;
+            lastLineLayouts = lineLayouts;
 
             static long long lastPrep[4] = { 0 }, lastLabelSplit[2] = { 0 }, lastLabelXf = 0, lastLabelAttr = 0;
             const long long prep[4] = {

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -792,7 +792,6 @@ namespace carto {
             contentDepthShift = TERRAIN_TANGRAM_DEPTH_SHIFT;
         }
         tileRenderer->setTerrainContentDepthShift(contentDepthShift);
-        tileRenderer->setLabelBatchCaching(getLabelBatchCaching());
         // Metre-constant clearance for draped LINES over the shared ground (see applyDepthBias in
         // vt). A line chords over the relief between its own vertices; under a ground that writes
         // depth that sag is what cuts roads and contours into fragments. The quantity is metres of
@@ -1159,22 +1158,6 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
         return depthShift;
 #else
         return 0.0f;
-#endif
-    }
-
-    bool TileRenderer::getLabelBatchCaching() {
-#ifdef __ANDROID__
-        //   adb shell setprop debug.carto.labelcache 0   (rebuild the 3D label batches every frame)
-        static const bool enabled = [] {
-            char property[PROP_VALUE_MAX] = { 0 };
-            if (__system_property_get("debug.carto.labelcache", property) > 0) {
-                return std::atoi(property) != 0;
-            }
-            return true;
-        }();
-        return enabled;
-#else
-        return true;
 #endif
     }
 

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -169,8 +169,6 @@ namespace carto {
         bool isPlanarProjectionMode() const;
         // Tangram-model measurement switch, read once from debug.carto.depthshift (Android only).
         static float getTerrainContentDepthShift();
-        // Measurement switch for the kept 3D label batches, debug.carto.labelcache (Android only).
-        static bool getLabelBatchCaching();
         // tangram res/scenes/terrain-3d.yaml: depth_shift = -0.02*u_proj[2][3], and [2][3] is -1.
         static constexpr float TERRAIN_TANGRAM_DEPTH_SHIFT = 0.02f;
         // It is a per-step separation between coplanar style layers, not a budget to spread over

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -499,7 +499,8 @@ screen space and must not change); (2) cache the offsets, which step 1 has made 
 (3) quantize the batch anchor and keep the batch arrays and GL buffers across frames, invalidated by
 the label set, placements, opacities, style slots and the anchor.
 
-**Step 1 is done.** `Label::CAMERA_AXIS_DEPTH_OFFSET` (attribs[3] = 2) tells `labelVsh` to scale the
+**Step 1 was done, then reverted with step 3** (see [Reverted](#reverted-labels-jump-in-the-sky) at
+the end of this section). `Label::CAMERA_AXIS_DEPTH_OFFSET` (attribs[3] = 2) told `labelVsh` to scale the
 offset by `clamp(anchorClip.w * uLabelDepthScale, 0.05, 8.0)` — clip `w` is the view depth the CPU
 factor was a ratio of, and `uLabelDepthScale` is 1 / camera-to-focus distance. The CPU then emits
 offsets divided by that factor, so what is in the buffer depends on the zoom and the style, not on
@@ -519,8 +520,8 @@ because the key moved), this rules out the source side entirely: the timed regio
 **writing into the batch arrays**, and copying N cached entries writes exactly the bytes the loop
 wrote. No cache of what goes into the batch can win.
 
-**Step 3, the batch kept across frames, is done — and there was a second view dependency the plan
-above missed.** `Label::setupCoordinateSystem` snaps the anchor to a quarter of the screen pixel
+**Step 3, the batch kept across frames, was done and is now reverted — and there was a second view
+dependency the plan above missed.** `Label::setupCoordinateSystem` snaps the anchor to a quarter of the screen pixel
 grid (that is what keeps glyphs at a stable subpixel phase), and it did so by projecting the anchor
 with the view-projection and inverting it back. So the anchor moved on every camera translation
 whatever the scale did — and it cost a **4x4 double inverse per label per frame**, on the culler
@@ -563,6 +564,27 @@ that is left is **2D**: `labels2DMs` is 48–94 ms/interval, dominated by `LINE`
 `updateLineVertexData`. Note also that only a style using `text-placement: nutibillboard` puts
 labels in the 3D pass at all; with the demo's inline style the 3D pass is 1.2 ms/interval and this
 whole mechanism measures nothing.
+
+### Reverted: labels jump in the sky
+
+Steps 1 and 3 shipped as mobile-sdk #83 / libs-carto #41 and were **reverted the same day**:
+reported on device (iOS, city camera) as labels jumping out of position, in 2D as well as 3D. Since
+the measured gain was zero frames, there was nothing to weigh against it. What the code review found,
+for whoever retries this:
+
+- **The generation is snapshotted too late.** `renderFrame` sets
+  `_labelBatchCache.generation = Label::getDrawGeneration()` *after* the batch is built. The culler
+  runs on its own thread and bumps that counter during the build, so a placement change landing
+  mid-build is swallowed and the batch stays stale until some unrelated label changes it. Snapshot
+  before the loop.
+- **Plates froze while their text kept scaling.** Glyphs went out as `CAMERA_AXIS_DEPTH_OFFSET` and
+  are rescaled by the shader every frame; `appendLabelPlates` emits `CAMERA_AXIS_OFFSET` with the
+  build-time `calculateTerrainScaleFactor` baked in. Within one frame that is the ~1% quantum step 1
+  documented, but in a *kept* batch the plate scale never updates at all while the text does, over
+  the whole 0.05–8 factor range. Plates have to move to the shader mode too, which means the callout
+  lift and shift (measured against the same scale) move with them.
+
+Neither is proven to be the reported jump — no repro was captured before the revert.
 
 ## Against tangram
 


### PR DESCRIPTION
## Summary

Reverts the code of #83 (`f28890e1`) and bumps `libs-carto` to the matching revert.

- Reported on device (iOS, city camera): labels jump out of position, in **2D as well as 3D**.
- #83's own measurement was **no frame-rate change** (26.4/26.0/25.6 fps with the cache against
  26.4/25.8/25.8 without), so the cache buys nothing to weigh against the regression.
- Drops `TileRenderer::setLabelBatchCaching`, the `debug.carto.labelcache` property and the
  `replayedBatches`/`patchedBatches` RenderStats line.

Docs the same squashed commit carried are **kept**, because they stay true:

- `10-performance.md` — the decode-pool retake, unrelated to labels.
- `06-labels.md` — the label-batch measurements, now with a `Reverted: labels jump in the sky`
  section recording the two defects a retry has to fix first (the draw generation snapshotted after
  the batch is built, and plates frozen at the build-time CPU scale while their glyphs are rescaled
  by the shader every frame).

## Testing

`clang++ -fsyntax-only -std=c++17` clean on `all/native/renderers/TileRenderer.cpp` and
`all/native/renderers/MapRenderer.cpp`.

Not device-checked — this restores the behaviour shipped before #83. The check is the reporter's own
scenario: city camera, pan and confirm labels stay anchored, 2D and 3D. On Android:

```
adb shell am start -n com.akylas.cartotest/.MainActivity --es style assets --es lon 5.724 --es lat 45.188 --es zoom 15 --es tilt 45
```

`--es style assets` matters: only a style using `text-placement: nutibillboard` puts labels in the
3D pass at all.

## Depends on

https://github.com/farfromrefug/mobile-carto-libs/pull/43 — merge that one **first**, then rebase
this branch's pointer bump onto the merged submodule commit.