### PR TITLE
fix(labels): query the terrain occlusion depth with the camera it was rendered from

### DIFF
--- a/all/native/renderers/TerrainRenderer.cpp
+++ b/all/native/renderers/TerrainRenderer.cpp
@@ -457,6 +457,7 @@ namespace carto {
         job.width = bufferWidth;
         job.height = bufferHeight;
         job.far = viewState.getFar();
+        job.mvpMatrix = mvpMatrix;
         job.items.reserve(tileMeshes.size());
         for (const auto& tileMesh : tileMeshes) {
             const std::shared_ptr<TileMesh>& mesh = tileMesh.second;
@@ -535,6 +536,7 @@ namespace carto {
         newDepthData->width = bufferWidth;
         newDepthData->height = bufferHeight;
         newDepthData->far = viewState.getFar();
+        newDepthData->mvpMatrix = mvpMatrix;
         {
             std::lock_guard<std::mutex> lock(_depthMutex);
             _depthDataSnapshot = std::move(newDepthData);
@@ -545,24 +547,53 @@ namespace carto {
         return true;
     }
 
-    float TerrainRenderer::getDepthW(float screenX, float screenY) const {
+    float TerrainRenderer::sampleDepthW(const TerrainDepthBuffer& depthData, int x, int y) {
+        if (x < 0 || y < 0 || x >= depthData.width || y >= depthData.height) {
+            return std::numeric_limits<float>::max();
+        }
+        // The framebuffer rows start at the bottom of the screen; screen y grows downwards
+        const std::uint8_t* ptr = &depthData.data[(static_cast<std::size_t>(depthData.height - 1 - y) * depthData.width + x) * 4];
+        if (ptr[3] == 0) {
+            return std::numeric_limits<float>::max(); // sky pixel (zero coverage)
+        }
+        float depth = ptr[0] / 255.0f + ptr[1] / 65025.0f + ptr[2] / 16581375.0f;
+        return depth * depthData.far;
+    }
+
+    bool TerrainRenderer::isOccludedByTerrain(const cglib::vec3<double>& pos, float tolerance) const {
         std::shared_ptr<const TerrainDepthBuffer> depthData;
         {
             std::lock_guard<std::mutex> lock(_depthMutex);
             depthData = _depthDataSnapshot;
         }
-        if (!depthData || depthData->width < 1 || depthData->height < 1) {
-            return std::numeric_limits<float>::max();
+        if (!depthData || depthData->width < 1 || depthData->height < 1 || depthData->mvpMatrix == cglib::mat4x4<double>::zero()) {
+            return false;
         }
-        int x = std::min(std::max(static_cast<int>(screenX) / BUFFER_DOWNSCALE, 0), depthData->width - 1);
-        int y = std::min(std::max(static_cast<int>(screenY) / BUFFER_DOWNSCALE, 0), depthData->height - 1);
-        // The framebuffer rows start at the bottom of the screen; screen y grows downwards
-        const std::uint8_t* ptr = &depthData->data[(static_cast<std::size_t>(depthData->height - 1 - y) * depthData->width + x) * 4];
-        if (ptr[3] == 0) {
-            return std::numeric_limits<float>::max(); // sky pixel (zero coverage)
+
+        cglib::vec4<double> clipPos = cglib::transform(cglib::vec4<double>(pos(0), pos(1), pos(2), 1), depthData->mvpMatrix);
+        if (clipPos(3) <= 0) {
+            return false;
         }
-        float depth = ptr[0] / 255.0f + ptr[1] / 65025.0f + ptr[2] / 16581375.0f;
-        return depth * depthData->far;
+        int x = static_cast<int>((clipPos(0) / clipPos(3) * 0.5 + 0.5) * depthData->width);
+        int y = static_cast<int>((0.5 - clipPos(1) / clipPos(3) * 0.5) * depthData->height);
+        float depthW = sampleDepthW(*depthData, x, y);
+        if (depthW == std::numeric_limits<float>::max()) {
+            return false; // sky, or moved outside what this buffer covers
+        }
+        // Farthest terrain depth around the position rather than the depth of its own pixel:
+        // labels drawn on the ground sit exactly ON the terrain, the depth buffer is read back
+        // downscaled, and on a slope the neighbouring pixel can be a good deal nearer - so an
+        // exact comparison makes a label's own ground occlude it, differently on every frame,
+        // which is what made labels blink while panning.
+        for (int i = 0; i < 4; i++) {
+            int dx = (i & 1 ? OCCLUSION_SAMPLE_OFFSET : -OCCLUSION_SAMPLE_OFFSET);
+            int dy = (i & 2 ? OCCLUSION_SAMPLE_OFFSET : -OCCLUSION_SAMPLE_OFFSET);
+            float neighbourDepthW = sampleDepthW(*depthData, x + dx, y + dy);
+            if (neighbourDepthW < std::numeric_limits<float>::max()) {
+                depthW = std::max(depthW, neighbourDepthW);
+            }
+        }
+        return static_cast<float>(clipPos(3)) > depthW * tolerance;
     }
 
     void TerrainRenderer::collectVisibleTiles(const ViewState& viewState, const std::shared_ptr<TerrainOptions>& terrainOptions, std::vector<MapTile>& tiles) const {

--- a/all/native/renderers/TerrainRenderer.h
+++ b/all/native/renderers/TerrainRenderer.h
@@ -121,11 +121,17 @@ namespace carto {
         bool isDepthBufferStale() const { return _depthStale; }
 
         /**
-         * Returns the linear eye depth (view w, internal units) of the terrain at the
-         * given screen position from the last updateDepthBuffer call. Returns a huge
-         * value for sky pixels or when no depth data is available.
+         * True when the given world position is behind the terrain, by more than the given
+         * relative depth tolerance (1 = no slack).
+         *
+         * The position is projected with the camera the depth buffer was RENDERED from, not
+         * with the current one: the buffer lags a moving camera by up to the submit interval,
+         * so a current-camera distance compared against it reads every label as occluded while
+         * zooming out. Projecting with the buffer's own matrix makes the answer merely late.
+         * Fails open (not occluded) when there is no data, or when the position falls behind
+         * that camera or outside its viewport.
          */
-        float getDepthW(float screenX, float screenY) const;
+        bool isOccludedByTerrain(const cglib::vec3<double>& pos, float tolerance) const;
 
         /**
          * The terrain tile cover for this camera - the tiles the surface would be drawn from.
@@ -157,6 +163,7 @@ namespace carto {
         static constexpr int MAX_MESH_GRID_SIZE = 96; // grid cells per tile edge, upper bound
         static constexpr int MAX_CACHED_MESHES = 160;
         static constexpr int DEPTH_TEXTURE_MESH_RESOLUTION = 32; // mesh cap for the occlusion depth texture
+        static constexpr int OCCLUSION_SAMPLE_OFFSET = 4; // buffer pixels sampled around a queried position
 
         static const std::string TERRAIN_DEPTH_VERTEX_SHADER;
         static const std::string TERRAIN_DEPTH_FRAGMENT_SHADER;
@@ -188,6 +195,9 @@ namespace carto {
         std::shared_ptr<TileMesh> buildTileMesh(const MapTile& tile, const std::shared_ptr<ElevationTileGrid>& grid, const std::shared_ptr<ElevationManager>& elevationManager, int gridSize) const;
         int calculateMeshGridSize(const MapTile& tile, const std::shared_ptr<ElevationTileGrid>& grid, int meshResolution) const;
         cglib::mat4x4<double> calculateTileMatrix(const MapTile& tile) const;
+        // Linear eye depth (view w, internal units) of the terrain at a buffer pixel. Returns a
+        // huge value for sky pixels and for pixels outside the buffer.
+        static float sampleDepthW(const TerrainDepthBuffer& depthData, int x, int y);
 
         std::shared_ptr<FrameBuffer> _frameBuffer;
         std::shared_ptr<Shader> _shader;

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -1272,12 +1272,13 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
             if (mapRenderer->getTerrainRenderer() != nullptr) {
                 {
                     _labelOcclusionState.reset();
-                    cglib::mat4x4<double> mvpMat = viewState.getModelviewProjectionMat();
-                    float screenWidth = static_cast<float>(viewState.getWidth());
-                    float screenHeight = static_cast<float>(viewState.getHeight());
                     std::weak_ptr<MapRenderer> mapRendererWeak = _mapRenderer;
+                    // The tolerance is relative to distance: at its default it only absorbs the
+                    // mismatch between the anchor and the terrain it sits on, and raising it lets
+                    // partly hidden features label (the peak-finder case). The projection itself
+                    // belongs to the depth buffer's own camera, so it lives with the buffer.
                     float occlusionTolerance = 1.0f + std::max(MIN_OCCLUSION_TOLERANCE, terrainOptions->getBillboardOcclusionTolerance());
-                    tileRenderer->setLabelOcclusionTest([mapRendererWeak, mvpMat, screenWidth, screenHeight, occlusionTolerance](const cglib::vec3<double>& pos) {
+                    tileRenderer->setLabelOcclusionTest([mapRendererWeak, occlusionTolerance](const cglib::vec3<double>& pos) {
                         auto mapRenderer = mapRendererWeak.lock();
                         if (!mapRenderer) {
                             return false;
@@ -1286,34 +1287,7 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
                         if (!terrainRenderer) {
                             return false;
                         }
-                        cglib::vec4<double> clipPos = cglib::transform(cglib::vec4<double>(pos(0), pos(1), pos(2), 1), mvpMat);
-                        if (clipPos(3) <= 0) {
-                            return false;
-                        }
-                        float screenX = static_cast<float>((clipPos(0) / clipPos(3) * 0.5 + 0.5) * screenWidth);
-                        float screenY = static_cast<float>((0.5 - clipPos(1) / clipPos(3) * 0.5) * screenHeight);
-                        // Farthest terrain depth around the anchor rather than the depth of its own
-                        // pixel: labels drawn on the ground sit exactly ON the terrain, the depth
-                        // buffer is read back downscaled and one frame late, and on a slope the
-                        // neighbouring pixel can be a good deal nearer - so an exact comparison
-                        // makes a label's own ground occlude it, differently on every frame, which
-                        // is what made labels blink while panning.
-                        float depthW = terrainRenderer->getDepthW(screenX, screenY);
-                        if (depthW < std::numeric_limits<float>::max()) {
-                            for (int i = 0; i < 4; i++) {
-                                float dx = (i & 1 ? OCCLUSION_SAMPLE_OFFSET : -OCCLUSION_SAMPLE_OFFSET);
-                                float dy = (i & 2 ? OCCLUSION_SAMPLE_OFFSET : -OCCLUSION_SAMPLE_OFFSET);
-                                float neighbourDepthW = terrainRenderer->getDepthW(screenX + dx, screenY + dy);
-                                if (neighbourDepthW < std::numeric_limits<float>::max()) {
-                                    depthW = std::max(depthW, neighbourDepthW);
-                                }
-                            }
-                        }
-                        // Occluded if clearly behind the terrain there. The tolerance is relative to
-                        // distance: at its default it only absorbs the mismatch between the anchor
-                        // and the terrain it sits on, and raising it lets partly hidden features
-                        // label (the peak-finder case).
-                        return static_cast<float>(clipPos(3)) > depthW * occlusionTolerance;
+                        return terrainRenderer->isOccludedByTerrain(pos, occlusionTolerance);
                     });
                     return;
                 }

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -201,7 +201,6 @@ namespace carto {
 
         static constexpr int SURFACE_RESET_DELAY = 500; // minimum interval (ms) between elevation-driven tile surface rebuilds
 
-        static constexpr float OCCLUSION_SAMPLE_OFFSET = 8.0f; // screen pixels sampled around a label anchor for the terrain depth
         static constexpr float MIN_OCCLUSION_TOLERANCE = 0.01f; // relative depth slack a label anchored on the terrain always gets
 
         static const std::string LIGHTING_SHADER_2D;

--- a/all/native/renderers/utils/TerrainDepthWorker.cpp
+++ b/all/native/renderers/utils/TerrainDepthWorker.cpp
@@ -202,7 +202,7 @@ namespace carto {
         glViewport(0, 0, job.width, job.height);
 
         // Clear to 'sky': maximum depth, zero coverage - the same encoding the synchronous
-        // path writes, so getDepthW reads both the same way.
+        // path writes, so both are sampled the same way.
         glClearColor(1.0f, 1.0f, 1.0f, 0.0f);
         glDepthMask(GL_TRUE);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -229,6 +229,7 @@ namespace carto {
         result->width = job.width;
         result->height = job.height;
         result->far = job.far;
+        result->mvpMatrix = job.mvpMatrix;
         result->data.resize(static_cast<std::size_t>(job.width) * job.height * 4);
         glReadPixels(0, 0, job.width, job.height, GL_RGBA, GL_UNSIGNED_BYTE, result->data.data());
         return result;

--- a/all/native/renderers/utils/TerrainDepthWorker.h
+++ b/all/native/renderers/utils/TerrainDepthWorker.h
@@ -30,6 +30,10 @@ namespace carto {
         int width = 0;
         int height = 0;
         float far = 0;
+        // The camera this was rendered from. An occlusion query must project with THIS matrix,
+        // not the current frame's: the buffer lags a moving camera by up to the submit interval,
+        // and comparing a current-camera distance against it inverts the answer while zooming.
+        cglib::mat4x4<double> mvpMatrix = cglib::mat4x4<double>::zero();
     };
 
     /**
@@ -66,6 +70,7 @@ namespace carto {
             int width = 0;
             int height = 0;
             float far = 0;
+            cglib::mat4x4<double> mvpMatrix = cglib::mat4x4<double>::zero(); // carried into the result
             std::vector<DrawItem> items;
         };
 

--- a/docs/rendering/04-terrain.md
+++ b/docs/rendering/04-terrain.md
@@ -329,7 +329,32 @@ it runs on `TerrainDepthWorker`: its own thread, its own EGL context, deliberate
 Two GL contexts still share one GPU, so the submit interval matters more than the work:
 every frame 13.2 fps, 250 ms 14.3, **500 ms 14.9** (13.7 synchronous). Tangram does the same thing
 with a shared context and never waits on it.
-</content>
+
+### Query with the buffer's camera, not the frame's
+
+Symptom: labels that should be visible fade out and come back while **zooming**, in 3D only, at any
+camera (reported at 45.188/5.719 z13.18 t30 r-15). 2D never shows it because
+`TileRenderer::updateLabelOcclusionTest` returns early when terrain is off — 2D runs no occlusion
+test at all.
+
+The buffer lags the camera by design (`DEPTH_SUBMIT_MOVING_INTERVAL` = 500 ms while moving, plus
+worker latency), and the test used to project the label with the **current frame's** MVP and compare
+that distance against it. Zooming out moves the camera farther than the 1 % tolerance floor
+(`MIN_OCCLUSION_TOLERANCE`) inside those 500 ms, so every anchor reads as behind the terrain,
+`updateLabel` fades it to 0, and the next read-back brings it back. Zooming in inverts the same
+mismatch through screen drift: the anchor samples a pixel the old camera had something else at —
+and `getDepthW` **clamped** out-of-range coordinates to the border pixel, so a label leaving the old
+frustum read a border ridge instead of failing open.
+
+`TerrainDepthBuffer` now carries the `mvpMatrix` it was rendered with, and
+`TerrainRenderer::isOccludedByTerrain` projects with that matrix, samples in buffer pixels, and
+fails open (not occluded) for a position behind that camera or outside its viewport. Staleness then
+only makes the answer **late**, never inverted, which is what the throttle assumed all along. The
+query also takes the snapshot once instead of per sample, so the five taps cannot straddle a
+read-back.
+
+Not affected: billboards and vector elements decide occlusion by ray-marching the elevation grids
+from the current camera (`BillboardPlacementWorker`), which is self-consistent already.
 
 ## Draped lines sagging into the terrain (no regular grid)
 

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -407,7 +407,9 @@ zoom filter.
 ## On the GL thread
 
 - **Fades.** `updateLabel` moves opacity toward `visible ? 1 : 0`; invisible-but-fading labels stay
-  rendered until they reach 0.
+  rendered until they reach 0. Over terrain it also fades a label out when its anchor is behind a
+  ridge — a stale occlusion buffer queried with the wrong camera is what made labels blink while
+  zooming, see [04-terrain.md](04-terrain.md#query-with-the-buffers-camera-not-the-frames).
 - **Terrain anchoring.** Label geometry is built flat at decode time, so a label must be re-anchored
   onto the terrain: once when it is new, and afterwards only when the elevation under one of its
   tiles changed. `invalidateLabelElevation(tileIds)` marks exactly those; the blanket version exists


### PR DESCRIPTION
## Summary

Labels that should stay visible faded out and back **while zooming in 3D**. 2D never showed it: `TileRenderer::updateLabelOcclusionTest` returns early when terrain is off, so 2D runs no occlusion test at all.

Mechanism: the terrain occlusion depth buffer lags a moving camera by design (`DEPTH_SUBMIT_MOVING_INTERVAL` = 500 ms), but the test projected the label anchor with the **current frame's** MVP and compared that distance against it. A zoom moves the camera far more than the 1 % tolerance floor (`MIN_OCCLUSION_TOLERANCE`) inside those 500 ms, so every anchor read as behind the terrain and `updateLabel` faded it to 0 until the next read-back. Zooming in inverted the same mismatch through screen drift, and `getDepthW` **clamped** out-of-range coordinates to the border pixel, so a label leaving the old frustum read a border ridge instead of failing open.

- `TerrainDepthBuffer` now carries the `mvpMatrix` it was rendered with (both the worker and the synchronous path set it).
- `getDepthW(screenX, screenY)` replaced by `TerrainRenderer::isOccludedByTerrain(pos, tolerance)`: projects with the buffer's own matrix, samples in buffer pixels, **fails open** for a position behind that camera or outside its viewport, and takes the snapshot once for all five taps instead of re-locking per sample.
- Staleness now only makes the answer *late*, never inverted — which is what the throttle assumed all along.
- Billboards and vector elements are unaffected: they ray-march the elevation grids from the current camera (`BillboardPlacementWorker`).

Docs: new `### Query with the buffer's camera, not the frame's` in `docs/rendering/04-terrain.md`, cross-linked from `06-labels.md`.

## Testing

`clang++ -fsyntax-only -std=c++17 -DTARGET_OS_ANDROID` clean on all three touched translation units (`TerrainRenderer.cpp`, `TileRenderer.cpp`, `TerrainDepthWorker.cpp`).

Device-verified on the reported camera — pinch zoom in/out, labels no longer blink:

```sh
adb shell am start -n com.akylas.cartotest/.MainActivity \
  --es lon 5.719388 --es lat 45.188102 --es zoom 13.18 --es tilt 30 --es rotation -15.12
```

A/B against `--es occlusion false` (occlusion off entirely) — labels should now behave the same while zooming, with real ridge occlusion still working when the camera settles.