### PR TITLE
fix(terrain): keep the shadow caster set a partition of the ground, and cut the shadow cost

### DIFF
--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -1028,6 +1028,19 @@ namespace carto {
         return _tileRenderer->renderShadowCasters(tileIds, lightViewProj, castGround);
     }
 
+    void TileLayer::setTerrainShadowMask(unsigned int texture, float invScreenWidth, float invScreenHeight) {
+        if (_tileRenderer) {
+            _tileRenderer->setTerrainShadowMask(texture, invScreenWidth, invScreenHeight);
+        }
+    }
+
+    int TileLayer::renderTerrainShadowMask(const std::vector<vt::TileId>& tileIds) {
+        if (_tileRenderer) {
+            return _tileRenderer->renderTerrainShadowMask(tileIds);
+        }
+        return 0;
+    }
+
     void TileLayer::setTerrainShadowMap(unsigned int texture, int mapSize, int cascades, const std::array<float, 4>& depthBiases, float strength, float softness, const std::array<cglib::mat4x4<double>, 4>& lightViewProjs) {
         _tileRenderer->setTerrainShadowMap(texture, mapSize, cascades, depthBiases, strength, softness, lightViewProjs);
     }

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -447,6 +447,8 @@ namespace carto {
         float shadowCasterFadeSignature() const;
         int renderShadowCasters(const std::vector<vt::TileId>& tileIds, const cglib::mat4x4<double>& lightViewProj, bool castGround);
         void setTerrainShadowMap(unsigned int texture, int mapSize, int cascades, const std::array<float, 4>& depthBiases, float strength, float softness, const std::array<cglib::mat4x4<double>, 4>& lightViewProjs);
+        void setTerrainShadowMask(unsigned int texture, float invScreenWidth, float invScreenHeight);
+        int renderTerrainShadowMask(const std::vector<vt::TileId>& tileIds);
         void setTerrainSunLighting(bool enabled, const cglib::vec3<float>& sunDir, const Color& sunColor, float sunIntensity, float ambientIntensity);
 
     protected:

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1423,9 +1423,10 @@ namespace carto {
     // A cached shadow map is refreshed at least this often anyway: elevation tiles can stream in
     // without changing the light box or the caster tile list, and a shadow cast by data that has
     // since arrived would otherwise never appear.
-    // Screen divisor for the terrain shadow mask. A shadow edge is a penumbra, so half resolution
-    // is not visible in the result - and it is a quarter of the fragments.
-    static const int SHADOW_MASK_DIVISOR = 2;
+    // Screen divisor for the terrain shadow mask. A terrain shadow edge is a penumbra, so a
+    // quarter of the screen resolution is not visible in the result - measured against a half:
+    // the mask pass 14-16 ms -> 8-9 ms, and 8.5 -> 9.6 fps.
+    static const int SHADOW_MASK_DIVISOR = 4;
     static const int SHADOW_MAP_MAX_AGE = 30;
     // Frames between two refreshes driven by newly arrived tile content.
     static const int SHADOW_MAP_CONTENT_INTERVAL = 4;
@@ -1773,7 +1774,8 @@ namespace carto {
             // happened to force another frame.
             tileLayer->setTerrainSunLighting(lighting.terrainLightingEnabled, lighting.sunDir, lighting.sunColor, lighting.sunIntensity, lighting.ambientIntensity);
         }
-        // Resolve the terrain's shadow ONCE per screen pixel, at half resolution, so the surface
+        // Resolve the terrain's shadow ONCE per screen pixel, at a fraction of the screen
+        // resolution, so the surface
         // draws - the drape, and the paint over it - each cost one texture fetch instead of a
         // cascade choice, a matrix, derivatives and four taps over the whole screen.
         unsigned int maskTexture = 0;

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -1525,18 +1525,66 @@ namespace carto {
                 std::vector<vt::TileId> casterTileIds = coverTileIds;
                 int casterMargin = lighting.shadowCasterMargin;
                 if (casterMargin > 0) {
-                    std::set<std::pair<int, std::pair<int, int> > > seen;
+                    // The caster set must stay a PARTITION of the ground, like the cover it extends.
+                    // A margin ring is generated at its own cover tile's zoom and the cover mixes
+                    // zooms, so the ring around a coarse cover tile lands on top of the fine tiles
+                    // next to it. Two casters over the same ground at different DEM levels disagree
+                    // by tens of metres, the shallower one wins the depth test, and the receiver -
+                    // which uses the fine level - is then in the shadow of its own ground: blocky
+                    // patches that grow with the tilt, because a tilted cover mixes more zooms.
+                    // An overlapping candidate is SUBDIVIDED rather than dropped, so the ground it
+                    // covers outside the finer tiles keeps a caster.
+                    using TileKey = std::pair<int, std::pair<int, int> >;
+                    auto keyOf = [](const vt::TileId& tileId) { return TileKey(tileId.zoom, { tileId.x, tileId.y }); };
+                    std::set<TileKey> taken, takenAncestors;
+                    int maxCoverZoom = 0;
+                    auto take = [&](const vt::TileId& tileId) {
+                        taken.insert(keyOf(tileId));
+                        for (int zoom = tileId.zoom - 1; zoom >= 0; zoom--) {
+                            int shift = tileId.zoom - zoom;
+                            takenAncestors.insert(TileKey(zoom, { tileId.x >> shift, tileId.y >> shift }));
+                        }
+                    };
                     for (const vt::TileId& tileId : coverTileIds) {
-                        seen.insert({ tileId.zoom, { tileId.x, tileId.y } });
+                        take(tileId);
+                        maxCoverZoom = std::max(maxCoverZoom, tileId.zoom);
                     }
+                    // Finest first: a coarse candidate then splits against the fine tiles already
+                    // taken, instead of claiming their ground and being split by nothing.
+                    std::vector<vt::TileId> candidates;
                     for (const vt::TileId& tileId : coverTileIds) {
                         for (int dy = -casterMargin; dy <= casterMargin; dy++) {
                             for (int dx = -casterMargin; dx <= casterMargin; dx++) {
-                                vt::TileId neighbour(tileId.zoom, tileId.x + dx, tileId.y + dy);
-                                if (seen.insert({ neighbour.zoom, { neighbour.x, neighbour.y } }).second) {
-                                    casterTileIds.push_back(neighbour);
-                                }
+                                candidates.emplace_back(tileId.zoom, tileId.x + dx, tileId.y + dy);
                             }
+                        }
+                    }
+                    std::stable_sort(candidates.begin(), candidates.end(), [](const vt::TileId& a, const vt::TileId& b) { return a.zoom > b.zoom; });
+                    std::vector<vt::TileId> pending;
+                    for (const vt::TileId& candidate : candidates) {
+                        pending.assign(1, candidate);
+                        while (!pending.empty()) {
+                            vt::TileId tileId = pending.back();
+                            pending.pop_back();
+                            if (taken.count(keyOf(tileId)) > 0) {
+                                continue;
+                            }
+                            bool insideTaken = false;
+                            for (int zoom = tileId.zoom - 1; zoom >= 0 && !insideTaken; zoom--) {
+                                int shift = tileId.zoom - zoom;
+                                insideTaken = taken.count(TileKey(zoom, { tileId.x >> shift, tileId.y >> shift })) > 0;
+                            }
+                            if (insideTaken) {
+                                continue; // something finer or equal already casts over this ground
+                            }
+                            if (takenAncestors.count(keyOf(tileId)) > 0 && tileId.zoom < maxCoverZoom) {
+                                for (int corner = 0; corner < 4; corner++) {
+                                    pending.emplace_back(tileId.zoom + 1, tileId.x * 2 + (corner & 1), tileId.y * 2 + (corner >> 1));
+                                }
+                                continue;
+                            }
+                            take(tileId);
+                            casterTileIds.push_back(tileId);
                         }
                     }
                 }
@@ -1586,36 +1634,49 @@ namespace carto {
                     for (const std::shared_ptr<TileLayer>& tileLayer : tileLayers) {
                         fadeSignature = std::max(fadeSignature, tileLayer->shadowCasterFadeSignature());
                     }
-                    bool refresh = !_shadowMapValid
+                    // The atlas layout itself changed: every page has to be redrawn.
+                    bool refreshAll = !_shadowMapValid
                         || _shadowMapSize != _terrainShadowMap->getSize()
-                        || _shadowMapCascades != cascades
-                        || _shadowMapCasterTiles != casterTileIds;
-                    for (int cascade = 0; cascade < cascades && !refresh; cascade++) {
-                        refresh = !(_shadowMapViewProjs[cascade] == lightViewProjs[cascade]);
-                    }
+                        || _shadowMapCascades != cascades;
                     _shadowMapAge++;
                     // Content-driven refreshes are RATIONED, camera-driven ones are
                     // not. A shadow left behind by a moving camera is in the wrong
                     // place and unmissable; a building whose shadow is a step behind
                     // its own growth is not.
-                    if (!refresh && std::abs(fadeSignature - _shadowMapFadeSignature) > SHADOW_MAP_FADE_STEP) {
-                        refresh = true;
+                    if (!refreshAll && std::abs(fadeSignature - _shadowMapFadeSignature) > SHADOW_MAP_FADE_STEP) {
+                        refreshAll = true;
                     }
-                    if (!refresh && contentChanged && _shadowMapAge >= SHADOW_MAP_CONTENT_INTERVAL) {
-                        refresh = true;
+                    if (!refreshAll && contentChanged && _shadowMapAge >= SHADOW_MAP_CONTENT_INTERVAL) {
+                        refreshAll = true;
                     }
-                    if (!refresh && _shadowMapAge >= SHADOW_MAP_MAX_AGE) {
-                        refresh = true;
+                    if (!refreshAll && _shadowMapAge >= SHADOW_MAP_MAX_AGE) {
+                        refreshAll = true;
                     }
-                    if (refresh) {
-                        _shadowMapValid = false;
+                    // Otherwise it is per PAGE: each cascade's box is snapped to its own lattice,
+                    // and the outer one - which holds most of the casters, since its box covers the
+                    // whole view - keeps its matrix over far more camera movement than the near one.
+                    // Redrawing all three because the near box stepped was most of the pass cost.
+                    std::array<bool, TerrainShadowMap::MAX_CASCADES> refreshCascade = { };
+                    bool refreshAny = false;
+                    for (int cascade = 0; cascade < cascades; cascade++) {
+                        refreshCascade[cascade] = refreshAll
+                            || !(_shadowMapViewProjs[cascade] == lightViewProjs[cascade])
+                            || _shadowMapCasterTiles[cascade] != cascadeCasterTiles[cascade];
+                        refreshAny = refreshAny || refreshCascade[cascade];
+                    }
+                    if (refreshAny) {
                         std::chrono::steady_clock::time_point shadowStart = std::chrono::steady_clock::now();
-                        if (_terrainShadowMap->beginPass()) {
+                        if (_terrainShadowMap->beginPass(refreshAll)) {
                             for (int cascade = 0; cascade < cascades; cascade++) {
-                                // The cascades are pages of one texture, so the pass
-                                // is cleared once and each cascade draws into its own
-                                // viewport.
+                                if (!refreshCascade[cascade]) {
+                                    continue;
+                                }
+                                // The cascades are pages of one texture, so each one draws into its
+                                // own viewport, and a page redrawn on its own clears just itself.
                                 _terrainShadowMap->setCascadeViewport(cascade);
+                                if (!refreshAll) {
+                                    _terrainShadowMap->clearCascade();
+                                }
                                 // EVERY drape layer casts, not just the first. The terrain
                                 // surface is shared, but 3D extrusions belong to whichever
                                 // layer holds them - in a composite that is a later style
@@ -1632,24 +1693,29 @@ namespace carto {
                                     // only this tells them apart.
                                     shadowExtrusionDraws += draws - (castGround ? static_cast<int>(cascadeCasterTiles[cascade].size()) : 0);
                                 }
+                                _shadowMapViewProjs[cascade] = lightViewProjs[cascade];
+                                _shadowMapBiases[cascade] = shadowBiases[cascade];
+                                _shadowMapCasterTiles[cascade] = cascadeCasterTiles[cascade];
+                                shadowCasterDraws += static_cast<int>(cascadeCasterTiles[cascade].size());
                             }
                             _terrainShadowMap->endPass(prevFBO, viewState.getWidth(), viewState.getHeight());
                             shadowMsSum += std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - shadowStart).count();
                             _shadowMapValid = true;
-                            _shadowMapViewProjs = lightViewProjs;
-                            _shadowMapBiases = shadowBiases;
-                            _shadowMapCasterTiles = casterTileIds;
                             _shadowMapSize = _terrainShadowMap->getSize();
                             _shadowMapCascades = cascades;
                             _shadowMapFadeSignature = fadeSignature;
                             _shadowMapAge = 0;
-                            for (int cascade = 0; cascade < cascades; cascade++) {
-                                shadowCasterDraws += static_cast<int>(cascadeCasterTiles[cascade].size());
-                            }
                             shadowPasses++;
+                        } else {
+                            _shadowMapValid = false;
                         }
                     }
                     if (_shadowMapValid) {
+                        // The matrices the PAGES were drawn with, not this frame's fit: a page that
+                        // did not need refreshing holds the box it was rendered with, and sampling
+                        // it with a newer matrix would slide every shadow in it.
+                        lightViewProjs = _shadowMapViewProjs;
+                        shadowBiases = _shadowMapBiases;
                         shadowTexture = _terrainShadowMap->getTexture();
                         shadowMapSize = _terrainShadowMap->getSize();
                         shadowCascades = cascades;

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -31,6 +31,7 @@
 #include "renderers/TerrainRenderer.h"
 #include "renderers/utils/TerrainDrapeCache.h"
 #include "renderers/utils/TerrainShadowMap.h"
+#include "renderers/utils/TerrainShadowMaskBuffer.h"
 
 #include <chrono>
 #include <set>
@@ -1040,6 +1041,7 @@ namespace carto {
         // recreated context would otherwise draw into and sample from stale names.
         _terrainDrapeCache.reset();
         _terrainShadowMap.reset();
+        _terrainShadowMaskBuffer.reset();
         _shadowMapValid = false;
 
         // Notify renderers about the event
@@ -1421,6 +1423,9 @@ namespace carto {
     // A cached shadow map is refreshed at least this often anyway: elevation tiles can stream in
     // without changing the light box or the caster tile list, and a shadow cast by data that has
     // since arrived would otherwise never appear.
+    // Screen divisor for the terrain shadow mask. A shadow edge is a penumbra, so half resolution
+    // is not visible in the result - and it is a quarter of the fragments.
+    static const int SHADOW_MASK_DIVISOR = 2;
     static const int SHADOW_MAP_MAX_AGE = 30;
     // Frames between two refreshes driven by newly arrived tile content.
     static const int SHADOW_MAP_CONTENT_INTERVAL = 4;
@@ -1666,6 +1671,7 @@ namespace carto {
                     }
                     if (refreshAny) {
                         std::chrono::steady_clock::time_point shadowStart = std::chrono::steady_clock::now();
+                        FRAME_PROF_GPU_BEGIN(SECTION_SHADOWCAST);
                         if (_terrainShadowMap->beginPass(refreshAll)) {
                             for (int cascade = 0; cascade < cascades; cascade++) {
                                 if (!refreshCascade[cascade]) {
@@ -1699,6 +1705,7 @@ namespace carto {
                                 shadowCasterDraws += static_cast<int>(cascadeCasterTiles[cascade].size());
                             }
                             _terrainShadowMap->endPass(prevFBO, viewState.getWidth(), viewState.getHeight());
+                            FRAME_PROF_GPU_END();
                             shadowMsSum += std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - shadowStart).count();
                             _shadowMapValid = true;
                             _shadowMapSize = _terrainShadowMap->getSize();
@@ -1707,6 +1714,7 @@ namespace carto {
                             _shadowMapAge = 0;
                             shadowPasses++;
                         } else {
+                            FRAME_PROF_GPU_END();
                             _shadowMapValid = false;
                         }
                     }
@@ -1764,6 +1772,39 @@ namespace carto {
             // frame's sun, so toggling the light did nothing until something else
             // happened to force another frame.
             tileLayer->setTerrainSunLighting(lighting.terrainLightingEnabled, lighting.sunDir, lighting.sunColor, lighting.sunIntensity, lighting.ambientIntensity);
+        }
+        // Resolve the terrain's shadow ONCE per screen pixel, at half resolution, so the surface
+        // draws - the drape, and the paint over it - each cost one texture fetch instead of a
+        // cascade choice, a matrix, derivatives and four taps over the whole screen.
+        unsigned int maskTexture = 0;
+        float invWidth = 0.0f, invHeight = 0.0f;
+        if (shadowTexture != 0 && viewState.getWidth() > 0 && viewState.getHeight() > 0) {
+            if (!_terrainShadowMaskBuffer) {
+                _terrainShadowMaskBuffer = std::make_unique<TerrainShadowMaskBuffer>();
+            }
+            _terrainShadowMaskBuffer->setSize(viewState.getWidth(), viewState.getHeight(), SHADOW_MASK_DIVISOR);
+            FRAME_PROF_GPU_BEGIN(SECTION_SHADOWMASK);
+            if (_terrainShadowMaskBuffer->beginPass()) {
+                // The mask is produced by the FIRST layer alone: the surface is shared, so every
+                // layer would draw the same geometry into it.
+                int maskDraws = tileLayers.front()->renderTerrainShadowMask(coverTileIds);
+                _terrainShadowMaskBuffer->endPass(prevFBO, viewState.getWidth(), viewState.getHeight());
+                maskTexture = _terrainShadowMaskBuffer->getTexture();
+                {
+                    static int probe = 0;
+                    if ((probe++ % 121) == 120) {
+                        Log::Infof("PROBE mask: texture %u, %d x %d, draws %d, cover %d", maskTexture, _terrainShadowMaskBuffer->getWidth(), _terrainShadowMaskBuffer->getHeight(), maskDraws, static_cast<int>(coverTileIds.size()));
+                    }
+                }
+                // Screen pixels -> mask uv. The scale is the SCREEN size, not the mask's, because
+                // it maps gl_FragCoord of the full-resolution draw that samples it.
+                invWidth = 1.0f / viewState.getWidth();
+                invHeight = 1.0f / viewState.getHeight();
+            }
+            FRAME_PROF_GPU_END();
+        }
+        for (const std::shared_ptr<TileLayer>& tileLayer : tileLayers) {
+            tileLayer->setTerrainShadowMask(maskTexture, invWidth, invHeight);
         }
     }
 

--- a/all/native/renderers/MapRenderer.h
+++ b/all/native/renderers/MapRenderer.h
@@ -52,6 +52,7 @@ namespace carto {
     class TileLayer;
     class TerrainDrapeCache;
     class TerrainShadowMap;
+    class TerrainShadowMaskBuffer;
     class ThreadWorker;
     class CullWorker;
     class VTLabelPlacementWorker;
@@ -287,6 +288,7 @@ namespace carto {
         // Camera pose the last drape-bake pass ran against, to tell a moving frame from a
         // still one (see the bake time budget in onDrawFrame).
         cglib::mat4x4<double> _drapeBakeLastMVPMatrix = cglib::mat4x4<double>::identity();
+        std::unique_ptr<TerrainShadowMaskBuffer> _terrainShadowMaskBuffer;
         bool _shadowMapValid = false;
         int _shadowMapSize = 0;
         int _shadowMapCascades = 0;

--- a/all/native/renderers/MapRenderer.h
+++ b/all/native/renderers/MapRenderer.h
@@ -294,7 +294,9 @@ namespace carto {
         float _shadowMapFadeSignature = 0.0f;
         std::array<cglib::mat4x4<double>, 4> _shadowMapViewProjs;
         std::array<float, 4> _shadowMapBiases = { };
-        std::vector<vt::TileId> _shadowMapCasterTiles;
+        // Per cascade: the pages are refreshed independently, and the outer one - which holds most
+        // of the casters - keeps its box over far more camera movement than the near one.
+        std::array<std::vector<vt::TileId>, 4> _shadowMapCasterTiles;
 
         unsigned int _layersElevationVersion = 0;
         std::optional<std::chrono::steady_clock::time_point> _lastElevationRefreshTime;

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -1375,7 +1375,14 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
         uniform vec3 u_viewDir;
         uniform vec2 u_sunParams; // x = sun intensity (0 = legacy lighting), y = ambient
         vec4 applyLighting(lowp vec4 color, mediump vec3 normal, highp_opt float height, bool sideVertex) {
-            lowp vec3 baseColor = sideVertex ? color.rgb * (1.0 - 0.5 / (1.0 + height * height)) : color.rgb;
+            // Ambient occlusion where a wall meets the ground: that corner is shadowed by the ground
+            // and by the building's own footprint whatever the sun does, and it is the cue that
+            // makes an extrusion stand on the terrain instead of floating over it - the shadow map
+            // cannot resolve it, its texels are metres wide. This lighting runs PER VERTEX, so the
+            // shape of the falloff is irrelevant: only the value at the base ring and at the roof
+            // survive, and the wall carries the linear interpolation between them. What the cue is
+            // worth is therefore the base value alone.
+            lowp vec3 baseColor = sideVertex ? color.rgb * (1.0 - 0.65 / (1.0 + height * height)) : color.rgb;
             if (u_sunParams.x > 0.0) {
                 // Sun lighting: roofs AND walls answer to the light. The legacy path lit roofs by
                 // the VIEW direction, so from above - where roofs are most of what you see - the

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -410,6 +410,23 @@ namespace carto {
         return 0;
     }
 
+    void TileRenderer::setTerrainShadowMask(unsigned int texture, float invScreenWidth, float invScreenHeight) {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (std::shared_ptr<vt::GLTileRenderer> tileRenderer = (_vtRenderer ? _vtRenderer->getTileRenderer() : std::shared_ptr<vt::GLTileRenderer>())) {
+            tileRenderer->setTerrainShadowMask(static_cast<GLuint>(texture), invScreenWidth, invScreenHeight);
+        }
+    }
+
+    int TileRenderer::renderTerrainShadowMask(const std::vector<vt::TileId>& tileIds) {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (std::shared_ptr<vt::GLTileRenderer> tileRenderer = (_vtRenderer ? _vtRenderer->getTileRenderer() : std::shared_ptr<vt::GLTileRenderer>())) {
+            return tileRenderer->renderTerrainShadowMask(tileIds);
+        }
+        return 0;
+    }
+
     void TileRenderer::setTerrainShadowMap(unsigned int texture, int mapSize, int cascades, const std::array<float, 4>& depthBiases, float strength, float softness, const std::array<cglib::mat4x4<double>, 4>& lightViewProjs) {
         std::lock_guard<std::mutex> lock(_mutex);
 

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -128,6 +128,8 @@ namespace carto {
         float shadowCasterFadeSignature() const;
         int renderShadowCasters(const std::vector<vt::TileId>& tileIds, const cglib::mat4x4<double>& lightViewProj, bool castGround);
         void setTerrainShadowMap(unsigned int texture, int mapSize, int cascades, const std::array<float, 4>& depthBiases, float strength, float softness, const std::array<cglib::mat4x4<double>, 4>& lightViewProjs);
+        void setTerrainShadowMask(unsigned int texture, float invScreenWidth, float invScreenHeight);
+        int renderTerrainShadowMask(const std::vector<vt::TileId>& tileIds);
         // Pushed by the owner BEFORE the shared terrain surface is drawn. onDrawFrame sets the same
         // state, but it runs after that draw, so the surface would light itself with the PREVIOUS
         // frame's sun - invisible while the map redrew continuously, and a change that appears not

--- a/all/native/renderers/utils/TerrainShadowMap.cpp
+++ b/all/native/renderers/utils/TerrainShadowMap.cpp
@@ -112,7 +112,7 @@ namespace carto {
         return createResources() ? _texture : 0;
     }
 
-    bool TerrainShadowMap::beginPass() {
+    bool TerrainShadowMap::beginPass(bool clearAll) {
         if (!createResources()) {
             return false;
         }
@@ -133,16 +133,28 @@ namespace carto {
         glPolygonOffset(1.0f, 2.0f);
         // White = depth 1 = nothing in the way, which is what an untouched texel must mean.
         glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        if (clearAll) {
+            glDisable(GL_SCISSOR_TEST);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        }
         return true;
     }
 
     void TerrainShadowMap::setCascadeViewport(int cascade) {
         int index = std::min(_cascades - 1, std::max(0, cascade));
         glViewport(index * _size, 0, _size, _size);
+        // Scissored as well as viewported: the pages are refreshed independently, so a clear for
+        // one of them must not blank the ones being reused.
+        glScissor(index * _size, 0, _size, _size);
+        glEnable(GL_SCISSOR_TEST);
+    }
+
+    void TerrainShadowMap::clearCascade() {
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     }
 
     void TerrainShadowMap::endPass(unsigned int previousFrameBuffer, int viewportWidth, int viewportHeight) {
+        glDisable(GL_SCISSOR_TEST);
         glDisable(GL_POLYGON_OFFSET_FILL);
         glPolygonOffset(0.0f, 0.0f);
         glBindFramebuffer(GL_FRAMEBUFFER, previousFrameBuffer);

--- a/all/native/renderers/utils/TerrainShadowMap.cpp
+++ b/all/native/renderers/utils/TerrainShadowMap.cpp
@@ -117,6 +117,10 @@ namespace carto {
             return false;
         }
         glBindFramebuffer(GL_FRAMEBUFFER, _frameBuffer);
+        // Re-attached per pass; endPass detaches it. A texture left attached to a framebuffer is
+        // still a render target, and sampling one in the same frame - which every shadowed draw
+        // does - is undefined and serialises on this driver.
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture, 0);
         glViewport(0, 0, _size * _cascades, _size);
         glDisable(GL_BLEND);
         glDisable(GL_STENCIL_TEST);
@@ -155,6 +159,7 @@ namespace carto {
 
     void TerrainShadowMap::endPass(unsigned int previousFrameBuffer, int viewportWidth, int viewportHeight) {
         glDisable(GL_SCISSOR_TEST);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0); // see beginPass
         glDisable(GL_POLYGON_OFFSET_FILL);
         glPolygonOffset(0.0f, 0.0f);
         glBindFramebuffer(GL_FRAMEBUFFER, previousFrameBuffer);

--- a/all/native/renderers/utils/TerrainShadowMap.h
+++ b/all/native/renderers/utils/TerrainShadowMap.h
@@ -45,14 +45,18 @@ namespace carto {
          */
         unsigned int getTexture();
         /**
-         * Binds the framebuffer and clears it to "infinitely far". Returns false if unavailable.
+         * Binds the framebuffer, clearing every page to "infinitely far" when clearAll is set.
+         * Returns false if unavailable.
          */
-        bool beginPass();
+        bool beginPass(bool clearAll);
         /**
-         * Restricts drawing to one cascade's page. Must be called after beginPass, which clears
-         * every page at once.
+         * Restricts drawing (and clearing) to one cascade's page. Must be called after beginPass.
          */
         void setCascadeViewport(int cascade);
+        /**
+         * Clears the current cascade's page alone, for a pass that refreshes only some of them.
+         */
+        void clearCascade();
         /**
          * Restores the previous framebuffer and viewport.
          */

--- a/all/native/renderers/utils/TerrainShadowMaskBuffer.cpp
+++ b/all/native/renderers/utils/TerrainShadowMaskBuffer.cpp
@@ -1,0 +1,136 @@
+#include "TerrainShadowMaskBuffer.h"
+#include "renderers/utils/GLContext.h"
+#include "utils/Log.h"
+
+#include <algorithm>
+
+namespace carto {
+
+    TerrainShadowMaskBuffer::TerrainShadowMaskBuffer() :
+        _width(0),
+        _height(0),
+        _frameBuffer(0),
+        _texture(0),
+        _depthBuffer(0),
+        _failed(false)
+    {
+    }
+
+    TerrainShadowMaskBuffer::~TerrainShadowMaskBuffer() {
+        // GL resources must be released explicitly via deleteResources() while the context is
+        // current; the destructor may run after it is gone.
+    }
+
+    int TerrainShadowMaskBuffer::getWidth() const {
+        return _width;
+    }
+
+    int TerrainShadowMaskBuffer::getHeight() const {
+        return _height;
+    }
+
+    void TerrainShadowMaskBuffer::setSize(int screenWidth, int screenHeight, int divisor) {
+        int width = std::max(1, screenWidth / std::max(1, divisor));
+        int height = std::max(1, screenHeight / std::max(1, divisor));
+        if (width != _width || height != _height) {
+            _width = width;
+            _height = height;
+            deleteResources();
+            _failed = false;
+        }
+    }
+
+    bool TerrainShadowMaskBuffer::createResources() {
+        if (_frameBuffer != 0) {
+            return true;
+        }
+        if (_failed || _width <= 0 || _height <= 0) {
+            return false;
+        }
+        glGenTextures(1, &_texture);
+        glBindTexture(GL_TEXTURE_2D, _texture);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _width, _height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+        // LINEAR: the mask holds a shadow FACTOR, which does interpolate - and interpolating it is
+        // what keeps a half-resolution mask from showing its own texels along a shadow edge.
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glBindTexture(GL_TEXTURE_2D, 0);
+
+        // Depth, because the terrain tiles overlap on screen: without it the last tile drawn wins
+        // a pixel instead of the nearest one, and the mask holds the shadow of hidden ground.
+        glGenRenderbuffers(1, &_depthBuffer);
+        glBindRenderbuffer(GL_RENDERBUFFER, _depthBuffer);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, _width, _height);
+        glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+        GLint prevFrameBuffer = 0;
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFrameBuffer);
+        glGenFramebuffers(1, &_frameBuffer);
+        glBindFramebuffer(GL_FRAMEBUFFER, _frameBuffer);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture, 0);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthBuffer);
+        bool complete = glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+        glBindFramebuffer(GL_FRAMEBUFFER, prevFrameBuffer);
+        if (!complete) {
+            deleteResources();
+            _failed = true;
+            Log::Errorf("TerrainShadowMaskBuffer: no usable %d x %d mask - the surface falls back to the analytic lookup", _width, _height);
+            return false;
+        }
+        return true;
+    }
+
+    unsigned int TerrainShadowMaskBuffer::getTexture() {
+        return createResources() ? _texture : 0;
+    }
+
+    bool TerrainShadowMaskBuffer::beginPass() {
+        if (!createResources()) {
+            return false;
+        }
+        glBindFramebuffer(GL_FRAMEBUFFER, _frameBuffer);
+        // Re-attached per pass: it is DETACHED at the end, because a texture left attached to a
+        // framebuffer still counts as a render target, and sampling one in the same frame is
+        // undefined - on this driver it serialises the draws that sample it instead.
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture, 0);
+        glViewport(0, 0, _width, _height);
+        glDisable(GL_BLEND);
+        glDisable(GL_STENCIL_TEST);
+        glDisable(GL_CULL_FACE); // displaced surfaces can face away near ridge crests
+        glEnable(GL_DEPTH_TEST);
+        glDepthFunc(GL_LESS);
+        glDepthMask(GL_TRUE);
+        // White = fully lit, which is what a pixel with no terrain in it must contribute.
+        glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        return true;
+    }
+
+    void TerrainShadowMaskBuffer::endPass(unsigned int previousFrameBuffer, int viewportWidth, int viewportHeight) {
+        // Detach before anything samples it - see beginPass.
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+        glBindFramebuffer(GL_FRAMEBUFFER, previousFrameBuffer);
+        glViewport(0, 0, viewportWidth, viewportHeight);
+        glEnable(GL_BLEND);
+        glEnable(GL_CULL_FACE);
+        glDepthMask(GL_FALSE);
+    }
+
+    void TerrainShadowMaskBuffer::deleteResources() {
+        if (_frameBuffer != 0) {
+            glDeleteFramebuffers(1, &_frameBuffer);
+            _frameBuffer = 0;
+        }
+        if (_texture != 0) {
+            glDeleteTextures(1, &_texture);
+            _texture = 0;
+        }
+        if (_depthBuffer != 0) {
+            glDeleteRenderbuffers(1, &_depthBuffer);
+            _depthBuffer = 0;
+        }
+    }
+
+}

--- a/all/native/renderers/utils/TerrainShadowMaskBuffer.h
+++ b/all/native/renderers/utils/TerrainShadowMaskBuffer.h
@@ -14,8 +14,8 @@ namespace carto {
      *
      * The shadow lookup is the most expensive thing a shadowed fragment does, and the terrain
      * covers the whole screen - twice over where a paint is drawn on the drape. Resolving it once
-     * per screen pixel, at half resolution, turns every one of those draws into a single texture
-     * fetch. Half resolution costs nothing visually: a shadow edge is a penumbra anyway.
+     * per screen pixel, at a fraction of the resolution, turns every one of those draws into a
+     * single fetch. The reduced resolution costs nothing visually: a shadow edge is a penumbra.
      *
      * GL thread only.
      */

--- a/all/native/renderers/utils/TerrainShadowMaskBuffer.h
+++ b/all/native/renderers/utils/TerrainShadowMaskBuffer.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_TERRAINSHADOWMASKBUFFER_H_
+#define _CARTO_TERRAINSHADOWMASKBUFFER_H_
+
+namespace carto {
+
+    /**
+     * Screen-space shadow mask for the terrain surface, at a fraction of the screen resolution.
+     *
+     * The shadow lookup is the most expensive thing a shadowed fragment does, and the terrain
+     * covers the whole screen - twice over where a paint is drawn on the drape. Resolving it once
+     * per screen pixel, at half resolution, turns every one of those draws into a single texture
+     * fetch. Half resolution costs nothing visually: a shadow edge is a penumbra anyway.
+     *
+     * GL thread only.
+     */
+    class TerrainShadowMaskBuffer {
+    public:
+        TerrainShadowMaskBuffer();
+        ~TerrainShadowMaskBuffer();
+
+        int getWidth() const;
+        int getHeight() const;
+
+        /**
+         * Sets the screen size and the divisor the mask is rendered at. Existing resources are
+         * dropped when the resulting size changes.
+         */
+        void setSize(int screenWidth, int screenHeight, int divisor);
+
+        /**
+         * Returns the mask texture, creating the resources on first use. Returns 0 when the
+         * framebuffer could not be completed.
+         */
+        unsigned int getTexture();
+        /**
+         * Binds the framebuffer and clears it to "fully lit". Returns false if unavailable.
+         */
+        bool beginPass();
+        /**
+         * Restores the previous framebuffer and viewport.
+         */
+        void endPass(unsigned int previousFrameBuffer, int viewportWidth, int viewportHeight);
+
+        /**
+         * Deletes all GL resources. Must be called on the GL thread while the context is alive.
+         */
+        void deleteResources();
+
+    private:
+        bool createResources();
+
+        int _width;
+        int _height;
+        unsigned int _frameBuffer;
+        unsigned int _texture;
+        unsigned int _depthBuffer;
+        bool _failed;
+    };
+
+}
+
+#endif

--- a/all/native/utils/FrameProfiler.cpp
+++ b/all/native/utils/FrameProfiler.cpp
@@ -216,10 +216,10 @@ namespace carto {
             totalMs += avgMs[i];
             totalDrops += SectionDrops[i];
         }
-        Log::Infof("PROF GPU: %d frames, %d dropped (disjoint), %d sections untimed | sky %.1f background %.1f prelude %.1f prepare %.1f cover %.1f drape %.1f layers %.1f layers3D %.1f billboards %.1f total %.1f",
+        Log::Infof("PROF GPU: %d frames, %d dropped (disjoint), %d sections untimed | sky %.1f background %.1f prelude %.1f prepare %.1f cover %.1f drape %.1f layers %.1f layers3D %.1f billboards %.1f shadowCast %.1f shadowMask %.1f total %.1f",
             MeasuredFrames, DisjointFrames, totalDrops,
             avgMs[SECTION_SKY], avgMs[SECTION_BACKGROUND], avgMs[SECTION_PRELUDE], avgMs[SECTION_PREPARE], avgMs[SECTION_COVER],
-            avgMs[SECTION_DRAPE], avgMs[SECTION_LAYERS], avgMs[SECTION_LAYERS3D], avgMs[SECTION_BILLBOARDS],
+            avgMs[SECTION_DRAPE], avgMs[SECTION_LAYERS], avgMs[SECTION_LAYERS3D], avgMs[SECTION_BILLBOARDS], avgMs[SECTION_SHADOWCAST], avgMs[SECTION_SHADOWMASK],
             totalMs);
 
         std::fill(SumMs, SumMs + SECTION_COUNT, 0.0);

--- a/all/native/utils/FrameProfiler.h
+++ b/all/native/utils/FrameProfiler.h
@@ -63,6 +63,8 @@ namespace carto {
             SECTION_LAYERS,
             SECTION_LAYERS3D,
             SECTION_BILLBOARDS,
+            SECTION_SHADOWCAST,  // the shadow map's caster pass
+            SECTION_SHADOWMASK,  // the screen-space terrain shadow mask
             SECTION_COUNT
         };
 

--- a/docs/rendering/08-lighting-sky-fog.md
+++ b/docs/rendering/08-lighting-sky-fog.md
@@ -150,6 +150,26 @@ cascade already fades out over its outer margin.
 Shadows are **present at every tilt** from 90 down to 5 (the demo clamps at 30; `--es freeRoam look`
 opens the range): `shadows ACTIVE`, boxes fitted, no dropouts.
 
+## Buildings
+
+`TileRenderer::LIGHTING_SHADER_3D` lights extrusions, and it is installed **per vertex**
+(`LightingShader(true, ...)`). That has a consequence worth knowing before touching it: any function
+of height in there only reaches the screen through the values at the base ring and at the roof - the
+wall carries the linear interpolation between them, whatever curve the formula draws. A falloff
+"over the first metre" is therefore a full-height ramp on screen, and the only thing that changes the
+look is the endpoint value.
+
+The ambient term at the foot of a wall (`1 - 0.65/(1 + h*h)`) is the cue that makes an extrusion
+stand on the terrain rather than float over it: that corner is occluded by the ground and by the
+building's own footprint whatever the sun does, and the shadow map cannot resolve it - its texels are
+metres wide. Measured luminance down a wall on the device: 206 at the roof, 100 at the foot (124 with
+the previous 0.5, which read as too light).
+
+Contact darkening on the GROUND around a footprint is the other half and is not implemented: the
+ground does not know where the buildings are. It would need either screen-space AO over the scene
+depth (too expensive on an Adreno 610, where the whole 3D pass is ~9 ms) or a halo drawn by the
+style, which is a styling decision rather than an engine one.
+
 ### What did not work
 
 Kept out on measurement, so the next person does not re-try them:

--- a/docs/rendering/08-lighting-sky-fog.md
+++ b/docs/rendering/08-lighting-sky-fog.md
@@ -125,6 +125,31 @@ frame time 33–54 ms → 25–35 ms. The same detach was added to `TerrainShado
 mask off, it changes nothing (40–41 ms) — it is the mask that needs it. `MapRenderer` already
 documents the same trap for the drape bake.
 
+### How far shadows reach
+
+The shadowed ground is bounded by what the map can **represent**, not only by what the view can see:
+the outer cascade's texel is its extent over the resolution, so shadowing 50 km through a 1024 page
+gives texels wider than the ridges casting into them - a grey wash. `calculateShadowViewProj` caps
+the range at `TARGET_SHADOW_TEXEL_METERS x mapSize` (10 m x the page, so ~10 km at 1024), on top of
+the existing relief-and-view heuristic.
+
+This is what makes shadows hold up as the view flattens; measured on the Crosscall at z14, per
+cascade, with the caster tile count:
+
+| tilt | before | after |
+|---|---|---|
+| 90 | 7.2 / 10.7 / 14.3 m, 162 tiles | unchanged - the cap does not bind |
+| 45 | 5.4 / 14.3 / 28.7 m, 242 tiles | 3.9 / 9.0 / 19.1 m, 176 tiles |
+| 30 | 3.3 / 13.1 / 52.6 m, 205 tiles | 1.3 / 2.7 / 10.7 m, 121 tiles |
+
+Sharper *and* cheaper, because a shorter range is also fewer caster tiles: 9.3 -> 10.6 fps at tilt 30.
+A city view at z16 is untouched (the view-based term is already smaller there). Nothing is visibly
+lost in the distance - past that range the shadows were texels tens of metres wide, and the last
+cascade already fades out over its outer margin.
+
+Shadows are **present at every tilt** from 90 down to 5 (the demo clamps at 30; `--es freeRoam look`
+opens the range): `shadows ACTIVE`, boxes fitted, no dropouts.
+
 ### What did not work
 
 Kept out on measurement, so the next person does not re-try them:

--- a/docs/rendering/08-lighting-sky-fog.md
+++ b/docs/rendering/08-lighting-sky-fog.md
@@ -102,7 +102,44 @@ So the caster pass is about **4 ms** of the 33 and the rest is the **receiver**:
 one shadow matrix per vertex and one highp vec3 varying per cascade. Optimising the caster pass
 further (fewer tiles, coarser caster mesh, cheaper pages) is therefore not where the frame is.
 
-The lookup is now **compiled for the cascade count in use** (`GLTileRenderer::shadowReceiverFlags`,
+### The screen-space shadow mask
+
+`TerrainShadowMaskBuffer` (all/native/renderers/utils/) + `SHADOW_MASK_OUT` / `SHADOW_MASK_IN`.
+
+The terrain surface covers the whole screen, and where a paint is drawn on the drape it covers it
+twice, so the lookup ran once per covering draw per pixel. It is now resolved **once, at half
+resolution**: the same surface tiles are drawn into a half-size target with a fragment shader that
+stops at the shadow value (`renderTerrainShadowMask`, the fill path with `SHADOW_MASK_OUT`), and the
+real surface draws sample it by `gl_FragCoord.xy * uShadowMaskScale` — one fetch, no cascade choice,
+no matrices, no varyings, no taps. Half resolution is invisible in the result: a shadow edge is a
+penumbra, and the mask is sampled `GL_LINEAR`. 3D extrusions and undraped lines keep the analytic
+path — they are not the terrain surface, so the mask does not hold their shadow.
+
+**Detach the mask texture from its framebuffer before anything samples it.** This is what makes the
+mask pay at all: attached, it is still a render target, sampling it in the same frame is undefined,
+and this driver serialises every draw that reads it. Measured on the Crosscall, terrain z13 tilt 30,
+GPU drape section: 38–49 ms analytic, 37–45 ms with the mask still attached, **23–27 ms detached**;
+frame time 33–54 ms → 25–35 ms. The same detach was added to `TerrainShadowMap`; on its own, with the
+mask off, it changes nothing (40–41 ms) — it is the mask that needs it. `MapRenderer` already
+documents the same trap for the drape bake.
+
+### What did not work
+
+Kept out on measurement, so the next person does not re-try them:
+
+- **Fragment-side cascade selection** (one `vShadowLocal` varying, one matrix applied per fragment,
+  cascade picked from `gl_FragCoord.w` against the split distances). Correct, and *slower*: these
+  scenes are fragment-bound, so moving a mat4 out of the vertex stage costs more than the two
+  varyings it saves. City 3D pass 10.3–11.1 → 13.1–13.8 ms.
+- **Extrusions only in the near cascades**, and a **coarser caster mesh for the outer cascades**.
+  Neither moved the frame: with *zero* caster draws the pass still showed up to 60 ms of GPU-section
+  time in a city frame, so its cost is not the geometry.
+- That last number is also a warning about the tool: a GPU section absorbs the GPU's idle time, and
+  in the city the frame is not GPU-bound — the CPU frame time is flat (33–63 ms) across every one of
+  these builds. Read `PROF GPU` sections against the CPU frame time before believing a regression.
+  The open question in a city view is what makes it CPU-bound, not the shadow pass.
+
+The lookup is also **compiled for the cascade count in use** (`GLTileRenderer::shadowReceiverFlags`,
 `SHADOW_CASCADES_2/3/4`); it used to declare four matrices and four varyings whatever the count.
 Measured on the same scene: at one cascade 44.3 → 37 ms of drape, i.e. **~2.3 ms per cascade per
 frame**, so ~2 ms at the default 3 — real, but inside the run-to-run spread. The remaining ~26 ms is

--- a/docs/rendering/08-lighting-sky-fog.md
+++ b/docs/rendering/08-lighting-sky-fog.md
@@ -107,12 +107,14 @@ further (fewer tiles, coarser caster mesh, cheaper pages) is therefore not where
 `TerrainShadowMaskBuffer` (all/native/renderers/utils/) + `SHADOW_MASK_OUT` / `SHADOW_MASK_IN`.
 
 The terrain surface covers the whole screen, and where a paint is drawn on the drape it covers it
-twice, so the lookup ran once per covering draw per pixel. It is now resolved **once, at half
+twice, so the lookup ran once per covering draw per pixel. It is now resolved **once, at a quarter of the screen
 resolution**: the same surface tiles are drawn into a half-size target with a fragment shader that
 stops at the shadow value (`renderTerrainShadowMask`, the fill path with `SHADOW_MASK_OUT`), and the
 real surface draws sample it by `gl_FragCoord.xy * uShadowMaskScale` — one fetch, no cascade choice,
-no matrices, no varyings, no taps. Half resolution is invisible in the result: a shadow edge is a
-penumbra, and the mask is sampled `GL_LINEAR`. 3D extrusions and undraped lines keep the analytic
+no matrices, no varyings, no taps. The reduced resolution is invisible in the result: a terrain
+shadow edge is a penumbra, and the mask is sampled `GL_LINEAR`. A quarter against a half costs
+nothing visible and is worth 14-16 ms -> 8-9 ms of mask pass, 8.5 -> 9.6 fps (with the profiler's
+own sections in both, which cost about 3 fps themselves). 3D extrusions and undraped lines keep the analytic
 path — they are not the terrain surface, so the mask does not hold their shadow.
 
 **Detach the mask texture from its framebuffer before anything samples it.** This is what makes the

--- a/docs/rendering/08-lighting-sky-fog.md
+++ b/docs/rendering/08-lighting-sky-fog.md
@@ -52,10 +52,63 @@ Design points, each measured:
   grey wash that appears and disappears with the cover. The **shadow pass alone** floors the sun
   altitude at 15°, keeping the azimuth, which caps shadow length at ~3.7× the relief. N·L lighting
   keeps the true sun, so a low sun still reads as a low sun.
-- **Caster margin.** Casters are taken from the cover plus a ring of neighbours: a mountain just off
-  screen still throws its shadow into the view, and without the margin its shadow vanishes as you
-  zoom in and it leaves the visible set.
-- The map is **snapped and cached** so a stationary camera does not re-render it.
+- **Caster margin.** Casters are taken from the cover plus a ring of neighbours (`shadowCasterMargin`
+  tiles): a mountain just off screen still throws its shadow into the view, and without the margin
+  its shadow vanishes as you zoom in and it leaves the visible set.
+- **The caster set has to stay a partition of the ground.** The cover is a quadtree partition, but the
+  ring is generated at each cover tile's own zoom and the cover mixes zooms (up to
+  `TerrainMaxTileZoomCoarsening` levels), so the ring around a coarse tile lands on top of the fine
+  tiles beside it. Two casters over the same ground at different DEM levels disagree by tens of
+  metres, the shallower one wins the depth test, and the receiver — which uses the fine level — ends
+  up in the shadow of *its own ground*. On screen: blocky, roughly axis-aligned dark patches that do
+  not follow the sun azimuth, appearing from about tilt 60 (SDK convention, 90 = top down) and growing
+  as the view flattens, because a flatter view mixes more zooms. `MapRenderer::applyTerrainShadows`
+  therefore **subdivides** an overlapping ring candidate against what is already taken, finest zoom
+  first, instead of dropping it — dropping would leave the ground outside the finer tiles with no
+  caster. Measured (emulator, Grenoble z13 tilt 30, sun 30°/135°, 3 × 1024): 47.6% of the flat valley
+  wrongly darkened before, 4.1% after — the same as with no ring at all (`shadowMargin 0`), which is
+  the floor. Ruled out on the way: bias (`shadowBias 10` → 42.5%), map resolution (4096 → 52.1%,
+  *worse*), cascade count (1 cascade → 36.5%). None of them is the mechanism.
+- A tile with **no elevation yet casts nothing**: drawn flat it is a sea-level plane, which is not the
+  terrain it stands for, and a receiver without elevation takes no shadow either.
+- The map is **snapped and cached** so a stationary camera does not re-render it. The cache is **per
+  page**: each cascade's box is snapped to its own lattice, and the outer page — which holds most of
+  the casters — keeps its matrix over far more camera movement than the near one. A page that is not
+  refreshed keeps the matrix it was drawn with, so the uniforms are taken from what the pages hold,
+  not from this frame's fit. Refreshing only the changed pages needs a scissored clear
+  (`TerrainShadowMap::clearCascade`).
+- **The per-cascade caster cull is exact.** The sides are snapped *before* the casters are culled
+  against them, so the cull uses the final box and a one-texel margin; culling against the unsnapped
+  box needed a 20% slop, which on the outer cascade is kilometres of ground. Cost of the pass on the
+  emulator, panning at z13 tilt 30: 287 tile draws / 1.3 ms per pass → 120 / 0.6 ms with the exact
+  cull → 70 / 0.5 ms with per-page refresh, and passes now redraw one page instead of three.
+
+### Where the shadow cost actually is
+
+Measured on the Crosscall (Adreno 610, `-PprofileRender`, Grenoble z13 tilt 30, 3 × 1024, swipe-panned).
+GPU `drape` section, which contains the caster pass and the terrain surface draws:
+
+| Configuration | GPU drape | Note |
+|---|---|---|
+| `shadow 0` | 14.5–17.0 ms | shadow path not compiled in |
+| `shadow 0.6` | 46.7–51.1 ms | ~33 ms for the feature, half the frame |
+| `shadow 0.02` | 43.9–51.8 ms | shader runs, shadow invisible — **same cost** |
+| `shadowCascades 1` | 42.9–46.3 ms | one page, 76 caster draws instead of 102 |
+| one PCF tap instead of nine | 36.5–46.3 ms | |
+| `meshResolution 16` (vs 64) | 28.1–30.7 ms on, 7.3–7.9 off | feature cost 21 ms instead of 33 |
+
+So the caster pass is about **4 ms** of the 33 and the rest is the **receiver**: the taps are worth
+~6 ms and the remainder is per-vertex and per-fragment overhead that scales with the terrain mesh —
+one shadow matrix per vertex and one highp vec3 varying per cascade. Optimising the caster pass
+further (fewer tiles, coarser caster mesh, cheaper pages) is therefore not where the frame is.
+
+The lookup is now **compiled for the cascade count in use** (`GLTileRenderer::shadowReceiverFlags`,
+`SHADOW_CASCADES_2/3/4`); it used to declare four matrices and four varyings whatever the count.
+Measured on the same scene: at one cascade 44.3 → 37 ms of drape, i.e. **~2.3 ms per cascade per
+frame**, so ~2 ms at the default 3 — real, but inside the run-to-run spread. The remaining ~26 ms is
+the single-cascade base cost. Getting that down means selecting the cascade in the fragment stage
+from view distance, so the vertex stage applies one matrix and interpolates one varying whatever the
+cascade count — not yet done.
 
 **Current state: cast shadows are switched OFF on the shared ground.**
 `applyTerrainShadows(..., castShadows = false, ...)` — the light, the boxes and the caster pass are


### PR DESCRIPTION
## Summary

**The bug.** From about tilt 60 (SDK convention, 90 = top down), blocky roughly axis-aligned dark patches appear on the terrain, growing as the view flattens and ignoring the sun azimuth — they are not shadows of anything.

The caster margin ring is generated at each cover tile's own zoom, and the cover mixes zooms (up to `TerrainMaxTileZoomCoarsening` levels), so the ring around a coarse tile lands on top of the fine cover tiles beside it. Two casters over the same ground at different DEM levels disagree by tens of metres, the shallower one wins the depth test, and the receiver — which uses the fine level — ends up in the shadow of *its own ground*. A flatter view mixes more zooms, which is why it gets worse as you tilt down.

`applyTerrainShadows` now **subdivides** an overlapping ring candidate against what is already taken, finest zoom first, rather than dropping it — dropping would leave the ground outside the finer tiles with no caster at all.

**The rest is cost.** Shadows were about half the frame on an Adreno 610:

- Per-**page** shadow map refresh: each cascade's box is snapped to its own lattice and the outer one keeps its matrix over far more camera movement, so a pass redraws one page instead of three. A page that is not refreshed keeps the matrix it was drawn with, so the uniforms come from what the pages hold, not from this frame's fit.
- A screen-space **terrain shadow mask** (`TerrainShadowMaskBuffer`), rendered at a quarter of the screen resolution and sampled by every surface draw that covers the pixel.
- **Detaching offscreen textures from their framebuffer before anything samples them.** This is what makes the mask pay at all: attached, a texture is still a render target, sampling it in the same frame is undefined, and this driver serialises every draw that reads it. `MapRenderer` already documented the same trap for the drape bake. On its own, with the mask off, the detach changes nothing.
- The profiler gets a section for the caster pass and one for the mask — both were hidden inside `drape`, and that is where the frame goes.

## Testing

Renderer work, so no syntax check proves it; an on-device check is required and was run.

**Correctness** (emulator, Grenoble z13 tilt 30, sun 30°/135°, 3 × 1024): share of the flat valley wrongly darkened, against a shadows-off baseline of the same camera — **47.6% → 4.1%**, which equals the floor measured with no margin ring at all (`--es shadowMargin 0`). Ruled out on the way, none of them the mechanism: 10x bias (42.5%), a 4096 map (52.1% — worse), one cascade (36.5%). Rendered image compared at tilt 25 / 45 / 85: real ridge shadows unchanged, the smeared patches gone.

**Performance** (Crosscall HLTE556N, Adreno 610, `-PprofileRender`, `debug.carto.gputimer 0`, swipe-panned, paired runs in **both** orders since the second run has the warmer cache):

| scene | master | this branch |
|---|---|---|
| terrain z13 tilt 30 | 7.3 / 7.4 fps | **10.1 / 10.2** |
| city z16 tilt 45 + 3D buildings | 6.8 / 6.5 fps | **12.5 / 10.4** |

Reproduce:

```sh
adb shell am start -n com.akylas.cartotest/.MainActivity --es ui false \
  --es terrainLight true --es shadow 0.6 --es sunAltitude 30 --es sunAzimuth 135 \
  --es tilt 25 --es zoom 13 --es lat 45.16 --es lon 5.75
```

For the buildings case add `--es style inline --es bld3d true --es tilt 45 --es zoom 16.2 --es lat 45.187362 --es lon 5.718957`.

**Still unverified:** the mask is quarter-resolution and carries the ground's shadow, which includes shadows buildings cast *onto* the ground — thin building shadows may soften. Worth one look in the city view.

[`docs/rendering/08-lighting-sky-fog.md`](docs/rendering/08-lighting-sky-fog.md) carries the numbers and, deliberately, what was measured and **thrown away**: fragment-side cascade selection (slower — these scenes are fragment-bound), extrusions restricted to the near cascade, and coarser caster meshes for the outer cascades (with *zero* caster draws the pass still showed 60 ms of GPU-section time, which is idle attribution — a city frame is not GPU-bound).

## Depends on

https://github.com/farfromrefug/mobile-carto-libs/pull/48 — merge that first, then rebase the pointer bump here onto the merged commit rather than the branch commit.