### PR TITLE
fix(vt): the reported style regressions in labels, lines and clipped text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,17 @@ gh pr create --repo massif-maps/MassifMaps --title "feat: your title here" ...
 | `demo/DemoTests.java` | one-shot actions (routing, search, GeoJSON) |
 | `ui/main/SecondFragment.java` | Android glue only (view, permissions, map listener) |
 
-Layers (`base`, `satellite`, `hillshade`, `hypso`, `contour`, `contourTiles`, `routes`, `elements`) toggle live
+Layers (`base`, `satellite`, `hillshade`, `hypso`, `contour`, `contourTiles`, `routes`, `elements`, `bugs`) toggle live
 from the panel or with `--es <name> true|false`; the base map has `--es base plain|composite` and
 `--es style dir|zip|inline|project`. `dir` reads the style from a FOLDER via `DirAssetPackage`
 (`/sdcard/alpimaps_mbtiles/osm`), falling back to `osm.zip` then to inline CartoCSS.
+
+`bugs` is the STYLE REGRESSION repro layer (`DemoStyles.bugStyle`, `DemoMap.createBugsLayer`):
+synthetic GeoJSON on the start camera, one feature per reported symptom, each with its A/B knob —
+`bugLabelSize` (two label attachments, text gone at <= 10), `bugBackOpacity` (a `back/` instance
+punches the main line out), `bugLineColor` (a translucent line breaks at its joins),
+`bugAllowOverlap`/`bugTextClip` (allow-overlap alone routes line labels onto the clipped
+geometry path). `--es bugs true --es ui false` is enough to see all four.
 
 Change defaults in `DemoConfig` only — those fields are also what the panel mutates. These files
 may carry **uncommitted** local edits (camera, per-demo knobs): read before touching, keep changes

--- a/docs/internals/rendering/03-vt-renderer.md
+++ b/docs/internals/rendering/03-vt-renderer.md
@@ -176,47 +176,36 @@ from the dot product of consecutive binormals. Three things about it:
   skipped for a plain miter: tangram fans at every angle, but their line shader has no AA ramp and five
   near-degenerate slivers each carrying one is a visible seam.
 
-## Translucent layers: paint every pixel once
+## Translucent layers: no single-blend pass (removed)
 
-A style layer that is translucent must not blend a pixel twice, and no tesselation can guarantee
-that: a line whose vertices sit closer together than it is wide folds at every join, a route doubles
-back inside its own width, and a retained tile cross-fades over the tile that replaced it. Every
-overlap blends again, which reads as darker knots along the line.
+A translucent style layer blends a pixel again wherever its geometry overlaps itself — a line whose
+vertices sit closer together than it is wide folds at every join, a route doubles back inside its own
+width — which reads as darker knots along the line.
 
-`renderGeometry2D` therefore runs a translucent layer as a **single-blend** pass: the top stencil
-bit (`SINGLE_BLEND_STENCIL_BIT`) is cleared for the layer, `glStencilOp(KEEP, KEEP, GL_INVERT)`
-marks each pixel as it is painted, and the `GL_EQUAL` test rejects the second fragment. One bit, one
-masked clear per layer, no extra geometry and no extra pass.
+A **single-blend stencil pass** used to suppress that: one spare stencil bit per layer,
+`glStencilOp(KEEP, KEEP, GL_INVERT)` marking each pixel as it was painted and a `GL_EQUAL` test
+rejecting the second fragment. It was **removed**, because "one blend per pixel" is not a property of
+a pixel but of a symbolizer, and the stencil cannot tell them apart:
 
-- It engages **only where the artifact can exist**: layer opacity below 1, or any evaluated
-  `colorFuncs[i]` alpha below 1. An opaque layer cannot show it, and there a later fragment
-  legitimately covers an earlier one.
-- A `comp-op` layer is excluded — it already composites once through its own buffer.
-- The masks and the paint bit are **separate questions**. The tile masks are dropped in terrain mode
-  and under a shared ground; single blend needs no masks, only a spare bit, so it reads the real
-  stencil size (`maskStencilBits` vs `stencilBits`). Tying it to the masks is how it silently did
-  nothing in exactly the configuration — 3D terrain — where it was wanted.
-- The masks occupy the low bits, so it stands down past 128 target tiles in a frame.
-- **Nothing clears the paint bit when the layer is done**, so every layer after it must compare
-  without it. The per-tile mask test is `GL_EQUAL(stencilValue, mask)`, and with `mask` at 255 that
-  test also demands a zero paint bit — so a layer drawn after a translucent one was rejected in
-  exactly the shape the translucent one had painted. Visible in 2D only: in terrain mode
-  `maskStencilBits` is 0, and the teardown then disables the stencil test outright, which is why the
-  same frame was correct with terrain on. Reported as "casings drawn over the roads at z13–15": the
-  road *fills* were the layer being punched out, leaving the casing under them. The mask is
-  `255 & ~SINGLE_BLEND_STENCIL_BIT` for every layer but the single-blend one itself, where the paint
-  bit IS the rejection. Reproduced at 5.719581/45.186110 z14.60 tilt 90 (top-down), `--es style
-  assets --es terrain false`.
+- **A second symbolizer in the same layer is punched out.** A cartocss instance (`back/line-...`)
+  lives in the SAME attachment, so it is the same vt layer. With `back/line-opacity` set, the wide
+  back line paints first, flips the bit over its whole footprint, and the narrower main line — drawn
+  after, entirely inside it — is rejected everywhere. The reported symptom was "I see the back line,
+  I never see the line".
+- **Every internal join grows a seam.** The first fragment to reach a pixel owns it, so a
+  partial-coverage antialias edge can no longer be filled in by its neighbour. On a translucent
+  `line-width: 10` that reads as the line breaking at each vertex.
+- Tangram and maplibre have no equivalent pass. The same commit that added it also made the join
+  geometry **non-overlapping** (see the join section above), which is what actually removes the
+  common case; what is left is a line genuinely crossing itself, and every renderer blends that
+  twice.
 
-**The trade-off is antialias seams.** The first fragment to reach a pixel owns it, and if that
-fragment was a partial-coverage edge pixel the neighbour can no longer fill it in — faint lighter
-hairlines along internal join boundaries. Where that is unacceptable the alternative is the layer's
-own `opacity` + `comp-op`, which draws the layer opaque into the overlay buffer and composites it
-once: no seams, but a full-screen pass per layer, and that buffer carries no depth, so in 3D terrain
-the layer stops being occluded by ridges. Measured on an Adreno 610, the demo route (casing + fill,
-translucent, scripted pan, two reps of 25 one-second samples): **37.7 fps single-blend against 26.5
-fps through the overlay buffer**, `layers` 2.43 vs 3.62 ms. Single blend is the default for that
-reason.
+A style that really needs one composite still has the layer's own `opacity` + `comp-op`, which draws
+the layer opaque into the overlay buffer and composites it once: no seams, but a full-screen pass per
+layer, and that buffer carries no depth, so in 3D terrain the layer stops being occluded by ridges.
+Measured on an Adreno 610 while the pass existed (demo route, casing + fill, translucent, scripted
+pan, two reps of 25 one-second samples): **37.7 fps with the pass against 26.5 fps through the
+overlay buffer**, `layers` 2.43 vs 3.62 ms — that cost is what the overlay route still carries.
 
 ## Lines over terrain
 

--- a/docs/internals/rendering/05-depth-model.md
+++ b/docs/internals/rendering/05-depth-model.md
@@ -103,6 +103,26 @@ Two more from choosing constants instead of copying them: `depth_shift` scaled b
 nothing), then by `|m23|` (dragged a landcover fill in front of the mountain); and an ordinal stride
 of 32 per renderer, which reached the leak range with five layers.
 
+## A flat quad over a curved surface is a DECAL
+
+Lines and points are both chains of flat quads laid over a height field, so neither is coincident
+with it: between its corners a quad chords over relief the ground follows, and under a depth-writing
+ground it is cut away wherever it sags. Both get the same treatment in `renderGeometry2D` — a
+slope-scaled `glPolygonOffset(-2, -8)`, which tracks the sag because the sag scales with the
+primitive's own depth slope, plus `_terrainLineClearance`, a clearance in **metres** (the sag does
+not care how far away the quad is, which neither the clip-constant ordinal pull nor an NDC-constant
+depth bias can express without leaking through ridges at range).
+
+POINT was left out of that for a while and only lines got it, which is the wrong way round: a glyph
+quad of `text-clip` text is tens of metres wide against a line's few. Whole letters disappeared over
+3D terrain — **and only where the ground is draped**, because a draped tile draws its surface at TRUE
+depth and writes it, while an undraped one pushes its pre-pass surface back and leaves clearance by
+accident. Same drop at drape resolution 512 and 2048, absent in 2D: not the raster, the depth.
+
+The vertex shaders match: both sample the terrain at the **extruded** corner (`applyTerrain(pos +
+delta)`), never at the anchor. A quad placed at the anchor's height and then offset sideways is a
+flat plate whose uphill half is under the ground.
+
 ## Rules to keep
 
 1. **Never push the reference surface back.** Slack belongs on the content, forward and test-only. A

--- a/docs/internals/rendering/06-labels.mdx
+++ b/docs/internals/rendering/06-labels.mdx
@@ -59,6 +59,13 @@ tile set — and a placement rebuilt from a differently clipped copy of a line c
 "labels jump and disappear while panning" looked like. Keep the invariant when touching `Label` or
 `LabelCuller`.
 
+**Draw order is one list per pass**, sorted by priority → layer index → global id, and the batch
+changes glyph atlas mid-list. Grouping the labels by atlas first — which is what a
+`unordered_map<Bitmap, ...>` did — put two labels from different atlases in **pointer-hash order**,
+so an icon and the small label meant to sit on it were drawn in whichever order the allocator
+happened to give. It only showed below the raster-ladder boundary, where the smaller label lands in
+another atlas than the icon: `text-size: 11` drew over the icon and `text-size: 10` under it.
+
 Known remaining cost: `buildLabelMaps` reallocates every label on every tile-set change during
 panning. Reusing unchanged labels is the next win here, and it is delicate — it relies on fresh
 caches and `snapPlacement` semantics.
@@ -86,6 +93,113 @@ is what stops labels flickering when the camera moves slightly.
 Fork-specific rules, all comparing the **placement's** `localId` (hence the stability invariant
 above): `allowOverlapSameFeatureId`, `sameFeatureIdDependent`, and group ids with
 `minimumGroupDistance`.
+
+### Line runs: `line` lies flat, `billboard-line` stays upright
+
+Both orientations lay the glyph run out **along the line** (`Label::isLineRun`); they differ only in
+the plane it is laid out in, which `buildLineVertexData` picks:
+
+| `text-placement` | `LabelOrientation` | run laid out on | drawn as |
+|---|---|---|---|
+| `line` | `LINE` | the placement's own tangent frame (`placement->xAxis/yAxis`), no projection | flat on the surface, `WORLD_OFFSET` |
+| `billboard-line` | `LINE_BILLBOARD_3D` | the camera axes, through the view-projection | upright, `CAMERA_AXIS_OFFSET` |
+
+`line` is the map-like one: the text lies in the ground plane like the line it names, so it tilts and
+foreshortens with the map. `billboard-line` keeps its size and its shape at any tilt, at the cost of
+no longer lying on the surface — which is what a road name usually wants and a route distance usually
+does not.
+
+**This was a regression between 5.x and 6.0.** `LINE` was moved to the camera-axis layout wholesale
+("lay line labels out in screen space"), so `text-placement: line` silently became a billboard and
+there was no way back to the flat run; the only thing still drawing text flat was `text-clip`, which
+is not a label at all (see below). The two layouts are now separate orientations, `line` is flat
+again, and `billboard-line` — which used to place one upright point label per `text-spacing` step,
+ignoring the line direction — takes the run that follows the line.
+
+Consequences of the split, all keyed on `isLineRun()` / `isScreenLineRun()`:
+
+- The layout cache is keyed on the **view-projection only for a screen run**. A flat run does not
+  depend on the camera, so keying it on the view rebuilt it every frame for nothing.
+- The envelope is the run's bounds put back on **the label's own axes** (`setupCoordinateSystem`),
+  which is the camera basis for one and the tangent frame for the other.
+- Anchor pixel-snapping is skipped for both: it snaps the anchor to a quarter-pixel grid, which is
+  meaningless once the glyphs are laid out along a line rather than in a box.
+- `TextSymbolizer` feeds both the same way — the anchors, `text-spacing` and the measured run length
+  a line placement needs (`linePlacement`). It used to hand `billboard-line` a bare vertex with an
+  empty vertex list, which is exactly why that placement could not follow anything.
+
+**A layout fails in two different ways, and they are held differently** (`Label::LineLayout`):
+
+- `NO_ROOM` — the run does not fit, or nothing projects. That is a transient of this camera: fit is
+  judged on the projected line, from two different view states (the culler works on its pass's
+  snapshot, the renderer on the current camera), so a run at the edge of what fits alternates
+  between them and blinks at frame rate. A run already on screen rides out `LINE_LAYOUT_FAILURE_GRACE`
+  of these.
+- `UNREADABLE` — the glyphs turn far enough to pile up on the inside of a corner
+  (`MIN_LINE_SEGMENT_DOTPRODUCT`, `MAX_LINE_RUN_ANGLE_SPREAD`), or the run doubles back. That is a
+  property of the line's shape at this scale, not of the camera. It gets **no grace**, and its quads
+  are dropped rather than kept: the grace used to cover both, so a run the layout had just measured
+  as illegible stayed on screen for several passes — the reported "characters over each other at a
+  bend".
+
+**`text-spacing: 0` means one run for the WHOLE line on both paths.** The clip path used to restart
+the pen at the middle of every segment, so the same style drew one label per line when it was culled
+and one per bend when it was clipped (`generateLinePoints`). A segment outside the tile now still
+advances the pen, so the spacing is constant along the line instead of restarting at each tile
+border. Clipped text still gets one run per TILE the line crosses — the geometry is per tile and
+there is no label to merge them.
+
+`text-spacing` places anchors by **ground** distance, as mapbox's `symbol-spacing` does; under tilt
+they project closer together in the far field. The screen-space guarantee is `text-min-distance`,
+which gives the label a group id the culler enforces in pixels.
+
+**A candidate stretch of line is measured in the plane its run will be laid out in**, and the same
+measure both ranks the candidates and decides whether the run fits (`findClippedLinePlacement`). A
+screen run has to be compared on screen — a line running away from a tilted camera is worth a
+fraction of its ground length there, and measured on the ground it wins the placement and then does
+not fit. A flat run is compared on the ground, because that is where it lies: it used to be judged
+against a screen-HORIZONTAL run of the same world length, which asks for several times the room it
+needs as soon as the view tilts. That is what "the label only appears if I zoom in a lot, and once
+it is gone I have to zoom much further to get it back" was — the asymmetry is the layout hysteresis
+(`LINE_LAYOUT_FAILURE_GRACE`, `*_KEEP` thresholds) holding a placed run that a fresh search could no
+longer win.
+
+### Text drawn as geometry (`text-clip`)
+
+`text-clip` takes the text off the label pipeline entirely: `TextSymbolizer` builds `vt::TextStyle`
+glyph quads into the tile geometry (`createTextProcessor`), clipped to the tile. What that costs is
+everything the label pipeline is:
+
+| | label path | `text-clip: true` |
+|---|---|---|
+| culling, `text-allow-overlap`, `text-min-distance` | yes | **none** — there is no `vt::Label` to cull |
+| placement along the line | per glyph, follows the run (`buildLineVertexData`) | whole run rotated by its segment's angle |
+| `text-spacing: 0` (the default) | ONE label for the whole line | one at the **midpoint of every segment** |
+| orientation | `line` / `billboard-line` / `billboard` / `point` | always flat — geometry has no camera basis |
+| tile border | the label is placed across it | glyphs are **cut**, that is what clip means |
+
+**It used to default to `text-allow-overlap`** (upstream, 2019, no rationale recorded), so a style
+that only wanted its labels to overlap silently got the geometry path — and with it every row of that
+table. It now defaults to `false`, its own declared default, and the same applies to
+`shield-clip`. `marker-clip` is left coupled: an icon has no run to lay out and no name to place, and
+`marker-allow-overlap: true` on a dense POI layer is exactly the case the geometry path is cheap for.
+
+Under clip, `billboard-line` is treated as `line` — the run is rotated by its segment's angle rather
+than left horizontal. Clipped text cannot be a billboard at all, and leaving it unrotated was the one
+combination that neither followed the line nor stayed upright.
+
+Over 3D terrain its glyph quads take the line shader's rule: the terrain is sampled at the
+**extruded corner** (`applyTerrain(pos + delta)` in `pointVsh`), not at the anchor. A quad placed at
+the anchor's height and then offset sideways is a flat plate, and on a slope its uphill half sits
+under the ground, where the depth test against the terrain surface eats it — letters cut in half.
+The line shader learned the same lesson earlier, on a route casing breaking up on a cross-slope.
+
+That path shares the SDF encoding with labels and has to be kept in step with it: its antialias ramp
+is `2 · GLYPH_SDF_UNIT · (glyphRenderSize − GLYPH_RENDER_SPREAD) / _fullResolution`, the same rule
+`renderLabelBatch` uses, and its halo is converted with `HALO_PIXELS_PER_UNIT` like a label's. The
+form written for the single 27-texel raster and a spread of 4 survived the raster ladder and the
+spread change (4 → 8) and ended up measuring a ramp up to **six screen pixels**, which is a glyph
+dissolving into its own halo.
 
 ### Label size and the camera (fork-specific)
 

--- a/docs/internals/rendering/11-tangram-diff.md
+++ b/docs/internals/rendering/11-tangram-diff.md
@@ -106,6 +106,16 @@ The other half — deriving the render zoom from the terrain depth — is not po
 once, and it needs the screen-centre depth every frame (we have the terrain depth buffer, but it is
 read back for billboard occlusion on its own schedule).
 
+### A translucent layer is NOT forced to paint each pixel once
+
+Tangram has no equivalent of the single-blend stencil pass this fork briefly carried, and neither do
+we any more: scoped to a style layer, "one blend per pixel" punches a second symbolizer
+(`back/line-...`) out of the layer that contains it and turns every antialias join edge into a seam.
+The non-overlapping join geometry we took from them is what removes the common case; a line genuinely
+crossing itself blends twice for them too.
+[03-vt-renderer.md](03-vt-renderer.md#translucent-layers-no-single-blend-pass-removed) has the
+measurement and the alternative (`opacity` + `comp-op`).
+
 ### Draped fills (the old path) are being removed, not maintained
 
 Not documented here on purpose; see [the render-pipeline index](index.mdx#two-rules-that-shaped-the-render-code).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -87,8 +87,34 @@ old spelling will be removed in a later release.
 | `text-placement: nutipoint` | `flat` | flat in the placement plane, no camera facing |
 | `text-placement: nuticallout` | `callout` | screen-aligned with a leader line |
 
-`point` (upright on the ground normal, swivelling to face the camera) and `line` are unchanged.
+`point` (upright on the ground normal, swivelling to face the camera) is unchanged.
 See [Live style parameters](/docs/features/style-parameters) for what `param::` can do now.
+
+### `text-placement: line` lies flat again (behaviour change in 6.0.1)
+
+6.0.0 laid every `line` label out on the camera axes, so the text stayed upright at any tilt instead
+of lying on the map — the 5.x behaviour, and what the same text drawn with `text-clip` still did.
+`line` is flat again, and the upright run moved to `billboard-line`, which now follows the line
+instead of placing one upright label per `text-spacing` step.
+
+| You want | Use |
+|---|---|
+| the 5.x look, text in the ground plane (route distances, contour heights) | `text-placement: line` — no change needed |
+| the 6.0.0 look, text upright and readable at any tilt | `text-placement: billboard-line` |
+
+See [Labels](internals/rendering/06-labels.mdx) for the two layouts.
+
+### `text-clip` / `shield-clip` no longer follow `allow-overlap` (behaviour change in 6.0.1)
+
+`clip` used to default to whatever `allow-overlap` was, so `text-allow-overlap: true` alone moved the
+text off the label pipeline onto the tile geometry: no culler, no `text-min-distance`, no run
+following the line, one copy at the midpoint of **every** segment, and glyphs cut at the tile border.
+Both now default to `false`, which is their own declared default.
+
+- A style that wanted overlapping **labels** needs no change and gets correctly placed ones.
+- A style that relied on the clipped geometry path (usually for its cost, on very dense text) must
+  now say `text-clip: true` explicitly.
+- `marker-clip` is unchanged — `marker-allow-overlap: true` still takes the geometry path.
 
 ## Debug knobs
 

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoConfig.java
@@ -547,6 +547,60 @@ public final class DemoConfig {
     public static String ROUTE_TEST_OPACITY_MODE = "geom";
 
     // =============================================================================================
+    // STYLE REGRESSION REPROS (LAYER_BUGS)
+    // Four reported style regressions, on synthetic GeoJSON around the start position, each with
+    // the A/B switch the report gives. See DemoStyles.bugStyle for the CartoCSS.
+    //
+    //   #bugpoints  two label attachments on one point (BUG_ICON_MODE / BUG_LABEL_MODE):
+    //               the ::label text disappears below a size the ::icon one does not.
+    //   #bugsel     a 'back/' instance under the main line (BUG_BACK_OPACITY):
+    //               back/line-opacity and the main line stops being drawn.
+    //   #bugline    one translucent wide line (BUG_LINE_COLOR / BUG_LINE_WIDTH): breaks at joins,
+    //               plus line labels (BUG_TEXT_ALLOW_OVERLAP / BUG_TEXT_CLIP) - allow-overlap
+    //               alone routes the text down the CLIP path (no culler, tile-clipped).
+    // =============================================================================================
+
+    /** Style regression repro layer (synthetic GeoJSON + DemoStyles.bugStyle). */
+    public static boolean LAYER_BUGS = false;
+
+    /** ::icon attachment: glyph = a real icon under the label, empty = text-name '' as reported,
+     *  none = no ::icon attachment at all (the reported "works" control). */
+    public static String BUG_ICON_MODE = "glyph";
+    /** Where the small text lives: attachment = ::label, inline = the same properties on the rule
+     *  (the other reported "works" control). */
+    public static String BUG_LABEL_MODE = "attachment";
+    public static float BUG_ICON_SIZE = 20f;
+    /** The reported threshold: <= 10 the ::label text is gone, 11 and up it draws. */
+    public static float BUG_LABEL_SIZE = 10f;
+
+    /** 'back/' instance width bump over the main line, as the reported rule has it. */
+    public static float BUG_SEL_WIDTH = 6f;
+    /** The report has this white; on a light basemap a punched-out red line over an invisible white
+     *  one looks like nothing was drawn at all, so the demo paints the back line. */
+    public static String BUG_BACK_COLOR = "#1f6feb";
+    /** back/line-opacity. < 0 omits the property, which is the case that draws correctly. */
+    public static float BUG_BACK_OPACITY = 0.6f;
+
+    /** Translucent on purpose: alpha < 1 is what turns the vt single-blend stencil pass on. */
+    public static String BUG_LINE_COLOR = "#00000077";
+    public static float BUG_LINE_WIDTH = 10f;
+    /** Line labels along #bugline (the text-allow-overlap case). */
+    public static boolean BUG_LINE_LABEL = true;
+    public static float BUG_TEXT_SIZE = 14f;
+    public static boolean BUG_TEXT_ALLOW_OVERLAP = true;
+    /** unset | true | false. Unset is the reported case: mapnikvt defaults clip to allow-overlap. */
+    public static String BUG_TEXT_CLIP = "unset";
+    /** text-placement of the line labels: 'line' lies flat on the map, 'billboard-line' follows the
+     *  same line but stays upright. Tilt the camera - at tilt 90 (top down) they look the same. */
+    public static String BUG_TEXT_PLACEMENT = "line";
+    public static float BUG_TEXT_DY = 12f;
+    /** text-spacing: 0 (the CartoCSS default) is ONE label for the whole line on the label path,
+     *  and one per SEGMENT on the clip path. Above 0 both repeat every spacing + text width. */
+    public static float BUG_TEXT_SPACING = 0f;
+    /** text-min-distance. Only does anything on the label path with allow-overlap off. */
+    public static float BUG_TEXT_MIN_DISTANCE = 0f;
+
+    // =============================================================================================
     // ROUTE SELECTION BENCH (LAYER_ROUTE_SELECT)
     // Many routes served as GeoJSON vector tiles, with ONE of them selected through a style
     // parameter that is compared with a feature field - the shape every real route style uses:
@@ -856,6 +910,26 @@ public final class DemoConfig {
         ROUTE_SELECT_CYCLE_MS = DemoCfg.cfgInt("routeSelectCycle", ROUTE_SELECT_CYCLE_MS);
         ROUTE_SELECT_WIDTH = DemoCfg.cfgFloat("routeSelectWidth", ROUTE_SELECT_WIDTH);
         LAYER_MANEUVERS = DemoCfg.cfgBool("maneuvers", LAYER_MANEUVERS);
+        LAYER_BUGS = DemoCfg.cfgBool("bugs", LAYER_BUGS);
+
+        // style regression repros
+        BUG_ICON_MODE = DemoCfg.cfgStr("bugIcon", BUG_ICON_MODE);
+        BUG_LABEL_MODE = DemoCfg.cfgStr("bugLabel", BUG_LABEL_MODE);
+        BUG_ICON_SIZE = DemoCfg.cfgFloat("bugIconSize", BUG_ICON_SIZE);
+        BUG_LABEL_SIZE = DemoCfg.cfgFloat("bugLabelSize", BUG_LABEL_SIZE);
+        BUG_SEL_WIDTH = DemoCfg.cfgFloat("bugSelWidth", BUG_SEL_WIDTH);
+        BUG_BACK_COLOR = DemoCfg.cfgColor("bugBackColor", BUG_BACK_COLOR);
+        BUG_BACK_OPACITY = DemoCfg.cfgFloat("bugBackOpacity", BUG_BACK_OPACITY);
+        BUG_LINE_COLOR = DemoCfg.cfgColor("bugLineColor", BUG_LINE_COLOR);
+        BUG_LINE_WIDTH = DemoCfg.cfgFloat("bugLineWidth", BUG_LINE_WIDTH);
+        BUG_LINE_LABEL = DemoCfg.cfgBool("bugLineLabel", BUG_LINE_LABEL);
+        BUG_TEXT_SIZE = DemoCfg.cfgFloat("bugTextSize", BUG_TEXT_SIZE);
+        BUG_TEXT_ALLOW_OVERLAP = DemoCfg.cfgBool("bugAllowOverlap", BUG_TEXT_ALLOW_OVERLAP);
+        BUG_TEXT_CLIP = DemoCfg.cfgStr("bugTextClip", BUG_TEXT_CLIP);
+        BUG_TEXT_PLACEMENT = DemoCfg.cfgStr("bugTextPlacement", BUG_TEXT_PLACEMENT);
+        BUG_TEXT_DY = DemoCfg.cfgFloat("bugTextDy", BUG_TEXT_DY);
+        BUG_TEXT_SPACING = DemoCfg.cfgFloat("bugTextSpacing", BUG_TEXT_SPACING);
+        BUG_TEXT_MIN_DISTANCE = DemoCfg.cfgFloat("bugTextMinDistance", BUG_TEXT_MIN_DISTANCE);
 
         // composite slots ('hs', 'sat', 'contour' are the historical keys)
         COMPOSITE_HILLSHADE = DemoCfg.cfgBool("hs", COMPOSITE_HILLSHADE);

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoMap.java
@@ -88,7 +88,7 @@ public class DemoMap {
 
     /** One switchable layer of the demo. */
     public enum Feature {
-        CELESTIAL, STARS, BASE, SATELLITE, HILLSHADE, HYPSO, CONTOUR, CONTOUR_TILES, ROUTES, ROUTE_TEST, ROUTE_SELECT, MANEUVERS, ELEMENTS, PEAKS
+        CELESTIAL, STARS, BASE, SATELLITE, HILLSHADE, HYPSO, CONTOUR, CONTOUR_TILES, ROUTES, ROUTE_TEST, ROUTE_SELECT, MANEUVERS, ELEMENTS, BUGS, PEAKS
     }
 
     /** Bottom -> top draw order. Toggling a layer never reorders the others. */
@@ -98,6 +98,7 @@ public class DemoMap {
         Feature.CELESTIAL, Feature.STARS,
         Feature.BASE, Feature.SATELLITE, Feature.HILLSHADE, Feature.HYPSO,
         Feature.CONTOUR, Feature.CONTOUR_TILES, Feature.ROUTES, Feature.ROUTE_TEST, Feature.ROUTE_SELECT, Feature.MANEUVERS, Feature.ELEMENTS,
+        Feature.BUGS,
         // Last: the summit names go over everything the map draws.
         Feature.PEAKS
     };
@@ -244,6 +245,7 @@ public class DemoMap {
             case ROUTE_SELECT: return DemoConfig.LAYER_ROUTE_SELECT;
             case MANEUVERS: return DemoConfig.LAYER_MANEUVERS;
             case ELEMENTS: return DemoConfig.LAYER_ELEMENTS;
+            case BUGS: return DemoConfig.LAYER_BUGS;
             case PEAKS: return DemoConfig.LAYER_PEAKS;
             default: return false;
         }
@@ -264,6 +266,7 @@ public class DemoMap {
             case ROUTE_SELECT: DemoConfig.LAYER_ROUTE_SELECT = enabled; break;
             case MANEUVERS: DemoConfig.LAYER_MANEUVERS = enabled; break;
             case ELEMENTS: DemoConfig.LAYER_ELEMENTS = enabled; break;
+            case BUGS: DemoConfig.LAYER_BUGS = enabled; break;
             case PEAKS: DemoConfig.LAYER_PEAKS = enabled; break;
         }
         rebuildLayers();
@@ -325,6 +328,7 @@ public class DemoMap {
             case ROUTE_SELECT: return createRouteSelectLayer();
             case MANEUVERS: return createManeuversLayer();
             case ELEMENTS: return createElementsLayer();
+            case BUGS: return createBugsLayer();
             case PEAKS: return createPeaksLayer();
             default: return null;
         }
@@ -758,6 +762,71 @@ public class DemoMap {
             return null;
         }
         return new VectorTileLayer(source, decoder);
+    }
+
+    /**
+     * The STYLE REGRESSION repros: three synthetic features around the start position, one per
+     * reported symptom, styled by DemoStyles.bugStyle. GeoJSON vector tiles rather than vector
+     * elements, so everything goes through the SAME decoder, tesselator, label pipeline and
+     * shaders the reported styles do.
+     *
+     *   bugpoints  3 points, each carrying an icon glyph and a short label -> the two-attachment
+     *              label case. Drop 'bugLabelSize' to 10 and the label text goes.
+     *   bugsel     one line -> the 'back/' instance case. 'bugBackOpacity' -1 removes the property.
+     *   bugline    one zigzag -> the translucent-line join case, and the line-label case.
+     */
+    private Layer createBugsLayer() {
+        MBVectorTileDecoder decoder = DemoStyles.createBugDecoder();
+        GeoJSONVectorTileDataSource source = new GeoJSONVectorTileDataSource(0, 24);
+        // No simplification: a join artifact has to be looked at on the vertices the style gave.
+        source.setSimplifyTolerance(0);
+        try {
+            source.setLayerGeoJSONString(source.createLayer("bugline"), buildBugLineGeoJSON());
+            source.setLayerGeoJSONString(source.createLayer("bugsel"), buildBugSelGeoJSON());
+            source.setLayerGeoJSONString(source.createLayer("bugpoints"), buildBugPointsGeoJSON());
+        } catch (IOException e) {
+            Log.w(TAG, "bug repro geojson rejected: " + e.getMessage());
+            return null;
+        }
+        return new VectorTileLayer(source, decoder);
+    }
+
+    /** A zigzag across the view: every vertex is a join, which is where the break shows. */
+    private String buildBugLineGeoJSON() {
+        double lon = DemoConfig.START_LON, lat = DemoConfig.START_LAT - 0.0010;
+        StringBuilder coords = new StringBuilder();
+        for (int i = 0; i <= 6; i++) {
+            coords.append(i > 0 ? "," : "")
+                  .append('[').append(lon - 0.0030 + i * 0.0010).append(',')
+                  .append(lat + (i % 2 == 0 ? 0.0 : 0.00045)).append(']');
+        }
+        return "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\","
+                + "\"properties\":{\"class\":\"waypointline\",\"text\":\"367 m\"},"
+                + "\"geometry\":{\"type\":\"LineString\",\"coordinates\":[" + coords + "]}}]}";
+    }
+
+    /** One straight line for the 'back/' instance case - no joins, so only the instance is in play. */
+    private String buildBugSelGeoJSON() {
+        double lon = DemoConfig.START_LON, lat = DemoConfig.START_LAT + 0.0012;
+        return "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"id\":1},"
+                + "\"geometry\":{\"type\":\"LineString\",\"coordinates\":["
+                + "[" + (lon - 0.0025) + "," + lat + "],"
+                + "[" + (lon + 0.0025) + "," + (lat + 0.0002) + "]]}}]}";
+    }
+
+    /** Three points, far enough apart that no culling decision can be mistaken for the bug. */
+    private String buildBugPointsGeoJSON() {
+        double lon = DemoConfig.START_LON, lat = DemoConfig.START_LAT + 0.0004;
+        StringBuilder json = new StringBuilder("{\"type\":\"FeatureCollection\",\"features\":[");
+        String[] labels = { "12", "34", "56" };
+        for (int i = 0; i < labels.length; i++) {
+            json.append(i > 0 ? "," : "")
+                .append("{\"type\":\"Feature\",\"properties\":{\"icon\":\"")
+                .append(DemoStyles.BUG_ICON_GLYPH).append("\",\"label\":\"").append(labels[i]).append("\"},")
+                .append("\"geometry\":{\"type\":\"Point\",\"coordinates\":[")
+                .append(lon - 0.0018 + i * 0.0018).append(',').append(lat).append("]}}");
+        }
+        return json.append("]}").toString();
     }
 
     /**

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoPanel.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoPanel.java
@@ -205,6 +205,7 @@ public final class DemoPanel {
         buildContourSection(context, demo);
         buildRouteTestSection(context, demo);
         buildRouteSelectSection(context, demo);
+        buildBugSection(context, demo);
         buildSunSection(context, demo);
         buildCelestialSection(context, demo);
         buildSkyFogSection(context, demo);
@@ -671,6 +672,76 @@ public final class DemoPanel {
     /** The style is baked into the decoder, so the layer is rebuilt from scratch. */
     private static void reloadRouteTest(DemoMap demo) {
         demo.invalidate(DemoMap.Feature.ROUTE_TEST);
+        demo.rebuildLayers();
+    }
+
+    /**
+     * The four reported style regressions, each with the A/B the report gives. Turn the layer on
+     * with the 'bugs' checkbox in LAYERS (or --es bugs true); the features sit on the start camera.
+     */
+    private static void buildBugSection(Context context, final DemoMap demo) {
+        header(context, "STYLE BUGS");
+
+        // 1. two label attachments on one point.
+        final String[] iconModes = { "glyph", "empty", "none" };
+        choice(context, "::icon", iconModes, indexOf(iconModes, DemoConfig.BUG_ICON_MODE), new IntSetting() {
+            public void set(int index) { DemoConfig.BUG_ICON_MODE = iconModes[index]; reloadBugs(demo); }
+        });
+        final String[] labelModes = { "attachment", "inline" };
+        choice(context, "label in", labelModes, indexOf(labelModes, DemoConfig.BUG_LABEL_MODE), new IntSetting() {
+            public void set(int index) { DemoConfig.BUG_LABEL_MODE = labelModes[index]; reloadBugs(demo); }
+        });
+        slider(context, "label size", 6, 24, DemoConfig.BUG_LABEL_SIZE, true, new FloatSetting() {
+            public void set(float value) { DemoConfig.BUG_LABEL_SIZE = value; reloadBugs(demo); }
+        });
+        slider(context, "icon size", 6, 40, DemoConfig.BUG_ICON_SIZE, true, new FloatSetting() {
+            public void set(float value) { DemoConfig.BUG_ICON_SIZE = value; reloadBugs(demo); }
+        });
+
+        // 2. a 'back/' instance under the main line. -1 = no back/line-opacity at all.
+        slider(context, "back/line-opacity (-1 off)", -1f, 1f, DemoConfig.BUG_BACK_OPACITY, false, new FloatSetting() {
+            public void set(float value) { DemoConfig.BUG_BACK_OPACITY = value; reloadBugs(demo); }
+        });
+        slider(context, "selection width", 1, 20, DemoConfig.BUG_SEL_WIDTH, true, new FloatSetting() {
+            public void set(float value) { DemoConfig.BUG_SEL_WIDTH = value; reloadBugs(demo); }
+        });
+
+        // 3+4. the translucent line and its labels.
+        slider(context, "line width", 1, 30, DemoConfig.BUG_LINE_WIDTH, true, new FloatSetting() {
+            public void set(float value) { DemoConfig.BUG_LINE_WIDTH = value; reloadBugs(demo); }
+        });
+        final String[] lineColors = { "#00000077", "#000000ff" };
+        choice(context, "line colour", lineColors, indexOf(lineColors, DemoConfig.BUG_LINE_COLOR), new IntSetting() {
+            public void set(int index) { DemoConfig.BUG_LINE_COLOR = lineColors[index]; reloadBugs(demo); }
+        });
+        check(context, "line labels", DemoConfig.BUG_LINE_LABEL, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.BUG_LINE_LABEL = value; reloadBugs(demo); }
+        });
+        check(context, "text-allow-overlap", DemoConfig.BUG_TEXT_ALLOW_OVERLAP, new BoolSetting() {
+            public void set(boolean value) { DemoConfig.BUG_TEXT_ALLOW_OVERLAP = value; reloadBugs(demo); }
+        });
+        final String[] placements = { "line", "billboard-line", "billboard", "point" };
+        choice(context, "text-placement", placements, indexOf(placements, DemoConfig.BUG_TEXT_PLACEMENT), new IntSetting() {
+            public void set(int index) { DemoConfig.BUG_TEXT_PLACEMENT = placements[index]; reloadBugs(demo); }
+        });
+        final String[] clipModes = { "unset", "true", "false" };
+        choice(context, "text-clip", clipModes, indexOf(clipModes, DemoConfig.BUG_TEXT_CLIP), new IntSetting() {
+            public void set(int index) { DemoConfig.BUG_TEXT_CLIP = clipModes[index]; reloadBugs(demo); }
+        });
+        slider(context, "text size", 6, 30, DemoConfig.BUG_TEXT_SIZE, true, new FloatSetting() {
+            public void set(float value) { DemoConfig.BUG_TEXT_SIZE = value; reloadBugs(demo); }
+        });
+        slider(context, "text-spacing (0 = off)", 0, 400, DemoConfig.BUG_TEXT_SPACING, true, new FloatSetting() {
+            public void set(float value) { DemoConfig.BUG_TEXT_SPACING = value; reloadBugs(demo); }
+        });
+        slider(context, "text-min-distance (0 = off)", 0, 200, DemoConfig.BUG_TEXT_MIN_DISTANCE, true, new FloatSetting() {
+            public void set(float value) { DemoConfig.BUG_TEXT_MIN_DISTANCE = value; reloadBugs(demo); }
+        });
+    }
+
+    /** The style is baked into the decoder, so the layer is rebuilt from scratch. */
+    private static void reloadBugs(DemoMap demo) {
+        demo.invalidate(DemoMap.Feature.BUGS);
         demo.rebuildLayers();
     }
 

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoStyles.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoStyles.java
@@ -703,6 +703,132 @@ public final class DemoStyles {
         return mss.toString();
     }
 
+    // =============================================================================================
+    // STYLE REGRESSION REPROS (DemoConfig.LAYER_BUGS)
+    // The reported rules, kept as close to the report as they can be - the point is that the
+    // CartoCSS shape is the same, not that it looks good. Every A/B the report names is a knob.
+    // =============================================================================================
+
+    /** A PUA glyph of assets/style/fonts/osm.ttf, standing in for the reported '[style.icon]'. */
+    public static final String BUG_ICON_GLYPH = ICON_PEAK;
+
+    /**
+     * Style of the REGRESSION REPRO layer. Three rules, one per reported symptom:
+     *
+     *   #bugpoints  two label attachments on one point. The ::label text is reported to vanish at
+     *               text-size <= 10 and to draw at 11, and to draw either way once the ::icon
+     *               attachment is gone or the text moves out of ::label (BUG_ICON_MODE /
+     *               BUG_LABEL_MODE are those two controls).
+     *   #bugsel     the selection rule: a 'back/' instance under the main line. Adding
+     *               back/line-opacity is reported to stop the main line being drawn - both live in
+     *               ONE attachment, so they are one vt layer.
+     *   #bugline    a translucent wide line (breaks at the joins), carrying line labels. Note what
+     *               text-clip does here: mapnikvt defaults it to text-allow-overlap, so
+     *               allow-overlap alone moves the text off the label path onto the clipped
+     *               geometry path.
+     */
+    public static String bugStyle() {
+        StringBuilder mss = new StringBuilder();
+
+        // --- 1. two label attachments on one point -------------------------------------------
+        mss.append("#bugpoints {\n");
+        if (!"none".equalsIgnoreCase(DemoConfig.BUG_ICON_MODE)) {
+            String iconName = "empty".equalsIgnoreCase(DemoConfig.BUG_ICON_MODE) ? "''" : "[icon]";
+            mss.append("  ::icon {\n")
+               .append("    text-placement: billboard;\n")
+               .append("    text-placement-priority: 9;\n")
+               .append("    text-name: ").append(iconName).append(";\n")
+               .append("    text-size: ").append(DemoConfig.BUG_ICON_SIZE).append(";\n")
+               .append("    text-face-name: 'osm';\n")
+               .append("    text-halo-fill: #ffffff;\n")
+               .append("    text-halo-radius: 1;\n")
+               .append("    text-fill: #c0392b;\n")
+               .append("    text-allow-overlap: true;\n")
+               .append("    text-clip: false;\n")
+               .append("  }\n");
+        }
+        boolean labelInAttachment = !"inline".equalsIgnoreCase(DemoConfig.BUG_LABEL_MODE);
+        String labelIndent = labelInAttachment ? "    " : "  ";
+        if (labelInAttachment) {
+            mss.append("  ::label {\n");
+        }
+        mss.append(labelIndent).append("text-name: [label];\n")
+           .append(labelIndent).append("text-size: ").append(DemoConfig.BUG_LABEL_SIZE).append(";\n")
+           .append(labelIndent).append("text-face-name: 'osm';\n")
+           .append(labelIndent).append("text-dx: 0;\n")
+           .append(labelIndent).append("text-dy: 0;\n")
+           .append(labelIndent).append("text-horizontal-alignment: middle;\n")
+           .append(labelIndent).append("text-vertical-alignment: middle;\n")
+           .append(labelIndent).append("text-placement-priority: 9;\n")
+           .append(labelIndent).append("text-placement: billboard;\n")
+           .append(labelIndent).append("text-fill: #1a1a1a;\n")
+           .append(labelIndent).append("text-allow-overlap: true;\n")
+           .append(labelIndent).append("text-clip: false;\n");
+        if (labelInAttachment) {
+            mss.append("  }\n");
+        }
+        mss.append("}\n");
+
+        // --- 2. a 'back/' instance under the main line ----------------------------------------
+        float width = DemoConfig.BUG_SEL_WIDTH;
+        mss.append("#bugsel::selected {\n")
+           .append("  back/line-color: ").append(DemoConfig.BUG_BACK_COLOR).append(";\n")
+           .append("  back/line-width: ").append(width + 5f).append(";\n")
+           .append("  back/line-join: round;\n")
+           .append("  back/line-cap: round;\n");
+        if (DemoConfig.BUG_BACK_OPACITY >= 0) {
+            mss.append("  back/line-opacity: ").append(DemoConfig.BUG_BACK_OPACITY).append(";\n");
+        }
+        mss.append("  line-join: miter;\n")
+           .append("  line-cap: round;\n")
+           .append("  line-color: #e2001a;\n")
+           .append("  line-width: ").append(width + 2f).append(";\n")
+           .append("}\n");
+
+        // --- 3+4. a translucent line, and its line labels --------------------------------------
+        mss.append("#bugline {\n")
+           .append("  line-color: ").append(DemoConfig.BUG_LINE_COLOR).append(";\n")
+           .append("  line-width: ").append(DemoConfig.BUG_LINE_WIDTH).append(";\n")
+           .append("  line-join: round;\n")
+           .append("  line-cap: round;\n");
+        if (DemoConfig.BUG_LINE_LABEL) {
+            mss.append("  text-name: [text];\n")
+               .append("  text-placement: ").append(DemoConfig.BUG_TEXT_PLACEMENT).append(";\n")
+               .append("  text-fill: black;\n")
+               .append("  text-spacing: 40;\n")
+               .append("  text-wrap-before: true;\n")
+               .append("  text-face-name: 'DIN Pro Medium';\n")
+               .append("  text-size: ").append(DemoConfig.BUG_TEXT_SIZE).append(";\n")
+               .append("  text-halo-fill: #ffffff;\n")
+               .append("  text-halo-radius: 2;\n")
+               .append("  text-dy: ").append(DemoConfig.BUG_TEXT_DY).append(";\n");
+            if (DemoConfig.BUG_TEXT_SPACING > 0) {
+                mss.append("  text-spacing: ").append(DemoConfig.BUG_TEXT_SPACING).append(";\n");
+            }
+            if (DemoConfig.BUG_TEXT_MIN_DISTANCE > 0) {
+                mss.append("  text-min-distance: ").append(DemoConfig.BUG_TEXT_MIN_DISTANCE).append(";\n");
+            }
+            if (DemoConfig.BUG_TEXT_ALLOW_OVERLAP) {
+                mss.append("  text-allow-overlap: true;\n");
+            }
+            if (!"unset".equalsIgnoreCase(DemoConfig.BUG_TEXT_CLIP)) {
+                mss.append("  text-clip: ").append(DemoConfig.BUG_TEXT_CLIP).append(";\n");
+            }
+        }
+        mss.append("}");
+        return mss.toString();
+    }
+
+    /** The CartoCSS is written here, the FONTS come from the APK asset package (as the POI style). */
+    public static MBVectorTileDecoder createBugDecoder() {
+        String css = bugStyle();
+        Log.i(TAG, "bug repro style:\n" + css);
+        AssetPackage pack = openAppAssets();
+        return pack != null
+                ? new MBVectorTileDecoder(new CartoCSSStyleSet(css, pack))
+                : new MBVectorTileDecoder(new CartoCSSStyleSet(css));
+    }
+
     /**
      * Style of the MANEUVER ARROW layer (DemoConfig.LAYER_MANEUVERS). ManeuverArrowBuilder
      * serves one LINE per arrow; the head is 'line-end-arrow', which the vt line tesselator builds


### PR DESCRIPTION
## Summary

Pointer bump for the renderer fixes, the documentation for them, and the demo layer that reproduces them.

What a style sees:

- **`text-placement: line` lies flat on the map again**, as it did in 5.x. The upright run moved to `billboard-line`, which now follows its line instead of placing one label per `text-spacing` step.
- **`text-clip` / `shield-clip` no longer default to `allow-overlap`** — a style that only wants its labels to overlap keeps the label pipeline (breaking, below).
- **`text-spacing: 0` means one run for the whole line** whether the text is clipped or not; it used to mean one per *segment* on the clip path.
- A **`back/` instance with its own opacity no longer punches the main line** out of its own layer.
- A **translucent line no longer breaks at every join**.
- A **small label is no longer drawn under the icon** it sits on (it flipped at the raster-ladder boundary — `text-size: 11` over, `10` under).
- **Clipped text is no longer cut in half over draped 3D terrain.**

The mechanisms are in the submodule PR; the pages that changed here are [`06-labels.mdx`](docs/internals/rendering/06-labels.mdx) (the two line runs, the clip path, draw order, the two layout failure kinds), [`05-depth-model.md`](docs/internals/rendering/05-depth-model.md) (a flat quad over a curved surface is a decal), [`03-vt-renderer.md`](docs/internals/rendering/03-vt-renderer.md) (why the single-blend pass went, with the measurement kept) and [`11-tangram-diff.md`](docs/internals/rendering/11-tangram-diff.md).

`scripts/android-dev` gains a `bugs` layer: synthetic GeoJSON on the start camera, one feature per reported symptom, each with the A/B knob its report gives. It goes through the real decoder, tesselator, label pipeline and shaders, not vector elements.

## Testing

```
adb shell am start -n com.massifmaps.MassifDemo/.MainActivity --es ui false --es bugs true \
  --es elements false --es map false --es zoom 16.22 --es tilt 90
```

Then sweep `bugTextPlacement` (`line` / `billboard-line`), `bugTextClip` (`unset` / `true` / `false`), `bugBackOpacity` (`0.6` / `-1`), `bugLabelSize` (`10` / `12`), `bugTextSpacing` (`0` / `60`), and `terrain` on/off. Tilt 45, not 90, to tell a flat run from a billboard one — top-down they look identical.

Everything above was checked on an emulator. **Not verified:** a real slope for the depth-decal change, and label draw-call count before/after the draw-order change. Both are called out in the submodule PR.

## Breaking changes

`text-clip` and `shield-clip` default to `false` instead of following `allow-overlap`. A style that relied on the clipped geometry path must now ask for it explicitly; a style that only wanted overlapping labels needs no change and gets correctly placed ones. `marker-clip` is unchanged. Migration note in [`docs/migration.md`](docs/migration.md).

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/52 — merge that first, then rebase the pointer bump here onto the merged commit rather than the branch commit.