### PR TITLE
fix(terrain): stop the previous zoom flashing over the map when zooming out

### DIFF
--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -2719,7 +2719,12 @@ namespace massif {
                         // which merely looks soft. Prefer the soft one. A tile whose own surface
                         // is skipped has no ancestor draw at all, so it still needs them.
                         bool showsAncestor = !hasContent && draped.texture != 0 && !skipSurface;
-                        if (((!complete && !showsStandIn) || skipSurface) && !showsAncestor) {
+                        // Same rule for a leaf drawing its OWN bake: it already covers this ground
+                        // and is merely missing a layer, with the re-bake queued. Stacking the finer
+                        // generation over it is the second tesselation the comment above warns
+                        // about - measured as a two-frame mesh pop at every integer zoom out.
+                        bool showsOwnBake = hasContent && baked && !skipSurface;
+                        if (((!complete && !showsStandIn) || skipSurface) && !showsAncestor && !showsOwnBake) {
                             // Zooming out the cached tiles are the FINER ones underneath; draw them
                             // over the top, several levels deep. They must come AFTER this tile's own
                             // entry - the surfaces coincide and the later draw wins, so pushed first

--- a/all/native/renderers/TerrainRenderer.cpp
+++ b/all/native/renderers/TerrainRenderer.cpp
@@ -33,6 +33,7 @@ namespace massif {
         float exaggeration = 1.0f;
         int gridSize = 0;
         std::shared_ptr<TileMesh> mesh;
+        unsigned int lastUsed = 0; // _meshCacheClock value of the last pass that drew this mesh
     };
 
     TerrainRenderer::TerrainRenderer() :
@@ -607,6 +608,29 @@ namespace massif {
         }
     }
 
+    void TerrainRenderer::evictLeastRecentlyUsedMeshes(unsigned int pass) {
+        // Evict the least-recently-used entries, NOT the whole cache - same reasoning as
+        // ElevationTextureCache::evictLeastRecentlyUsed. A full flush rebuilt every mesh of every
+        // pass whenever the working set crossed the cap, which is exactly what a multi-level zoom
+        // out does. Meshes already drawn in this pass are never victims: dropping one would give
+        // the tile a flat mesh for the rest of the frame.
+        while (_meshCache.size() >= MAX_CACHED_MESHES) {
+            auto lru = _meshCache.end();
+            for (auto entryIt = _meshCache.begin(); entryIt != _meshCache.end(); entryIt++) {
+                if (entryIt->second.lastUsed >= pass) {
+                    continue;
+                }
+                if (lru == _meshCache.end() || entryIt->second.lastUsed < lru->second.lastUsed) {
+                    lru = entryIt;
+                }
+            }
+            if (lru == _meshCache.end()) {
+                break; // every entry belongs to this pass: let the cache exceed the cap for one pass
+            }
+            _meshCache.erase(lru);
+        }
+    }
+
     void TerrainRenderer::collectTileMeshes(const ViewState& viewState, const std::shared_ptr<TerrainOptions>& terrainOptions, int meshResolutionCap, std::vector<std::pair<MapTile, std::shared_ptr<TileMesh> > >& tileMeshes) {
         std::shared_ptr<ElevationManager> elevationManager = terrainOptions->getElevationManager();
 
@@ -621,6 +645,8 @@ namespace massif {
             meshResolution = std::min(meshResolution, meshResolutionCap);
         }
 
+        unsigned int pass = ++_meshCacheClock;
+
         tileMeshes.reserve(tiles.size());
         for (const MapTile& tile : tiles) {
             long long tileId = tile.getTileId();
@@ -634,17 +660,18 @@ namespace massif {
             // every cached mesh each time a new elevation tile arrives during loading.
             auto it = _meshCache.find(std::make_pair(tileId, gridSize));
             if (it == _meshCache.end() || it->second.grid != grid || it->second.exaggeration != exaggeration || it->second.gridSize != gridSize) {
-                if (_meshCache.size() >= MAX_CACHED_MESHES) {
-                    _meshCache.clear(); // simple full flush; meshes are cheap to rebuild
-                    it = _meshCache.end();
+                if (it == _meshCache.end() && _meshCache.size() >= MAX_CACHED_MESHES) {
+                    evictLeastRecentlyUsedMeshes(pass);
                 }
                 MeshCacheEntry entry;
                 entry.grid = grid;
                 entry.exaggeration = exaggeration;
                 entry.gridSize = gridSize;
                 entry.mesh = buildTileMesh(tile, grid, elevationManager, gridSize);
+                entry.lastUsed = pass;
                 it = _meshCache.insert_or_assign(std::make_pair(tileId, gridSize), std::move(entry)).first;
             }
+            it->second.lastUsed = pass;
             tileMeshes.emplace_back(tile, it->second.mesh);
         }
     }

--- a/all/native/renderers/TerrainRenderer.h
+++ b/all/native/renderers/TerrainRenderer.h
@@ -189,6 +189,9 @@ namespace massif {
         // rendering path and the offscreen depth job start from this, so they always draw the
         // same terrain.
         void collectTileMeshes(const ViewState& viewState, const std::shared_ptr<TerrainOptions>& terrainOptions, int meshResolutionCap, std::vector<std::pair<MapTile, std::shared_ptr<TileMesh> > >& tileMeshes);
+        // Drops the oldest meshes until the cache is back under its cap, sparing everything the
+        // current pass already drew.
+        void evictLeastRecentlyUsedMeshes(unsigned int pass);
         bool updateDepthBufferAsync(const ViewState& viewState, const std::shared_ptr<TerrainOptions>& terrainOptions);
         bool updateDepthBufferSync(const ViewState& viewState, const std::shared_ptr<TerrainOptions>& terrainOptions, const std::shared_ptr<GLResourceManager>& glResourceManager);
         void calculateVisibleTiles(const ViewState& viewState, const std::shared_ptr<ElevationManager>& elevationManager, const MapTile& tile, std::vector<MapTile>& tiles) const;
@@ -218,6 +221,7 @@ namespace massif {
         // tiles at a coarser grid than the rendered terrain, and a tile-only key would make
         // the two passes rebuild every mesh in turn.
         std::map<std::pair<long long, int>, MeshCacheEntry> _meshCache;
+        unsigned int _meshCacheClock = 0; // incremented per collectTileMeshes pass; stamps MeshCacheEntry::lastUsed
 
         // The occlusion depth is written by whichever path produced it and read by the label
         // placement worker, so it is published as a whole immutable snapshot: a reader either

--- a/docs/internals/rendering/04-terrain.md
+++ b/docs/internals/rendering/04-terrain.md
@@ -239,10 +239,61 @@ Three things then keep the bakes off the critical path:
   second the vector layers need. That is **the flash**. A tile counts as usable only when every
   layer that has something for it is in it.
 
+A bake pins the layer *blend* to 1 on purpose — a cached texture must not have a transient fade
+burnt into it — but it also used to pin the style's own layer **opacity** to 1, so a draped layer
+with `opacity: 0.5` baked fully opaque. `calculateDrapeOpacity` now supplies it, matching what the
+on-screen path passes as element opacity. Comp-op layers keep 1: reproducing them needs the overlay
+buffer the bake has no equivalent of.
+
 Stand-ins from the previous generation are pushed **after** the tile's own entry, not before: the
 surfaces coincide and the later draw wins, so pushed first they are buried under the fill they were
 meant to replace — the whole screen going white for a moment on every zoom out. Several levels deep,
 because one gesture crosses several zooms.
+
+A leaf already drawing its **own** bake does not get the finer generation stacked on top of it even
+when that bake is incomplete: it covers this ground and is merely missing a layer, with the re-bake
+already queued. Stacking a finer tesselation over it was a two-frame mesh pop at every integer zoom
+out (`showsOwnBake` in `MapRenderer`, same rule as `showsAncestor` above it).
+
+### The outgoing generation at an integer zoom out
+
+Zooming out z12 → z11, the drape cover moves to z11 while the z12 render tiles are retained and
+faded out. `GLTileRenderer::isTileDraped` used to answer "draped" only for a tile that **covers** a
+drape tile, so those finer tiles counted as undraped and kept drawing themselves in the 3D pass. Two
+separate defects fell out of that, both fixed, both worth knowing about because the path is easy to
+reintroduce:
+
+- **The direct raster draw was neither lit nor fogged.** `renderTileBitmap` built its program with
+  `PATTERN_FLAG | terrainFlag | fogFlag()` — no `TERRAIN_LIGHT_FLAG` — and it was the one draw path
+  in vt that never called `setupFogUniforms`, so the fog code was compiled in with uniforms nobody
+  ever wrote. `colormapFsh` had carried the full `TERRAIN_LIGHT` block all along as dead code. The
+  visible result was the previous zoom's ground flashing **unshaded** over the lit drape beside it —
+  measured as a uniform ×0.62 multiply on all three channels with the sky untouched, which is what
+  a missing shading term looks like and what finally identified it.
+- **The old imagery was drawn at all.** Once shaded identically the flash was gone, but the z12
+  raster was still painted over the z11 drape for the length of the fade — visible as the previous
+  zoom's satellite imagery. `isTileDraped` now answers "draped" in **both** directions: a drape tile
+  that *contains* the render tile covers that ground just as well as one contained by it.
+
+The old comment argued the finer tile had to keep drawing because nothing else covered that ground.
+That holds only while the covering drape tile has no content; vt cannot currently tell, so the risk
+this trades for is a coarser stand-in (not a hole) for the frames a fresh cover tile needs. If a
+blank patch ever appears right after a crossing, that is this trade, and the fix is to plumb
+bake-completeness from `MapRenderer` rather than to restore the old imagery.
+
+Adding the lit variant also moved the cost: it is only ever *asked* for at a crossing, so the lazy
+build put a full compile and link of the largest colormap variant (DEM taps, PCF, cascades) inside
+the gesture — a visible hang. `warmTerrainRasterShader`, called from `startFrame`, builds it on an
+ordinary frame and rebuilds only when the flag set changes.
+
+**Dead ends, in order, each killed by a measurement**: the elevation texture cache; the terrain mesh
+cache; drape cover composition and its 257 ms lag (real, visually inert); fingerprint churn on finer
+tiles; the seed blit; ancestor sub-rect stand-ins; coarse-fed bakes; absent layers; the day cycle;
+raster blending speed; `viewZoomCap`; drape stack stability; the background overpainting the raster;
+two raster generations baked at full opacity; and `TerrainRenderer`'s own background/surface/depth
+passes — which turned out not to run at all once a tile layer owns depth-write
+(`background=0 keepDepth=0 prepass=0 depthWriteAssigned=1`), and eliminating them is what pointed at
+vt's direct draw.
 
 ## Near and far planes
 

--- a/docs/internals/rendering/04-terrain.md
+++ b/docs/internals/rendering/04-terrain.md
@@ -114,6 +114,13 @@ adaptive path is only reached on a GPU without vertex texture fetch (no elevatio
 Because the grid is regular, it also means picking through `_tileSurfaceMap` finds nothing in grid
 mode — the pick path is the one consumer left that would need a lazily built surface.
 
+`TerrainRenderer` keeps its own mesh cache keyed by `(tile id, mesh grid size)` — the occlusion
+depth pass draws the same tiles at a coarser grid, and a tile-only key would make the two passes
+rebuild every mesh in turn. It evicts **least-recently-used**, sparing anything the current pass
+already drew. It used to `clear()` the whole cache on overflow, which rebuilt every mesh of every
+pass whenever the working set crossed the cap — i.e. exactly during a multi-level zoom, for the same
+reason `ElevationTextureCache` had already moved off a full flush.
+
 ### Edge stitching
 
 A coarser neighbour interpolates the DEM between its own (2^k wider) lattice nodes, so a fine tile


### PR DESCRIPTION
## What

Crossing an integer zoom out, the previous zoom's ground flashed over the new one — unshaded, then lingering as stale imagery for the length of the fade. Easiest to see with fog or terrain lighting on, but present without them.

Most of the fix is in vt: **massif-maps/massif-maps-libs#54** (merge first). This PR carries the pointer bump, the drape-surface half, an unrelated cache fix, and the write-up.

## Root cause (in vt)

`isTileDraped` answered "draped" only for a tile *covering* a drape tile, so the retained finer generation counted as undraped and kept drawing itself in the 3D pass. That path — `renderTileBitmap` — built its program without `TERRAIN_LIGHT_FLAG` and was the one draw path in vt that **never called `setupFogUniforms`**. So the old ground was drawn neither lit nor fogged, next to a drape that was both.

Measured as a uniform ×0.62 multiply on all three channels with the sky untouched. That signature — a shading term applied vs not applied — is what identified it after fifteen other hypotheses.

## In this repo

**`MapRenderer`** stacked the finer generation's surfaces over a leaf already drawing its own bake, because that bake was incomplete. But the leaf covers the ground and is merely missing a layer, with the re-bake queued — so the stack was a second tesselation over the same mesh. Two-frame mesh pop at every crossing. Same rule as `showsAncestor` beside it.

**`TerrainRenderer`** (separate, found on the way) cleared the *entire* mesh cache on overflow, rebuilding every mesh of every pass — render, occlusion depth, shadow cascades — whenever the working set crossed the cap. Which is what a multi-level zoom does. Now LRU, sparing anything the current pass drew, matching what `ElevationTextureCache` already did.

## Docs

`docs/internals/rendering/04-terrain.md` gains the mechanism, the trade-off vt's `isTileDraped` change makes, and **the fifteen dead ends** — elevation texture cache, mesh cache, cover composition and its 257 ms lag, fingerprint churn, seeding, stand-ins, coarse-fed bakes, absent layers, the day cycle, raster blend speed, `viewZoomCap`, drape stack stability, background overpaint, two generations baked opaque, and `TerrainRenderer`'s own ground passes (which turn out not to run at all once a tile layer owns depth-write). The diagnosis was the expensive part; the next reader should not pay it again.

## Verification

- Full `scripts/android-dev` gradle build, all four ABIs.
- Docusaurus production build clean — no broken-link block.
- **On device (Adreno 610)**, by @farfromrefug: blink, hang and lingering imagery all gone.

## Merge order

1. massif-maps/massif-maps-libs#54
2. this PR (carries the pointer bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)