### PR TITLE
docs: require a MassifMaps PR title to read as its changelog entry

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -46,7 +46,11 @@ Order:
    git -C libs-massif push -u origin <branch>
    gh pr create --repo massif-maps/massif-maps-libs --base develop --draft --title "fix(vt): ..." --body "..."
    ```
-3. **Open the main-repo PR**, whose branch carries the pointer bump. **Cross-link both ways**: the main PR body gets a `## Depends on` line with the submodule PR URL; the submodule PR body gets "Consumed by <main PR URL>".
+3. **Open the main-repo PR**, whose branch carries the pointer bump. Its title is the CHANGELOG
+   entry for this work — the diff is one line, the title is not: name the user-visible outcome, not
+   the bump. Rules and examples in the root [`CLAUDE.md`](../../../CLAUDE.md#a-massifmaps-pr-title-is-the-changelog-entry).
+   **Cross-link both ways**: the main PR body gets a `## Depends on` line with the submodule PR URL;
+   the submodule PR body gets "Consumed by <main PR URL>".
 4. **Never merge in the wrong order** — submodule PR merges first, then the pointer bump is rebased onto the merged submodule commit (not the branch commit) before the main PR merges. Point this out in the main PR body; only the user merges.
 
 ## Writing the description

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,34 @@ gh pr create --repo massif-maps/MassifMaps --title "feat: your title here" ...
 ```
 (Without `--repo` the command targets the archived CartoDB upstream and fails.)
 
+### A MassifMaps PR title IS the changelog entry
+
+MassifMaps PRs are squash-merged, so the PR title becomes the commit subject and the changelog
+generator quotes it verbatim (`### BREAKING CHANGES`, `### Bug Fixes`, one line per PR). Whoever
+reads the release notes sees that sentence and nothing else.
+
+This bites hardest on a PR that only carries a **submodule pointer bump** (`libs-massif`,
+`libs-external`), where the diff is one line and the real work is in the other repo. Title it by
+what an SDK USER gets, never by the mechanics:
+
+| ✗ | ✓ |
+|---|---|
+| `chore: bump libs-massif` | `fix(vt): lay a line label flat on the map again, as 5.x did` |
+| `fix: submodule pointer` | `feat(terrain): follow DEM tile borders across zoom levels` |
+| `fix(vt): various label fixes` | `fix(labels): stop a small label being drawn under its own icon` |
+
+- **One user-visible outcome per title**, in the imperative, readable without the diff. If the PR
+  fixes several unrelated things, say the one that matters and let the body carry the rest — or
+  split the PR.
+- **Scope by subsystem** (`vt`, `labels`, `terrain`, `renderers`, `datasources`), not by repo.
+- **`!` / `BREAKING CHANGE:`** whenever a style, an option default or an `all/modules/*.i` signature
+  changes — that is the section a user actually reads before upgrading.
+- The submodule PR keeps its own title, scoped to its module; the two need not match, and the
+  MassifMaps one is the one that ships.
+
+v6.0.0's changelog had to be rewritten by hand because the generated one read as a list of
+mechanics. The fix is the titles, not the generator.
+
 ## Working in this checkout
 
 `scripts/android-dev` is the live test bench. It is ONE composable demo, not a set of examples:


### PR DESCRIPTION
## Summary

MassifMaps PRs are squash-merged, so the PR title becomes the commit subject and the changelog generator quotes it verbatim — one line per PR is all a reader of the release notes gets.

It bites hardest on a PR that only carries a **submodule pointer bump**: the diff is one line, the real work is in `libs-massif`, and `chore: bump libs-massif` ships a release note that says nothing. Root `CLAUDE.md` now states the rule with good/bad examples, where the scope comes from, and when `!` / `BREAKING CHANGE:` is required. The `open-pr` skill links to it at the step that writes the title rather than repeating it.

v6.0.0's changelog had to be rewritten by hand for exactly this reason — the fix is the titles, not the generator.

## Testing

Documentation only. Site build not affected (`CLAUDE.md` and `.claude/**` are outside the Docusaurus tree).

## Note

The main-repo PR I opened just before this one, #121 (`fix(vt): the reported style regressions in labels, lines and clipped text`), is itself an example of what the rule bans — it names a category, not an outcome. Worth replacing that line by hand when the next changelog is written; something like *"fix(labels): lay a line label flat on the map again, and stop a translucent line breaking at its joins"*.