### PR TITLE
docs(renderers): record why the lit raster shader never compiled, and its fix

### DIFF
--- a/docs/internals/rendering/04-terrain.md
+++ b/docs/internals/rendering/04-terrain.md
@@ -269,7 +269,9 @@ reintroduce:
   ever wrote. `colormapFsh` had carried the full `TERRAIN_LIGHT` block all along as dead code. The
   visible result was the previous zoom's ground flashing **unshaded** over the lit drape beside it —
   measured as a uniform ×0.62 multiply on all three channels with the sky untouched, which is what
-  a missing shading term looks like and what finally identified it.
+  a missing shading term looks like and what finally identified it. Passing the flag was not enough
+  on its own: the block it enabled did not compile until its declarations were shared, see
+  [08-lighting-sky-fog.md](08-lighting-sky-fog.md#a-compile-failure-this-uncovered-and-its-fix).
 - **The old imagery was drawn at all.** Once shaded identically the flash was gone, but the z12
   raster was still painted over the z11 drape for the length of the fade — visible as the previous
   zoom's satellite imagery. `isTileDraped` now answers "draped" in **both** directions: a drape tile

--- a/docs/internals/rendering/08-lighting-sky-fog.md
+++ b/docs/internals/rendering/08-lighting-sky-fog.md
@@ -281,15 +281,32 @@ nothing lands in is never drawn) and fewer, larger pages.
 An ESSL 3.00 program that fails to build falls back to its 1.00 form rather than taking the map with
 it (`hasShaderVersionFallback()`).
 
-### An unrelated compile failure this uncovered
+### A compile failure this uncovered, and its fix
 
 Adding the version prelude shifted shader line numbers, which surfaced a **pre-existing** failure:
-`tilecolormap` built with `TERRAIN_LIGHT` + `TERRAIN` calls `terrainNormal()` and reads `uSunDir` /
-`uSunColor` / `uLightParams`, none of which `colormapFsh` declares — they live in `backgroundFsh`,
-a different string, or come from the application's lighting shader when one is installed. Without
-that shader the program does not compile. It is caught by `TileRenderer::prepareFrame` and logged, so
-it is invisible unless you grep for it: **6 occurrences per run on the committed build**, before any
-of this work. Not fixed here.
+`tilecolormap` built with `TERRAIN_LIGHT` + `TERRAIN` never compiled, in either stage. The fragment
+stage calls `terrainNormal()` and reads `uSunDir` / `uSunColor` / `uLightParams`; the vertex stage
+never declared or wrote `vElevUV` / `vElevCosh`. Both sets lived only in `backgroundFsh` /
+`backgroundVsh` — a different pair of strings — so the program failed on the first symbol the
+compiler reached. Caught by `TileRenderer::prepareFrame` and only logged, it was invisible unless
+grepped: **6 occurrences per run**, on every committed build since the flag was passed.
+
+So the feature behind it was dead. A raster drawn **outside** the drape at an integer zoom out
+(`renderTileBitmap`) never took the sun or the shadow of the surface under it — the flash that path
+exists to remove, see [04-terrain.md](04-terrain.md#the-outgoing-generation-at-an-integer-zoom-out).
+
+Fixed by lifting both blocks into `terrainLightVsh` / `terrainLightFsh`, prepended to `background*`
+and `colormap*` alike. `commonVsh` / `commonFsh` cannot host them: `terrainPaintVsh`,
+`terrainPaintFsh` and `terrainPaintPrelude` declare the same names for themselves and also get
+`TERRAIN_LIGHT`, so a shared declaration would collide there.
+
+Verified offline, not on a device. A throwaway harness replicates `buildShaderProgram`'s
+concatenation and `createShaderProgram`'s prelude, emits the variants that reach these strings (lit,
+shadowed, mask in/out, hardware PCF, plus terrain-paint / normal-map / line / polygon as a
+regression check) and runs `glslangValidator` over each: 0 errors after, and the reported error
+reproduced exactly on the unfixed header. Note glslang does **not** flag a fragment varying the
+vertex stage never declares, so which of "link error" or "reads undefined values" a real driver does
+here is untested — either way the vertex writes are what make the lighting correct.
 
 Compile errors now quote the source around the reported line and list the program's defines — the
 line number is into the concatenated source, which nothing on disk matches, and without the quote


### PR DESCRIPTION
## Summary

Documentation for massif-maps/massif-maps-libs#56.

- [`08-lighting-sky-fog.md`](docs/internals/rendering/08-lighting-sky-fog.md) — the section that ended
  with *"Not fixed here"* described the fragment stage only. Both stages were broken (`colormapVsh`
  never wrote `vElevUV` / `vElevCosh`), so the lit-raster path was **dead**, not merely noisy. Records
  the shared `terrainLightVsh` / `terrainLightFsh` fix, why `commonVsh` / `commonFsh` cannot host the
  declarations, and what the offline `glslangValidator` sweep does and does **not** prove.
- [`04-terrain.md`](docs/internals/rendering/04-terrain.md) — one cross-link from the integer-zoom-out
  section: passing `TERRAIN_LIGHT_FLAG` was not enough on its own, the block it enabled did not
  compile.

## Testing

`cd website && npm run build` → `[SUCCESS]`, no *"Exhaustive list of all broken links found"* block.
Both new anchors resolve.

## Depends on

massif-maps/massif-maps-libs#56 — merge that first.

**No submodule pointer bump in this PR, deliberately.** `master`'s `libs-massif` pointer (`9c5888a`)
is not an ancestor of `develop`, so bumping it to a `develop`-based commit here would drop what the
pointer carries and `develop` does not. The bump belongs to whichever PR next moves `master` onto a
merged `develop` commit, after #56 lands.