### PR TITLE
feat(labels): font name lists for marker popups and vector elements

### DIFF
--- a/all/native/graphics/BitmapCanvas.cpp
+++ b/all/native/graphics/BitmapCanvas.cpp
@@ -1,4 +1,5 @@
 #include "BitmapCanvas.h"
+#include "utils/SystemFontUtils.h"
 
 #if defined(_WIN32)
 #define MASSIF_BITMAP_CANVAS_IMPL UWPImpl
@@ -35,8 +36,10 @@ namespace massif {
         _impl->setStrokeWidth(width);
     }
 
-    void BitmapCanvas::setFont(const std::string& name, float size) {
-        _impl->setFont(name, size);
+    void BitmapCanvas::setFont(const std::string& names, float size) {
+        // The style names a font list, the platform text API takes one font it knows about
+        SystemFontUtils::FontMatch match = SystemFontUtils::MatchFont(names);
+        _impl->setFont(match.familyName, match.fileName, size);
     }
 
     void BitmapCanvas::pushClipRect(const ScreenBounds& clipRect) {

--- a/all/native/graphics/BitmapCanvas.h
+++ b/all/native/graphics/BitmapCanvas.h
@@ -31,7 +31,11 @@ namespace massif {
         void setDrawMode(DrawMode mode);
         void setColor(const Color& color);
         void setStrokeWidth(float width);
-        void setFont(const std::string& name, float size);
+        /**
+         * @param names A CSS-like font list, the most preferred name first, entries optionally
+         *              tagged with the platform they are for ("android:Roboto, ios:Helvetica Neue").
+         */
+        void setFont(const std::string& names, float size);
 
         void pushClipRect(const ScreenBounds& clipRect);
         void popClipRect();
@@ -53,7 +57,9 @@ namespace massif {
             virtual void setDrawMode(DrawMode mode) = 0;
             virtual void setColor(const Color& color) = 0;
             virtual void setStrokeWidth(float width) = 0;
-            virtual void setFont(const std::string& name, float size) = 0;
+            // A font already matched to the device: the family name the platform accepts, or - when
+            // the platform has no name for it - the font file. Both empty keeps the default font.
+            virtual void setFont(const std::string& familyName, const std::string& fileName, float size) = 0;
 
             virtual void pushClipRect(const ScreenBounds& clipRect) = 0;
             virtual void popClipRect() = 0;

--- a/all/native/styles/BalloonPopupButtonStyleBuilder.h
+++ b/all/native/styles/BalloonPopupButtonStyleBuilder.h
@@ -66,8 +66,10 @@ namespace massif {
          */
         std::string getTextFontName() const;
         /**
-         * Sets the name of the text font. It must be one of the fonts bundled with the platform.
-         * The default is HelveticaNeue-Light.
+         * Sets the name of the text font. Accepts a CSS-like list, the most preferred name first, entries
+         * optionally tagged with the platform they are for ("android:Roboto, ios:Helvetica Neue,
+         * sans-serif"). A name the device has no font for is skipped; generic names ("sans-serif",
+         * "serif", "monospace", "Arial", ...) map to the platform font. The default is HelveticaNeue-Light.
          * @param textFontName The new name for the text font.
          */
         void setTextFontName(const std::string& textFontName);

--- a/all/native/styles/BalloonPopupStyleBuilder.h
+++ b/all/native/styles/BalloonPopupStyleBuilder.h
@@ -122,8 +122,11 @@ namespace massif {
          */
         std::string getTitleFontName() const;
         /**
-         * Sets the name of the title font. It must be one of the fonts bundled with the platform.
-         * The default is HelveticaNeue-Light.
+         * Sets the name of the title font. Accepts a CSS-like list, the most preferred name
+         * first, entries optionally tagged with the platform they are for
+         * ("android:Roboto, ios:Helvetica Neue, sans-serif"). A name the device has no font for
+         * is skipped; generic names ("sans-serif", "serif", "monospace", "Arial", ...) map to the
+         * platform font. The default is HelveticaNeue-Light.
          * @param titleFontName The new name for the title font.
          */
         void setTitleFontName(const std::string& titleFontName);
@@ -187,8 +190,11 @@ namespace massif {
          */
         std::string getDescriptionFontName() const;
         /**
-         * Sets the name of the description font. It must be one of the fonts bundled with the platform.
-         * The default is HelveticaNeue-Light.
+         * Sets the name of the description font. Accepts a CSS-like list, the most preferred name
+         * first, entries optionally tagged with the platform they are for
+         * ("android:Roboto, ios:Helvetica Neue, sans-serif"). A name the device has no font for
+         * is skipped; generic names ("sans-serif", "serif", "monospace", "Arial", ...) map to the
+         * platform font. The default is HelveticaNeue-Light.
          * @param descFontName The new name for the description font.
          */
         void setDescriptionFontName(const std::string& descFontName);

--- a/all/native/styles/TextStyleBuilder.h
+++ b/all/native/styles/TextStyleBuilder.h
@@ -32,7 +32,10 @@ namespace massif {
          */
         std::string getFontName() const;
         /**
-         * Sets the font name for the text label.
+         * Sets the font name for the text label. Accepts a CSS-like list, the most preferred name first, entries
+         * optionally tagged with the platform they are for ("android:Roboto, ios:Helvetica Neue,
+         * sans-serif"). A name the device has no font for is skipped; generic names ("sans-serif",
+         * "serif", "monospace", "Arial", ...) map to the platform font.
          * @param fontName The new platform dependent font name for the text label.
          */
         void setFontName(const std::string& fontName);

--- a/all/native/utils/SystemFontUtils.h
+++ b/all/native/utils/SystemFontUtils.h
@@ -20,14 +20,38 @@ namespace massif {
     class SystemFontUtils {
     public:
         /**
+         * A system font matched to a requested name, for the platform text APIs the vector
+         * elements are drawn with.
+         */
+        struct FontMatch {
+            /**
+             * The name the platform text API accepts, empty when no requested name matched.
+             */
+            std::string familyName;
+            /**
+             * The font file, set only when the platform has no name for the matched font (Android).
+             */
+            std::string fileName;
+        };
+
+        /**
          * Loads the system font best matching the given name.
          * Generic names ("Arial", "Helvetica", "sans-serif", "serif", "monospace", ...) are mapped
-         * to the closest font of the platform, and a name without any match falls back to the
-         * default system font.
+         * to the closest font of the platform.
          * @param name The requested font name, optionally followed by a style ("Arial Bold").
-         * @return The font file data or null if the platform has no usable font at all.
+         * @param allowFallback True to answer a name without any match with the default system
+         *                      font, false to fail so that the caller can try the next name.
+         * @return The font file data or null if there is no match.
          */
-        static std::shared_ptr<BinaryData> LoadFont(const std::string& name);
+        static std::shared_ptr<BinaryData> LoadFont(const std::string& name, bool allowFallback);
+
+        /**
+         * Matches a font list to a font installed on the device.
+         * @param names A CSS-like font list, the most preferred name first, entries optionally
+         *              tagged with the platform they are for ("android:Roboto, ios:Helvetica Neue").
+         * @return The first name of the list that the platform knows, empty if none of them does.
+         */
+        static FontMatch MatchFont(const std::string& names);
 
     private:
         SystemFontUtils();

--- a/all/native/vectortiles/MBVectorTileDecoder.cpp
+++ b/all/native/vectortiles/MBVectorTileDecoder.cpp
@@ -968,9 +968,11 @@ namespace massif {
                 }
             }
 
-            // Fonts the style asks for but does not provide are loaded from the system
+            // Fonts the style asks for but does not provide are loaded from the system. Strictly:
+            // a name the device has no font for must fail here, or a font list ("Roboto, Helvetica
+            // Neue") would stop at its first entry with the default font on every platform.
             fontManager->setFontDataLoader([](const std::string& name) {
-                if (std::shared_ptr<BinaryData> fontData = SystemFontUtils::LoadFont(name)) {
+                if (std::shared_ptr<BinaryData> fontData = SystemFontUtils::LoadFont(name, false)) {
                     return *fontData->getDataPtr();
                 }
                 return std::vector<unsigned char>();
@@ -985,6 +987,13 @@ namespace massif {
             if (!fallbackFont) {
                 // Styles without any font (inline CartoCSS, for example) still need a font for their labels
                 fallbackFont = fontManager->getFont(DEFAULT_FALLBACK_FONT_NAME, fallbackFont);
+            }
+            if (!fallbackFont) {
+                // Nothing the strict loader can answer, so take the default system font directly
+                if (std::shared_ptr<BinaryData> fontData = SystemFontUtils::LoadFont(DEFAULT_FALLBACK_FONT_NAME, true)) {
+                    std::string fontName = fontManager->loadFontData(*fontData->getDataPtr());
+                    fallbackFont = fontManager->getFont(fontName, fallbackFont);
+                }
             }
             mvt::SymbolizerContext::Settings settings(DEFAULT_TILE_SIZE, std::make_shared<mvt::StyleParameterStore>(), fallbackFont, _pixelScale);
             symbolizerContext = std::make_shared<mvt::SymbolizerContext>(bitmapManager, fontManager, strokeMap, glyphMap, settings);

--- a/android/native/graphics/BitmapCanvasAndroidImpl.cpp
+++ b/android/native/graphics/BitmapCanvasAndroidImpl.cpp
@@ -7,6 +7,8 @@
 #include "utils/Log.h"
 
 #include <cmath>
+#include <map>
+#include <mutex>
 
 namespace massif {
 
@@ -103,10 +105,12 @@ namespace massif {
     struct BitmapCanvas::AndroidImpl::TypefaceClass {
         JNIUniqueGlobalRef<jclass> clazz;
         jmethodID create;
+        jmethodID createFromFile;
 
         explicit TypefaceClass(JNIEnv* jenv) {
             clazz = JNIUniqueGlobalRef<jclass>(jenv, jenv->NewGlobalRef(jenv->FindClass("android/graphics/Typeface")));
             create = jenv->GetStaticMethodID(clazz, "create", "(Ljava/lang/String;I)Landroid/graphics/Typeface;");
+            createFromFile = jenv->GetStaticMethodID(clazz, "createFromFile", "(Ljava/lang/String;)Landroid/graphics/Typeface;");
         }
     };
 
@@ -243,7 +247,7 @@ namespace massif {
         jenv->CallVoidMethod(_paintObject, GetPaintClass()->setStrokeWidth, (jfloat)width);
     }
 
-    void BitmapCanvas::AndroidImpl::setFont(const std::string& name, float size) {
+    void BitmapCanvas::AndroidImpl::setFont(const std::string& familyName, const std::string& fileName, float size) {
         JNIEnv* jenv = AndroidUtils::GetCurrentThreadJNIEnv();
         JNILocalFrame jframe(jenv, 32, "BitmapCanvas::AndroidImpl::setFont");
         if (!jframe.isValid()) {
@@ -251,10 +255,33 @@ namespace massif {
             return;
         }
 
-        jstring fontName = jenv->NewStringUTF(name.c_str());
-        jobject typefaceObject = jenv->CallStaticObjectMethod(GetTypefaceClass()->clazz, GetTypefaceClass()->create, fontName, (jint)0); // 0 = NORMAL
+        // A family keeps the per-script fallback chain; a file, which only the fonts Android has no
+        // family name for need, does not - so it is the second choice. Null family = the default font.
+        jobject typefaceObject = nullptr;
+        if (!familyName.empty() || fileName.empty()) {
+            jstring fontName = (familyName.empty() ? nullptr : jenv->NewStringUTF(familyName.c_str()));
+            typefaceObject = jenv->CallStaticObjectMethod(GetTypefaceClass()->clazz, GetTypefaceClass()->create, fontName, (jint)0); // 0 = NORMAL
+        }
+        else {
+            typefaceObject = GetFileTypeface(jenv, fileName);
+        }
         jenv->CallObjectMethod(_paintObject, GetPaintClass()->setTypeface, typefaceObject);
         jenv->CallVoidMethod(_paintObject, GetPaintClass()->setTextSize, (jfloat)size);
+    }
+
+    jobject BitmapCanvas::AndroidImpl::GetFileTypeface(JNIEnv* jenv, const std::string& fileName) {
+        // Typeface.createFromFile parses the file on every call, unlike Typeface.create
+        static std::mutex mutex;
+        static std::map<std::string, JNIUniqueGlobalRef<jobject>> typefaceCache;
+
+        std::lock_guard<std::mutex> lock(mutex);
+        auto it = typefaceCache.find(fileName);
+        if (it == typefaceCache.end()) {
+            JNIUniqueLocalRef<jstring> filePath(jenv, jenv->NewStringUTF(fileName.c_str()));
+            jobject typefaceObject = jenv->CallStaticObjectMethod(GetTypefaceClass()->clazz, GetTypefaceClass()->createFromFile, filePath.get());
+            it = typefaceCache.emplace(fileName, JNIUniqueGlobalRef<jobject>(jenv, jenv->NewGlobalRef(typefaceObject))).first;
+        }
+        return it->second.get();
     }
 
     void BitmapCanvas::AndroidImpl::pushClipRect(const ScreenBounds& clipRect) {

--- a/android/native/graphics/BitmapCanvasAndroidImpl.h
+++ b/android/native/graphics/BitmapCanvasAndroidImpl.h
@@ -20,7 +20,7 @@ namespace massif {
         virtual void setDrawMode(DrawMode mode);
         virtual void setColor(const Color& color);
         virtual void setStrokeWidth(float width);
-        virtual void setFont(const std::string& name, float size);
+        virtual void setFont(const std::string& familyName, const std::string& fileName, float size);
 
         virtual void pushClipRect(const ScreenBounds& clipRect);
         virtual void popClipRect();
@@ -47,6 +47,8 @@ namespace massif {
         struct TextUtilsTruncateAtClass;
 
         void ellipsizeText(JNIEnv* jenv, std::string& text, int maxWidth, bool breakLines) const;
+
+        static jobject GetFileTypeface(JNIEnv* jenv, const std::string& fileName);
 
         static std::unique_ptr<RectFClass>& GetRectFClass();
         static std::unique_ptr<BitmapClass>& GetBitmapClass();

--- a/android/native/utils/SystemFontUtils.cpp
+++ b/android/native/utils/SystemFontUtils.cpp
@@ -11,35 +11,52 @@
 
 #include <dirent.h>
 
+#include <vt/FontNames.h>
+
 namespace massif {
 
     namespace {
 
         const char* const FONT_DIRECTORIES[] = { "/system/fonts", "/product/fonts", "/system/font", "/data/fonts", nullptr };
 
+        struct FontAlias {
+            const char* name;
+            const char* fileCandidates; // font files, for the FreeType path of the vector tile labels
+            const char* androidFamily;  // Typeface family, for the platform text path of the vector elements
+        };
+
         // Generic/foreign font names mapped to the Android font families, in preference order
-        const std::pair<const char*, const char*> FONT_ALIASES[] = {
-            { "arial",          "roboto notosans droidsans" },
-            { "helvetica",      "roboto notosans droidsans" },
-            { "helveticaneue",  "roboto notosans droidsans" },
-            { "verdana",        "roboto notosans droidsans" },
-            { "tahoma",         "roboto notosans droidsans" },
-            { "segoeui",        "roboto notosans droidsans" },
-            { "sansserif",      "roboto notosans droidsans" },
-            { "sans",           "roboto notosans droidsans" },
-            { "timesnewroman",  "notoserif droidserif tinos" },
-            { "times",          "notoserif droidserif tinos" },
-            { "georgia",        "notoserif droidserif tinos" },
-            { "serif",          "notoserif droidserif tinos" },
-            { "couriernew",     "droidsansmono notosansmono cousine" },
-            { "courier",        "droidsansmono notosansmono cousine" },
-            { "consolas",       "droidsansmono notosansmono cousine" },
-            { "monospace",      "droidsansmono notosansmono cousine" },
-            { "mono",           "droidsansmono notosansmono cousine" },
-            { nullptr, nullptr }
+        const FontAlias FONT_ALIASES[] = {
+            { "arial",          "roboto notosans droidsans",        "sans-serif" },
+            { "helvetica",      "roboto notosans droidsans",        "sans-serif" },
+            { "helveticaneue",  "roboto notosans droidsans",        "sans-serif" },
+            { "verdana",        "roboto notosans droidsans",        "sans-serif" },
+            { "tahoma",         "roboto notosans droidsans",        "sans-serif" },
+            { "segoeui",        "roboto notosans droidsans",        "sans-serif" },
+            { "sansserif",      "roboto notosans droidsans",        "sans-serif" },
+            { "sans",           "roboto notosans droidsans",        "sans-serif" },
+            { "roboto",         "roboto notosans droidsans",        "sans-serif" },
+            { "notosans",       "notosans roboto droidsans",        "sans-serif" },
+            { "droidsans",      "droidsans roboto notosans",        "sans-serif" },
+            { "timesnewroman",  "notoserif droidserif tinos",       "serif" },
+            { "times",          "notoserif droidserif tinos",       "serif" },
+            { "georgia",        "notoserif droidserif tinos",       "serif" },
+            { "serif",          "notoserif droidserif tinos",       "serif" },
+            { "notoserif",      "notoserif droidserif tinos",       "serif" },
+            { "droidserif",     "droidserif notoserif tinos",       "serif" },
+            { "couriernew",     "droidsansmono notosansmono cousine", "monospace" },
+            { "courier",        "droidsansmono notosansmono cousine", "monospace" },
+            { "consolas",       "droidsansmono notosansmono cousine", "monospace" },
+            { "monospace",      "droidsansmono notosansmono cousine", "monospace" },
+            { "mono",           "droidsansmono notosansmono cousine", "monospace" },
+            { "cursive",        "dancingscript cutivemono",         "cursive" },
+            { nullptr, nullptr, nullptr }
         };
 
         const char* const STYLE_SUFFIXES[] = { "bolditalic", "boldoblique", "bold", "italic", "oblique", "regular", "book", nullptr };
+
+        // Weights Android exposes as their own family ('sans-serif-light'), unlike the style suffixes
+        const char* const FAMILY_WEIGHT_SUFFIXES[] = { "condensed", "medium", "black", "light", "thin", nullptr };
 
         const char* const DEFAULT_FONTS[] = { "robotoregular", "notosansregular", "droidsans", "robotobold", nullptr };
 
@@ -110,7 +127,20 @@ namespace massif {
             return std::string();
         }
 
-        std::string resolveFontFile(const std::string& name) {
+        // Splits a trailing suffix off the normalized name ('arialbold' -> 'arial' + 'bold')
+        std::string splitSuffix(const std::string& normalizedName, const char* const* suffixes, std::string& family) {
+            family = normalizedName;
+            for (int i = 0; suffixes[i]; i++) {
+                std::string suffix = suffixes[i];
+                if (normalizedName.size() > suffix.size() && normalizedName.compare(normalizedName.size() - suffix.size(), suffix.size(), suffix) == 0) {
+                    family = normalizedName.substr(0, normalizedName.size() - suffix.size());
+                    return suffix;
+                }
+            }
+            return std::string();
+        }
+
+        std::string resolveFontFile(const std::string& name, bool allowFallback) {
             const std::map<std::string, std::string>& fontMap = getSystemFontMap();
             std::string normalizedName = normalizeFontName(name);
 
@@ -119,22 +149,13 @@ namespace massif {
                 return fileName;
             }
 
-            // Split the trailing style ('arialbold' -> 'arial' + 'bold') and try the aliases of the family
-            std::string family = normalizedName;
-            std::string style;
-            for (int i = 0; STYLE_SUFFIXES[i]; i++) {
-                std::string suffix = STYLE_SUFFIXES[i];
-                if (normalizedName.size() > suffix.size() && normalizedName.compare(normalizedName.size() - suffix.size(), suffix.size(), suffix) == 0) {
-                    family = normalizedName.substr(0, normalizedName.size() - suffix.size());
-                    style = suffix;
-                    break;
-                }
-            }
-            for (int i = 0; FONT_ALIASES[i].first; i++) {
-                if (family != FONT_ALIASES[i].first) {
+            std::string family;
+            std::string style = splitSuffix(normalizedName, STYLE_SUFFIXES, family);
+            for (int i = 0; FONT_ALIASES[i].name; i++) {
+                if (family != FONT_ALIASES[i].name) {
                     continue;
                 }
-                std::string candidates = FONT_ALIASES[i].second;
+                std::string candidates = FONT_ALIASES[i].fileCandidates;
                 for (std::size_t pos = 0; pos < candidates.size(); ) {
                     std::size_t spacePos = candidates.find(' ', pos);
                     std::string candidate = candidates.substr(pos, spacePos == std::string::npos ? std::string::npos : spacePos - pos);
@@ -151,6 +172,10 @@ namespace massif {
                 break;
             }
 
+            if (!allowFallback) {
+                return std::string();
+            }
+
             // Unresolved name, use the default system font
             for (int i = 0; DEFAULT_FONTS[i]; i++) {
                 fileName = findFontFile(fontMap, DEFAULT_FONTS[i]);
@@ -161,12 +186,59 @@ namespace massif {
             return fontMap.empty() ? std::string() : fontMap.begin()->second;
         }
 
+        // The Typeface family for a name, empty if Android has no family under that name. Preferred
+        // over the font file: a family keeps the per-script fallback chain a single file does not.
+        std::string resolveFontFamily(const std::string& name) {
+            std::string family;
+            std::string weight = splitSuffix(normalizeFontName(name), FAMILY_WEIGHT_SUFFIXES, family);
+            for (int i = 0; FONT_ALIASES[i].name; i++) {
+                if (family != FONT_ALIASES[i].name) {
+                    continue;
+                }
+                std::string androidFamily = FONT_ALIASES[i].androidFamily;
+                // Android carries the weight variants of its sans family only
+                if (!weight.empty() && androidFamily == "sans-serif") {
+                    return androidFamily + "-" + weight;
+                }
+                return androidFamily;
+            }
+            return std::string();
+        }
+
     }
 
-    std::shared_ptr<BinaryData> SystemFontUtils::LoadFont(const std::string& name) {
-        std::string fileName = resolveFontFile(name);
+    SystemFontUtils::FontMatch SystemFontUtils::MatchFont(const std::string& names) {
+        static std::mutex mutex;
+        static std::map<std::string, FontMatch> matchCache;
+
+        std::lock_guard<std::mutex> lock(mutex);
+        auto it = matchCache.find(names);
+        if (it != matchCache.end()) {
+            return it->second;
+        }
+
+        FontMatch match;
+        for (const std::string& name : vt::parseFontNames(names)) {
+            match.familyName = resolveFontFamily(name);
+            if (!match.familyName.empty()) {
+                break;
+            }
+            match.fileName = resolveFontFile(name, false);
+            if (!match.fileName.empty()) {
+                break;
+            }
+        }
+        matchCache[names] = match;
+        return match;
+    }
+
+    std::shared_ptr<BinaryData> SystemFontUtils::LoadFont(const std::string& name, bool allowFallback) {
+        std::string fileName = resolveFontFile(name, allowFallback);
         if (fileName.empty()) {
-            Log::Errorf("SystemFontUtils::LoadFont: No system font for %s", name.c_str());
+            // Not an error without the fallback: the caller is walking a font list and tries the next name
+            if (allowFallback) {
+                Log::Errorf("SystemFontUtils::LoadFont: No system font for %s", name.c_str());
+            }
             return std::shared_ptr<BinaryData>();
         }
 

--- a/docs/rendering/06-labels.md
+++ b/docs/rendering/06-labels.md
@@ -404,6 +404,53 @@ Metres are converted with the mercator stretch at the view's own latitude
 a style author writes in metres. Tangram has no equivalent: their only control is the same per-tile
 zoom filter.
 
+## Font names (fork-specific)
+
+A face name is a **CSS-like list**, most preferred first, and an entry may say which platform it is
+for. `vt::parseFontNames` ([FontNames.cpp](../../libs-massif/vt/src/vt/FontNames.cpp)) is the one
+parser; `TextSymbolizer::getFont` runs it over `text-face-name` and over every name of a font set,
+so a mapnik font set and a single comma-separated name end up as the same chain:
+
+```css
+#poi {
+  text-face-name: "Roboto, Helvetica Neue, sans-serif";        /* one string */
+  text-face-name: "android:Roboto", "ios:Helvetica Neue", "Arial";  /* or a real CSS list */
+}
+```
+
+Names are tried back to front, so the first one that resolves becomes the main font and the rest its
+glyph fallbacks; a list where nothing resolves keeps the style's fallback font. `android:`, `ios:`,
+`macos:` and `windows:` are the tags — an entry tagged for another platform is dropped at parse
+time, an untagged entry is kept everywhere.
+
+**The system loader has to be strict for this to mean anything.** `SystemFontUtils::LoadFont` takes
+an `allowFallback` flag: `MBVectorTileDecoder` installs it as the `FontManager`'s data loader with
+`false`, so a name the device has no font for *fails* and the chain moves on. With the permissive
+behaviour the first entry always resolved — to the platform default — and entries 2..n were dead
+code. The style's fallback font (`Arial`, resolved permissively, outside the loader) still catches a
+chain where nothing matched, so an inline CartoCSS style with no font of its own is unchanged.
+
+Resolution is cached both ways in `FontManager` (`_fontDataMap` for a hit, `_missingFontSet` for a
+miss), so a list costs one lookup per name once per style load, not per tile. That is why there is
+no separate per-platform *option* — the tag inside the list is enough and does not repeat work.
+
+**Vector elements do not use this path.** `BalloonPopup`, `Text` and the popup buttons draw into a
+`BitmapCanvas` with the platform text API (Android `Typeface`, iOS CoreText, UWP DirectWrite), not
+FreeType — none of the alias mapping applied to them before, so `Typeface.create` silently returned
+the default for every name and no font name a style set had any visible effect.
+`BitmapCanvas::setFont` now runs the list through `SystemFontUtils::MatchFont`, which resolves it
+once (cached) to what the platform accepts:
+
+- Android: an alias table (`FONT_ALIASES`) maps the name to a **family** (`sans-serif`,
+  `sans-serif-light`, `serif`, `monospace`) — preferred over a font file, because a family keeps the
+  per-script fallback chain a single `.ttf` does not. Only a font Android has no family name for
+  falls back to `Typeface.createFromFile`, cached, since it re-parses the file on every call.
+- iOS/UWP: the name is checked against CoreText / the DirectWrite collection before use, because
+  both substitute the default font instead of failing.
+
+One visible consequence: the default popup face `HelveticaNeue-Light` now maps to `sans-serif-light`
+on Android instead of rendering as plain Roboto Regular.
+
 ## On the GL thread
 
 - **Fades.** `updateLabel` moves opacity toward `visible ? 1 : 0`; invisible-but-fading labels stay

--- a/docs/rendering/12-vector-elements.md
+++ b/docs/rendering/12-vector-elements.md
@@ -31,6 +31,14 @@ it when `MapRenderer::billboardsChanged` has been set.
 `BillboardSorter` orders them back-to-front for correct alpha blending — billboards are drawn after
 the layer's geometry, in a pass of their own (`billboards` in `PROF`).
 
+## Text on a billboard
+
+`BalloonPopup`, `Text` and the popup buttons rasterize their text into a bitmap with `BitmapCanvas`,
+which is the **platform** text API (Android `Typeface`, iOS CoreText, UWP DirectWrite) — not the
+FreeType/HarfBuzz path the tile labels use. Their font names go through the same list syntax and the
+same system-font matching as a style's `text-face-name`; see
+[06-labels.md](06-labels.md#font-names-fork-specific).
+
 ## Terrain interaction
 
 Two mechanisms, and they are different things:

--- a/ios/native/graphics/BitmapCanvasIOSImpl.h
+++ b/ios/native/graphics/BitmapCanvasIOSImpl.h
@@ -23,7 +23,7 @@ namespace massif {
         virtual void setDrawMode(DrawMode mode);
         virtual void setColor(const Color& color);
         virtual void setStrokeWidth(float width);
-        virtual void setFont(const std::string& name, float size);
+        virtual void setFont(const std::string& familyName, const std::string& fileName, float size);
 
         virtual void pushClipRect(const ScreenBounds& clipRect);
         virtual void popClipRect();

--- a/ios/native/graphics/BitmapCanvasIOSImpl.mm
+++ b/ios/native/graphics/BitmapCanvasIOSImpl.mm
@@ -48,9 +48,10 @@ namespace massif {
         _strokeWidth = width;
     }
 
-    void BitmapCanvas::IOSImpl::setFont(const std::string& name, float size) {
-        CFUniquePtr<CFStringRef> nameRef(CFStringCreateWithCString(nullptr, name.c_str(), kCFStringEncodingUTF8));
-        _font = CFUniquePtr<CTFontRef>(CTFontCreateWithName(nameRef, size, nullptr));
+    void BitmapCanvas::IOSImpl::setFont(const std::string& familyName, const std::string& fileName, float size) {
+        // fileName is unused: a font CoreText can open it can also name
+        CFUniquePtr<CFStringRef> nameRef(CFStringCreateWithCString(nullptr, familyName.c_str(), kCFStringEncodingUTF8));
+        _font = CFUniquePtr<CTFontRef>(familyName.empty() ? CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, size, nullptr) : CTFontCreateWithName(nameRef, size, nullptr));
         _fontSize = size;
     }
 

--- a/ios/native/utils/SystemFontUtils.mm
+++ b/ios/native/utils/SystemFontUtils.mm
@@ -3,18 +3,83 @@
 #include "utils/CFUniquePtr.h"
 #include "utils/Log.h"
 
+#include <cctype>
+#include <map>
+#include <mutex>
+
+#include <vt/FontNames.h>
+
 #import <Foundation/Foundation.h>
 #import <CoreText/CoreText.h>
 
 namespace massif {
 
-    std::shared_ptr<BinaryData> SystemFontUtils::LoadFont(const std::string& name) {
-        NSString* nsName = [NSString stringWithUTF8String:name.c_str()];
+    namespace {
 
-        // CoreText substitutes the default system font if the name does not match any installed font
-        CFUniquePtr<CTFontRef> font(CTFontCreateWithName((__bridge CFStringRef)nsName, 12.0f, NULL));
-        if (!font) {
-            Log::Errorf("SystemFontUtils::LoadFont: No system font for %s", name.c_str());
+        std::string normalizeFontName(const std::string& name) {
+            std::string normalized;
+            for (char c : name) {
+                if (std::isalnum(static_cast<unsigned char>(c))) {
+                    normalized.append(1, static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+                }
+            }
+            return normalized;
+        }
+
+        std::string toStdString(CFStringRef stringRef) {
+            return stringRef ? std::string([(__bridge NSString*)stringRef UTF8String]) : std::string();
+        }
+
+        // CoreText substitutes the default system font instead of failing, so what came back has to
+        // be compared with what was asked for. The family is enough for a style of it
+        // ('HelveticaNeue-Light' is the 'Helvetica Neue' family).
+        bool matchesRequestedName(CTFontRef font, const std::string& name) {
+            std::string normalizedName = normalizeFontName(name);
+            CFUniquePtr<CFStringRef> postScriptName(CTFontCopyPostScriptName(font));
+            if (normalizeFontName(toStdString(postScriptName)) == normalizedName) {
+                return true;
+            }
+            CFUniquePtr<CFStringRef> familyName(CTFontCopyFamilyName(font));
+            std::string normalizedFamily = normalizeFontName(toStdString(familyName));
+            return !normalizedFamily.empty() && normalizedName.compare(0, normalizedFamily.size(), normalizedFamily) == 0;
+        }
+
+        CFUniquePtr<CTFontRef> createFont(const std::string& name) {
+            NSString* nsName = [NSString stringWithUTF8String:name.c_str()];
+            return CFUniquePtr<CTFontRef>(CTFontCreateWithName((__bridge CFStringRef)nsName, 12.0f, NULL));
+        }
+
+    }
+
+    SystemFontUtils::FontMatch SystemFontUtils::MatchFont(const std::string& names) {
+        static std::mutex mutex;
+        static std::map<std::string, FontMatch> matchCache;
+
+        std::lock_guard<std::mutex> lock(mutex);
+        auto it = matchCache.find(names);
+        if (it != matchCache.end()) {
+            return it->second;
+        }
+
+        FontMatch match;
+        for (const std::string& name : vt::parseFontNames(names)) {
+            CFUniquePtr<CTFontRef> font = createFont(name);
+            if (font && matchesRequestedName(font, name)) {
+                match.familyName = name;
+                break;
+            }
+        }
+        matchCache[names] = match;
+        return match;
+    }
+
+    std::shared_ptr<BinaryData> SystemFontUtils::LoadFont(const std::string& name, bool allowFallback) {
+        CFUniquePtr<CTFontRef> font = createFont(name);
+        if (!font || (!allowFallback && !matchesRequestedName(font, name))) {
+            // Not an error without the fallback: the caller is walking a font list and tries the next name
+            if (allowFallback) {
+                Log::Errorf("SystemFontUtils::LoadFont: No system font for %s", name.c_str());
+            }
             return std::shared_ptr<BinaryData>();
         }
 

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoConfig.java
@@ -643,6 +643,26 @@ public final class DemoConfig {
     /** Adds a bench dataset as a REAL layer (route style) instead of timing tile builds, so the
      *  RENDER cost can be panned through. Empty = off. many | long | both | a file name. */
     public static String GEOJSON_BENCH_LAYER = "";
+    // =============================================================================================
+    // MARKER POPUP FONTS (DemoTests.runPopupFonts)
+    // A BalloonPopup per font list, to see what a font name resolves to on THIS device. The popups
+    // draw with the platform text API, not with the tile labels' FreeType path, so this is the
+    // only place the two font stacks can be compared side by side.
+    // '--es popupFonts sample' at startup, or the panel button; '--es popupFonts "A|B,C"' for a
+    // list of your own ('|' separates the popups, each one a CSS-like font list).
+    // =============================================================================================
+
+    /** Empty = off at startup. sample | a '|' separated list of font lists. */
+    public static String POPUP_FONTS = "";
+    /** What 'sample' shows: one popup per capability, in order. */
+    public static String POPUP_FONTS_SAMPLE =
+            "Roboto"                                                          // a named system font
+            + "|serif"                                                        // a generic family
+            + "|monospace"
+            + "|HelveticaNeue-Light"                                          // a weight of a family
+            + "|NoSuchFont, monospace"                                        // list: 1st is skipped
+            + "|android:sans-serif-light, ios:HelveticaNeue-Light, windows:Segoe UI Light";
+
     /** Simplify tolerance of the bench source, in tile subpixels. This is the SDK default (1.0),
      *  NOT the route test's 0: at 0 nothing is dropped at any zoom, and 5000 routes then reach the
      *  terrain lattice at full resolution - measured 24M indices/frame and 4 fps on the Crosscall,
@@ -1020,6 +1040,7 @@ public final class DemoConfig {
         GEOJSON_BENCH_TILES_PER_SIDE = DemoCfg.cfgInt("geojsonBenchTiles", GEOJSON_BENCH_TILES_PER_SIDE);
         GEOJSON_BENCH_LAYER = DemoCfg.cfgStr("geojsonLayer", GEOJSON_BENCH_LAYER);
         GEOJSON_BENCH_SIMPLIFY = DemoCfg.cfgFloat("geojsonBenchSimplify", GEOJSON_BENCH_SIMPLIFY);
+        POPUP_FONTS = DemoCfg.cfgStr("popupFonts", POPUP_FONTS);
 
         // inline style
         INLINE_BACKGROUND_COLOR = DemoCfg.cfgColor("bg", INLINE_BACKGROUND_COLOR);

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoMap.java
@@ -213,6 +213,10 @@ public class DemoMap {
         if (DemoConfig.GEOJSON_BENCH_LAYER != null && !DemoConfig.GEOJSON_BENCH_LAYER.isEmpty()) {
             DemoTests.addGeoJSONBenchLayer(this, DemoConfig.GEOJSON_BENCH_LAYER);
         }
+        if (DemoConfig.POPUP_FONTS != null && !DemoConfig.POPUP_FONTS.isEmpty()) {
+            DemoTests.runPopupFonts(this, DemoConfig.POPUP_FONTS,
+                    new MapPos(DemoConfig.START_LON, DemoConfig.START_LAT));
+        }
     }
 
     // =============================================================================================

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoPanel.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoPanel.java
@@ -995,6 +995,9 @@ public final class DemoPanel {
         button(context, "geojson line test", new Action() {
             public void run() { DemoTests.addGeoJSONLine(demo); }
         });
+        button(context, "popup font sampler", new Action() {
+            public void run() { DemoTests.runPopupFonts(demo, "sample"); }
+        });
         button(context, "geojson bench: many routes", new Action() {
             public void run() { DemoTests.runGeoJSONBench(demo, "many"); }
         });

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoTests.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoTests.java
@@ -26,7 +26,9 @@ import com.massifmaps.projections.Projection;
 import com.massifmaps.search.SearchRequest;
 import com.massifmaps.search.VectorTileSearchService;
 import com.massifmaps.styles.CartoCSSStyleSet;
+import com.massifmaps.styles.BalloonPopupStyleBuilder;
 import com.massifmaps.styles.LineStyleBuilder;
+import com.massifmaps.vectorelements.BalloonPopup;
 import com.massifmaps.vectorelements.Line;
 import com.massifmaps.vectortiles.MBVectorTileDecoder;
 
@@ -431,6 +433,41 @@ public final class DemoTests {
                 }
             }
         }).start();
+    }
+
+    /**
+     * One BalloonPopup per '|' separated font list, stacked around the start camera. What it shows
+     * is which font a name resolves to on THIS device - the popups draw with the platform text API,
+     * not with the tile labels' FreeType path.
+     *
+     *   --es popupFonts sample                     the built-in set, one popup per capability
+     *   --es popupFonts "Roboto|serif|monospace"   a set of your own
+     */
+    public static void runPopupFonts(final DemoMap demo, final String which) {
+        // The live camera, for the panel button. At startup the focus latitude is not applied yet,
+        // which is why DemoMap passes the configured start position instead.
+        runPopupFonts(demo, which, demo.mapView.getOptions().getBaseProjection()
+                .toWgs84(demo.mapView.getFocusPos()));
+    }
+
+    public static void runPopupFonts(final DemoMap demo, final String which, final MapPos wgs) {
+        String fontLists = (which == null || which.isEmpty()
+                || "sample".equalsIgnoreCase(which) || "true".equalsIgnoreCase(which))
+                ? DemoConfig.POPUP_FONTS_SAMPLE : which;
+        String[] fonts = fontLists.split("\\|");
+        LocalVectorDataSource source = results(demo);
+        Projection proj = demo.mapView.getOptions().getBaseProjection();
+        for (int i = 0; i < fonts.length; i++) {
+            BalloonPopupStyleBuilder builder = new BalloonPopupStyleBuilder();
+            builder.setTitleFontName(fonts[i]);
+            builder.setTitleFontSize(18);
+            builder.setDescriptionFontName(fonts[i]);
+            builder.setDescriptionFontSize(14);
+            MapPos pos = proj.fromWgs84(new MapPos(wgs.getX(),
+                    wgs.getY() + 0.0016 * (i - (fonts.length - 1) / 2.0)));
+            source.add(new BalloonPopup(pos, builder.buildStyle(), fonts[i], "Handgloves 0123"));
+        }
+        report(demo, "popup fonts: " + fonts.length);
     }
 
     /**

--- a/scripts/ios-dev/MassifDemo/DemoConfig.m
+++ b/scripts/ios-dev/MassifDemo/DemoConfig.m
@@ -306,6 +306,17 @@ static NSMutableDictionary *sValues = nil;
         // --- style parameter ---
         @"paramInterval":        @0.0f,
 
+        // --- marker popup fonts (DemoTests runPopupFonts) ---
+        // "" = off at startup. sample | a '|' separated list of CSS-like font lists.
+        @"popupFonts":          @"",
+        // What 'sample' shows: one popup per capability, in order.
+        @"popupFontsSample":    @"Roboto"                       // a named system font
+                                 "|serif"                       // a generic family
+                                 "|monospace"
+                                 "|HelveticaNeue-Light"         // a weight of a family
+                                 "|NoSuchFont, monospace"       // list: the 1st name is skipped
+                                 "|android:sans-serif-light, ios:HelveticaNeue-Light, windows:Segoe UI Light",
+
         // --- debug ---
         @"tileBorders":         @NO,
 

--- a/scripts/ios-dev/MassifDemo/DemoMap.m
+++ b/scripts/ios-dev/MassifDemo/DemoMap.m
@@ -142,6 +142,9 @@ static const DemoFeature LAYER_ORDER[] = {
         [self saveMapAppearance];
         [self enterStarSky];
     }
+    if ([DemoConfig stringFor:@"popupFonts"].length) {
+        [DemoTests run:@"popupFonts" demo:self]; // after applyCamera, so the popups land in view
+    }
     [self startScriptedAnimation];
 }
 

--- a/scripts/ios-dev/MassifDemo/DemoPanel.m
+++ b/scripts/ios-dev/MassifDemo/DemoPanel.m
@@ -367,6 +367,9 @@ typedef NS_ENUM(NSInteger, DemoEntryKind) {
             [DemoEntry button:@"geojson bench: long routes" apply:^{
                 [DemoTests run:@"geojsonBench" demo:demo];
             }],
+            [DemoEntry button:@"popup font sampler" apply:^{
+                [DemoTests run:@"popupFonts" demo:demo];
+            }],
             [DemoEntry button:@"clear test layers" apply:^{
                 [DemoTests run:@"clear" demo:demo];
             }],

--- a/scripts/ios-dev/MassifDemo/DemoTests.m
+++ b/scripts/ios-dev/MassifDemo/DemoTests.m
@@ -38,6 +38,8 @@ static MSFLocalVectorDataSource *sResults = nil;
         [self addGeoJSONLine:demo];
     } else if ([action isEqualToString:@"geojsonBench"]) {
         [self runGeoJSONBench:demo];
+    } else if ([action isEqualToString:@"popupFonts"]) {
+        [self runPopupFonts:demo];
     } else if ([action isEqualToString:@"clear"]) {
         [self clear:demo];
     }
@@ -361,6 +363,45 @@ static MSFLocalVectorDataSource *sResults = nil;
     } @catch (NSException *exception) {
         [DemoToast show:[NSString stringWithFormat:@"geojson test failed: %@", exception.reason]];
     }
+}
+
+/**
+ * One BalloonPopup per '|' separated font list, stacked around the camera: what a font name
+ * resolves to on THIS device. A popup draws with CoreText, not with the tile labels' FreeType
+ * path, so this is where the two font stacks can be compared side by side.
+ *
+ * '-popupFonts sample' at launch (or the panel button) shows the built-in set - one entry per
+ * capability - and '-popupFonts "A|B, C"' a set of your own.
+ */
++ (void)runPopupFonts:(DemoMap *)demo {
+    NSString *which = [DemoConfig stringFor:@"popupFonts"];
+    if (!which.length || [which caseInsensitiveCompare:@"sample"] == NSOrderedSame
+            || [which caseInsensitiveCompare:@"true"] == NSOrderedSame) {
+        which = [DemoConfig stringFor:@"popupFontsSample"];
+    }
+    NSArray<NSString *> *fonts = [which componentsSeparatedByString:@"|"];
+    MSFLocalVectorDataSource *source = [self results:demo];
+    MSFProjection *projection = [[demo.mapView getOptions] getBaseProjection];
+    MSFMapPos *wgs = [projection toWgs84:[demo.mapView getFocusPos]];
+    if ([wgs getX] == 0 && [wgs getY] == 0) { // no frame yet at startup
+        wgs = [[MSFMapPos alloc] initWithX:[DemoConfig doubleFor:@"lon"] y:[DemoConfig doubleFor:@"lat"]];
+    }
+    for (NSUInteger i = 0; i < fonts.count; i++) {
+        NSString *font = fonts[i];
+        MSFBalloonPopupStyleBuilder *builder = [[MSFBalloonPopupStyleBuilder alloc] init];
+        [builder setTitleFontName:font];
+        [builder setTitleFontSize:18];
+        [builder setDescriptionFontName:font];
+        [builder setDescriptionFontSize:14];
+        MSFMapPos *wgsPos = [[MSFMapPos alloc] initWithX:[wgs getX]
+                                                       y:[wgs getY] + 0.0016 * ((double)i - (fonts.count - 1) / 2.0)];
+        MSFBalloonPopup *popup = [[MSFBalloonPopup alloc] initWithPos:[projection fromWgs84:wgsPos]
+                                                               style:[builder buildStyle]
+                                                               title:font
+                                                                desc:@"Handgloves 0123"];
+        [source add:popup];
+    }
+    [DemoToast show:[NSString stringWithFormat:@"popup fonts: %d", (int)fonts.count]];
 }
 
 /**

--- a/website/docs/features/label-styling.md
+++ b/website/docs/features/label-styling.md
@@ -69,6 +69,31 @@ If a style packages no font at all, labels no longer fail: the SDK falls back to
 fonts** (`/system/fonts` on Android, CoreText on iOS/macOS, DirectWrite on UWP), with `Arial` mapped
 to the platform default. Style-packaged fonts always keep precedence.
 
+## Font lists
+
+A face name is a CSS-like list, most preferred first, and an entry may say which platform it is for:
+
+```css
+#poi {
+  text-face-name: "Roboto, Helvetica Neue, sans-serif";              /* one string */
+  text-face-name: "android:Roboto", "ios:Helvetica Neue", "Arial";   /* or a CSS list */
+}
+```
+
+`android:`, `ios:`, `macos:` and `windows:` are the tags; an entry tagged for another platform is
+dropped, an untagged one is kept everywhere. The first name the device has a font for becomes the
+main font and the rest are its glyph fallbacks. Resolution is cached, so a list costs nothing per
+tile.
+
+The same list works for the font names of the **vector elements** — `BalloonPopupStyleBuilder`
+(title, description), `BalloonPopupButtonStyleBuilder` and `TextStyleBuilder` — which previously
+ignored any name the platform did not know verbatim:
+
+```java
+BalloonPopupStyleBuilder builder = new BalloonPopupStyleBuilder();
+builder.setTitleFontName("Roboto, Helvetica Neue, sans-serif");
+```
+
 ## Plates behind the text and the icon
 
 ```css

--- a/winphone/native/graphics/BitmapCanvasUWPImpl.cpp
+++ b/winphone/native/graphics/BitmapCanvasUWPImpl.cpp
@@ -99,8 +99,10 @@ namespace massif {
         _strokeWidth = width;
     }
 
-    void BitmapCanvas::UWPImpl::setFont(const std::string& name, float size) {
+    void BitmapCanvas::UWPImpl::setFont(const std::string& familyName, const std::string& fileName, float size) {
         if (_dwriteFactory) {
+            // fileName is unused: a font DirectWrite has in its collection it can also name
+            std::string name = (familyName.empty() ? std::string("Segoe UI") : familyName);
             std::wstring wname;
             utf8::utf8to16(name.begin(), name.end(), std::back_inserter(wname));
             HRESULT hr = _dwriteFactory->CreateTextFormat(

--- a/winphone/native/graphics/BitmapCanvasUWPImpl.h
+++ b/winphone/native/graphics/BitmapCanvasUWPImpl.h
@@ -26,7 +26,7 @@ namespace massif {
         virtual void setDrawMode(DrawMode mode);
         virtual void setColor(const Color& color);
         virtual void setStrokeWidth(float width);
-        virtual void setFont(const std::string& name, float size);
+        virtual void setFont(const std::string& familyName, const std::string& fileName, float size);
 
         virtual void pushClipRect(const ScreenBounds& clipRect);
         virtual void popClipRect();

--- a/winphone/native/utils/SystemFontUtils.cpp
+++ b/winphone/native/utils/SystemFontUtils.cpp
@@ -4,47 +4,97 @@
 
 #include <utf8.h>
 
+#include <map>
+#include <mutex>
 #include <string>
 #include <vector>
 
 #include <wrl/client.h>
 #include <dwrite.h>
 
+#include <vt/FontNames.h>
+
 namespace massif {
 
-    std::shared_ptr<BinaryData> SystemFontUtils::LoadFont(const std::string& name) {
+    namespace {
+
+        Microsoft::WRL::ComPtr<IDWriteFontCollection> getSystemFontCollection() {
+            using Microsoft::WRL::ComPtr;
+
+            ComPtr<IDWriteFactory> factory;
+            HRESULT hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), reinterpret_cast<IUnknown**>(factory.GetAddressOf()));
+            if (FAILED(hr)) {
+                Log::Error("SystemFontUtils: Failed to create DirectWrite factory");
+                return ComPtr<IDWriteFontCollection>();
+            }
+
+            ComPtr<IDWriteFontCollection> fontCollection;
+            hr = factory->GetSystemFontCollection(fontCollection.GetAddressOf());
+            if (FAILED(hr)) {
+                Log::Error("SystemFontUtils: Failed to get the system font collection");
+                return ComPtr<IDWriteFontCollection>();
+            }
+            return fontCollection;
+        }
+
+        bool findFamily(const Microsoft::WRL::ComPtr<IDWriteFontCollection>& fontCollection, const std::string& name, UINT32& familyIndex) {
+            std::wstring wname;
+            utf8::utf8to16(name.begin(), name.end(), std::back_inserter(wname));
+            BOOL familyExists = FALSE;
+            HRESULT hr = fontCollection->FindFamilyName(wname.c_str(), &familyIndex, &familyExists);
+            return SUCCEEDED(hr) && familyExists;
+        }
+
+    }
+
+    SystemFontUtils::FontMatch SystemFontUtils::MatchFont(const std::string& names) {
+        static std::mutex mutex;
+        static std::map<std::string, FontMatch> matchCache;
+
+        std::lock_guard<std::mutex> lock(mutex);
+        auto it = matchCache.find(names);
+        if (it != matchCache.end()) {
+            return it->second;
+        }
+
+        FontMatch match;
+        if (Microsoft::WRL::ComPtr<IDWriteFontCollection> fontCollection = getSystemFontCollection()) {
+            for (const std::string& name : vt::parseFontNames(names)) {
+                UINT32 familyIndex = 0;
+                if (findFamily(fontCollection, name, familyIndex)) {
+                    match.familyName = name;
+                    break;
+                }
+            }
+        }
+        matchCache[names] = match;
+        return match;
+    }
+
+    std::shared_ptr<BinaryData> SystemFontUtils::LoadFont(const std::string& name, bool allowFallback) {
         using Microsoft::WRL::ComPtr;
 
-        ComPtr<IDWriteFactory> factory;
-        HRESULT hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), reinterpret_cast<IUnknown**>(factory.GetAddressOf()));
-        if (FAILED(hr)) {
-            Log::Error("SystemFontUtils::LoadFont: Failed to create DirectWrite factory");
+        ComPtr<IDWriteFontCollection> fontCollection = getSystemFontCollection();
+        if (!fontCollection) {
             return std::shared_ptr<BinaryData>();
         }
 
-        ComPtr<IDWriteFontCollection> fontCollection;
-        hr = factory->GetSystemFontCollection(fontCollection.GetAddressOf());
-        if (FAILED(hr)) {
-            Log::Error("SystemFontUtils::LoadFont: Failed to get the system font collection");
-            return std::shared_ptr<BinaryData>();
-        }
-
-        std::wstring wname;
-        utf8::utf8to16(name.begin(), name.end(), std::back_inserter(wname));
         UINT32 familyIndex = 0;
-        BOOL familyExists = FALSE;
-        hr = fontCollection->FindFamilyName(wname.c_str(), &familyIndex, &familyExists);
-        if (FAILED(hr) || !familyExists) {
+        bool familyExists = findFamily(fontCollection, name, familyIndex);
+        if (!familyExists && allowFallback) {
             // Unresolved name, use the default system font
-            hr = fontCollection->FindFamilyName(L"Segoe UI", &familyIndex, &familyExists);
+            familyExists = findFamily(fontCollection, "Segoe UI", familyIndex);
         }
-        if (FAILED(hr) || !familyExists) {
-            Log::Errorf("SystemFontUtils::LoadFont: No system font for %s", name.c_str());
+        if (!familyExists) {
+            // Not an error without the fallback: the caller is walking a font list and tries the next name
+            if (allowFallback) {
+                Log::Errorf("SystemFontUtils::LoadFont: No system font for %s", name.c_str());
+            }
             return std::shared_ptr<BinaryData>();
         }
 
         ComPtr<IDWriteFontFamily> fontFamily;
-        hr = fontCollection->GetFontFamily(familyIndex, fontFamily.GetAddressOf());
+        HRESULT hr = fontCollection->GetFontFamily(familyIndex, fontFamily.GetAddressOf());
         if (FAILED(hr)) {
             Log::Errorf("SystemFontUtils::LoadFont: Failed to get the font family of %s", name.c_str());
             return std::shared_ptr<BinaryData>();


### PR DESCRIPTION
## Summary

**The reported bug.** `BalloonPopup`, `Text` and the popup buttons rasterize their text with the *platform* text API through `BitmapCanvas` — not with the FreeType path the tile labels use — so none of the system-font work ever reached them. `Typeface.create` returns the default typeface for any family name Android does not know, and CoreText/DirectWrite substitute instead of failing, which is why no font name set on a popup style had any visible effect. The SDK's own default, `HelveticaNeue-Light`, is an iOS PostScript name and rendered as plain Roboto Regular on Android.

`BitmapCanvas::setFont` now resolves the name through `SystemFontUtils::MatchFont` (cached), preferring a platform **family** over a font file — a family keeps the per-script fallback chain that a single `.ttf` does not, so CJK/emoji in a popup still render. Only a font Android has no family name for falls back to `Typeface.createFromFile`, cached because it re-parses the file on every call.

**Font lists, and why the loader had to get strict.** A font name is now a CSS-like list on both stacks — style `text-face-name` and every vector-element font name — with optional per-platform entries:

```css
#poi { text-face-name: "android:Roboto, ios:Helvetica Neue, sans-serif"; }
```
```java
builder.setTitleFontName("Roboto, Helvetica Neue, sans-serif");
```

For that to select anything, `SystemFontUtils::LoadFont` gained an `allowFallback` flag and `MBVectorTileDecoder` installs the loader **strictly**: a name the device has no font for must fail, or the chain stops at its first entry with the platform default on every platform and entries 2..n are dead code. The style's fallback font is loaded permissively *outside* the loader, so a style with no font of its own (an inline CartoCSS string) is unchanged.

Resolution is cached both ways in `FontManager` (`_fontDataMap` hit, `_missingFontSet` miss) and in `MatchFont`, so a list costs one lookup per name per style load — not per tile. That is why there is no separate per-platform *option*: the tag inside the list is enough and repeats no work.

**Demo.** Both demos gained a `popup font sampler` action (panel ACTIONS, or `--es popupFonts sample` / `-popupFonts sample`): one popup per capability, side by side.

Docs updated in the same change — [`docs/rendering/06-labels.md`](docs/rendering/06-labels.md) (new "Font names" section), [`12-vector-elements.md`](docs/rendering/12-vector-elements.md), and the website's label-styling page.

## Breaking changes

None to any signature. One **behaviour** change worth knowing: a popup/label font name that previously fell through to the platform default now resolves properly, so `HelveticaNeue-Light` renders as `sans-serif-light` on Android instead of Roboto Regular. Apps that relied on the name being ignored will see a different weight.

## Testing

**Android — run-verified on an emulator** (`--es ui false --es drape false --es zoom 15`, lon 5.71896 / lat 45.18736, `--es popupFonts sample`), both at startup and from the panel button:

| font list | rendered |
|---|---|
| `Roboto` | Roboto regular |
| `serif` / `monospace` | serif / mono |
| `HelveticaNeue-Light` | light sans — was plain Roboto Regular before |
| `NoSuchFont, monospace` | mono — the unknown first entry is skipped |
| `ios:HelveticaNeue-Light, monospace` | mono — the `ios:` entry is dropped |
| `android:sans-serif-light, ios:…, windows:…` | light sans |
| `windows:Segoe UI` | default — nothing matches on Android |

`scripts/android-dev` gradle build (native SDK + demo) green.

**iOS — compile/link only.** SDK + demo `BUILD SUCCEEDED` for the simulator and every touched `.mm` is `-fsyntax-only` clean, but the app was **not run**: `simctl install` wedged repeatedly on this machine. A simulator/device pass is still owed — run the demo with `-popupFonts sample` and check the six popups differ the way the table above does, with `HelveticaNeue-Light` genuinely light.

**UWP — unverified.** No Windows toolchain here; `winphone/native/utils/SystemFontUtils.cpp` and the `BitmapCanvas` UWP impl are reviewed by eye only.

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/50 — merge that first, then rebase this branch's pointer bump onto the merged submodule commit (not the branch commit) before merging here.

Fixes #4