### PR TITLE
fix(ios): stop prelinking the Mac Catalyst slices

### DIFF
--- a/docs/maintenance/README.md
+++ b/docs/maintenance/README.md
@@ -8,3 +8,4 @@ they were run with, what breaks when a step is skipped, and the dead ends.
 | Page | What it covers |
 |------|----------------|
 | [`valhalla-upgrade.md`](valhalla-upgrade.md) | Merging a new upstream Valhalla release into `mbtiles-support`, regenerating protos / locales / the tz database, and the fork patches that must survive |
+| [`mac-catalyst.md`](mac-catalyst.md) | Why the Catalyst slices are a macOS project in disguise, what that breaks at link time, and what the build gives up to work around it |

--- a/docs/maintenance/mac-catalyst.md
+++ b/docs/maintenance/mac-catalyst.md
@@ -1,0 +1,77 @@
+# Mac Catalyst builds
+
+The Catalyst slices (`x86_64-maccatalyst`, `arm64-maccatalyst`) are not a real Catalyst build. They
+are a **macOS** Xcode project with the Catalyst target triple forced onto the compiles:
+
+```cmake
+# scripts/build/CMakeLists.txt
+if(APPLE AND (NOT IOS))          # = Mac Catalyst
+  add_compile_options("-target" "${SDK_IOS_ARCH}-apple-ios-13.0-macabi" ...)
+```
+
+`build-ios.py` then rewrites `-apple-ios-13.0-macabi` to `-apple-ios13.1-macabi` in the generated
+`project.pbxproj`. The project itself keeps `SDKROOT = macosx` and `MACOSX_DEPLOYMENT_TARGET`, and
+never sets `SUPPORTS_MACCATALYST` / `IS_MACCATALYST`.
+
+## The consequence
+
+Every **compile** produces an object stamped `Mac Catalyst`. Every **link** Xcode drives is targeted
+at plain `macOS`. `ld` rejects that combination:
+
+```
+ld: building for macOS, but linking in object file built for Mac Catalyst, file '...'
+Command PrelinkedObjectLink failed with a nonzero exit code
+```
+
+Measured with the shipping toolchain (Xcode 26.5) — the deployment target is irrelevant:
+
+| link | input | result |
+|------|-------|--------|
+| `ld -r -platform_version macos 11.3` | `-macabi` Mach-O | rejected |
+| `ld -r -platform_version macos 13.1` | `-macabi` Mach-O | rejected |
+| `ld -r -platform_version macos 14.0` | `-macabi` Mach-O | rejected |
+| `ld -r -platform_version macos 13.1` | LTO bitcode | **accepted** (bitcode carries no platform) |
+| `ld -r -platform_version macos … -platform_version mac-catalyst …` | `-macabi` Mach-O | rejected (reads as zippered) |
+| `libtool -static` | `-macabi` Mach-O, `-macabi` `.a` | **accepted** (no platform check) |
+
+That last row is the whole workaround, and the bitcode row explains why this stayed hidden for
+years: `-flto=full` turns every C/C++ translation unit into bitcode, so the prelink only ever saw
+platform-less input. The offenders are the things LTO cannot dissolve:
+
+- `libs-external/zstd/.../huf_decompress_amd64.S` — hand-written assembly (x86_64 only)
+- `libs-external/angle-metal/x86_64-maccatalyst/libangle.a` — a prebuilt static library, pulled in
+  through `PRELINK_LIBS`
+
+It surfaced in August 2026 only because the toolchain moved: the last green CI build was
+2026-06-03 on Xcode 16.x, and Xcode 26's linker enforces what ld64 let through.
+
+## What the build does about it
+
+For Catalyst only (`SDK_MACCATALYST`), in `scripts/build/CMakeLists.txt` and
+`scripts/routing/CMakeLists.txt`:
+
+- **no `GENERATE_MASTER_OBJECT_FILE`** — no `ld -r` prelink, so nothing platform-checks the objects
+- **no `-flto=full`** — the prelink was what ran the LTO codegen; without it the shipped `.a` would
+  contain bitcode, which every consuming app would then need a matching toolchain to read
+- **`OTHER_LIBTOOLFLAGS` instead of `PRELINK_LIBS`** for `libangle.a` — the libtool step merges
+  archive members without looking at their platform
+
+Catalyst therefore ships **without LTO**. iOS and the simulator slices are untouched.
+
+`libs-external/zstd` also drops its amd64 assembly on Catalyst (`ZSTD_DISABLE_ASM`). That was the
+first fix for this failure, before the prebuilt `libangle.a` showed the problem was general; with
+the prelink gone it is redundant, and it can be reverted whenever someone wants the assembly
+huffman path back on x86_64 Catalyst.
+
+## The real fix, when it is worth it
+
+Make it a genuine Catalyst build instead of a macOS one: `SUPPORTS_MACCATALYST=YES` and
+`xcodebuild -destination 'platform=macOS,variant=Mac Catalyst'` over a project whose `SDKROOT` is
+`iphoneos`. Xcode then emits `-platform_version mac-catalyst …` for the links, the prelink works,
+LTO comes back, and the `-target …-macabi` hack plus the `pbxproj` string rewrite in `build-ios.py`
+can go. It needs `build-ios.py` and the CMake project reworked together, so it is a project, not a
+patch.
+
+Until then: **anything added to an Apple build that is not compiled from C/C++ source in this tree
+will break Catalyst again** — another `.S`, another prebuilt `.a`, or any target that opts out of
+LTO. The failure always names the offending file.

--- a/scripts/build/CMakeLists.txt
+++ b/scripts/build/CMakeLists.txt
@@ -46,6 +46,7 @@ if(WIN32)
 endif(WIN32)
 
 if(APPLE AND (NOT IOS))
+  set(SDK_MACCATALYST TRUE)
   execute_process(COMMAND "xcodebuild" "-version" "-sdk" "macosx" "Path" OUTPUT_VARIABLE OSX_SDK_PATH ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   add_compile_options("-target" "${SDK_IOS_ARCH}-apple-ios-13.0-macabi" "-iframework" "${OSX_SDK_PATH}/System/iOSSupport/System/Library/Frameworks")
@@ -65,7 +66,13 @@ if(APPLE)
   set(CMAKE_XCODE_ATTRIBUTE_GCC_INSTRUMENT_PROGRAM_FLOW_ARCS NO)
 
   if(SDK_CPP_DEFINES MATCHES ".*_MASSIF_USE_METALANGLE.*")
-    set(CMAKE_XCODE_ATTRIBUTE_PRELINK_LIBS "${SDK_EXTERNAL_LIBS_DIR}/angle-metal/${SDK_IOS_BASEARCH}/libangle.a")
+    if(SDK_MACCATALYST)
+      # No prelink here (see below), so libangle is merged by the libtool step instead. libtool
+      # copies archive members without checking their platform, which ld -r refuses to do.
+      set(CMAKE_XCODE_ATTRIBUTE_OTHER_LIBTOOLFLAGS "${SDK_EXTERNAL_LIBS_DIR}/angle-metal/${SDK_IOS_BASEARCH}/libangle.a")
+    else()
+      set(CMAKE_XCODE_ATTRIBUTE_PRELINK_LIBS "${SDK_EXTERNAL_LIBS_DIR}/angle-metal/${SDK_IOS_BASEARCH}/libangle.a")
+    endif()
   endif()
 
   if(SDK_DEV_TEAM)
@@ -77,15 +84,25 @@ if(APPLE)
   # single master object (GENERATE_MASTER_OBJECT_FILE below): the ld -r that produces it runs the
   # LTO codegen, so the archive member we ship is native code, not bitcode that would then need a
   # compatible toolchain in every consuming app.
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -flto=full")
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto=full")
+  #
+  # Mac Catalyst gets neither. This is a macOS Xcode project with -target ...-macabi forced onto the
+  # compiles, so the prelink runs ld -r for macOS and refuses every real Mach-O input stamped Mac
+  # Catalyst - the prebuilt libangle.a, and any object not turned into bitcode by LTO. Without the
+  # prelink there is nothing to run the LTO codegen, so LTO has to go with it. See
+  # docs/maintenance/mac-catalyst.md.
+  if(NOT SDK_MACCATALYST)
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -flto=full")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto=full")
+  endif()
 
   if(CMAKE_BUILD_TYPE MATCHES "Release|RELEASE")
     set(CMAKE_XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING YES)
     set(CMAKE_XCODE_ATTRIBUTE_DEAD_CODE_STRIPPING YES)
     set(CMAKE_XCODE_ATTRIBUTE_SEPARATE_STRIP YES)
     set(CMAKE_XCODE_ATTRIBUTE_STRIP_STYLE "non-global")
-    set(CMAKE_XCODE_ATTRIBUTE_GENERATE_MASTER_OBJECT_FILE YES)
+    if(NOT SDK_MACCATALYST)
+      set(CMAKE_XCODE_ATTRIBUTE_GENERATE_MASTER_OBJECT_FILE YES)
+    endif()
   endif()
 endif(APPLE)
 

--- a/scripts/routing/CMakeLists.txt
+++ b/scripts/routing/CMakeLists.txt
@@ -46,7 +46,11 @@ if(APPLE)
     set(CMAKE_XCODE_ATTRIBUTE_DEAD_CODE_STRIPPING YES)
     set(CMAKE_XCODE_ATTRIBUTE_SEPARATE_STRIP YES)
     set(CMAKE_XCODE_ATTRIBUTE_STRIP_STYLE "non-global")
-    set(CMAKE_XCODE_ATTRIBUTE_GENERATE_MASTER_OBJECT_FILE YES)
+    # Not on Mac Catalyst: the prelink runs ld -r for macOS and rejects the Catalyst-stamped
+    # objects this project produces. See docs/maintenance/mac-catalyst.md.
+    if(NOT (APPLE AND (NOT IOS)))
+      set(CMAKE_XCODE_ATTRIBUTE_GENERATE_MASTER_OBJECT_FILE YES)
+    endif()
   endif()
 
 endif(APPLE)


### PR DESCRIPTION
## Summary

The zstd fix cleared one instance of a general problem; `libangle.a` is the next one:

```
ld: in .../angle-metal/x86_64-maccatalyst/libangle.a(libMetalANGLE_static.a-x86_64-master.o),
    building for macOS, but linking in object file built for Mac Catalyst
Command PrelinkedObjectLink failed with a nonzero exit code
```

Catalyst here is a **macOS** Xcode project with `-target …-macabi` forced onto the compiles, so
every object is stamped Mac Catalyst while Xcode's prelink runs `ld -r` for macOS. `-flto=full` hid
that for years — bitcode carries no platform, so the only inputs that ever tripped the check are the
ones LTO cannot dissolve: hand-written assembly, and prebuilt static libraries.

This turns the prelink off for Catalyst, and LTO with it — the `ld -r` was what ran the LTO codegen,
so keeping LTO without it would ship bitcode inside the archive and force every consuming app onto a
matching toolchain. `libangle.a` moves from `PRELINK_LIBS` to `OTHER_LIBTOOLFLAGS`, because libtool
copies archive members without looking at their platform. **iOS and the simulator slices keep both
the prelink and LTO.**

Trade-off worth an explicit nod: **Catalyst now ships without LTO.**

The durable fix is to make it a genuine Catalyst build (`SUPPORTS_MACCATALYST=YES` +
`-destination 'platform=macOS,variant=Mac Catalyst'`), which reworks `build-ios.py` and the CMake
project together and would let the prelink, LTO, the zstd assembly and the `pbxproj` string rewrite
all come back. `docs/maintenance/mac-catalyst.md` records the measurements, the workaround and that
plan.

## Testing

Toolchain: Xcode 26.5, macOS SDK 26.

- Linker behaviour measured directly, since the deployment target was the obvious suspect and is
  not the variable: `ld -r -platform_version macos {11.3,13.1,14.0}` rejects a `-macabi` Mach-O
  identically at every version; the same link accepts an LTO bitcode object; a second
  `-platform_version mac-catalyst` makes it zippered and still fails; `libtool -static` merges the
  real `libangle.a` with `-macabi` objects without complaint (17 MB archive, both members present).
- Regenerated both Xcode projects and diffed the settings:

  | | Catalyst x86_64 | iOS simulator arm64 |
  |---|---|---|
  | `GENERATE_MASTER_OBJECT_FILE` | 0 | 4 |
  | `PRELINK_LIBS` | 0 | 4 |
  | `OTHER_LIBTOOLFLAGS` with libangle | 4 | 0 |
  | `-flto` | 0 | 2 |

- **Not run here:** a full Catalyst archive. The local build stops earlier on `generated/ios-objc`
  wrappers belonging to a different profile, and regenerating would overwrite the tree's wrappers.
  CI on this branch is the real check.