### PR TITLE
fix(terrain): shade contours with the ground they lie on

### DIFF
--- a/all/native/components/TerrainOptions.h
+++ b/all/native/components/TerrainOptions.h
@@ -200,7 +200,8 @@ namespace massif {
          * Sets which style layers must NOT be baked into the drape texture, as a regular expression
          * over the vt layer name (which comes from the style's own rule names). They are drawn live
          * in the 3D pass at screen resolution instead. Hairline content is what the drape resolution
-         * costs, hence contours by default.
+         * costs, hence contours by default. They still take the terrain's sun and shadow, so they
+         * shade like the ground they lie on.
          * @param filter The regular expression, or an empty string to drape everything.
          */
         void setNoDrapeLayerFilter(const std::string& filter);

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1375,3 +1375,35 @@ Worth remembering before either is attempted: the 3D label batch **cache** remov
 targeted and bought **zero frames** ([06-labels.mdx](rendering/06-labels.mdx#a-persistent-label-batch-and-what-blocks-it)),
 and was reverted for correctness. Fewer label draws may go the same way — price it against the frame,
 not against the counter.
+
+---
+
+## 17. Lighting the undraped 2D content (2026-08-18)
+
+Contours (and any `NoDrapeLayerFilter` layer, and every 2D layer when the drape is off) were the
+only content in a lit scene still drawn at flat style colour: the sun is applied by the surface
+draw that samples the drape texture, and these are drawn live instead. `GEOMETRY_LIGHT` gives the
+point/line/polygon programs the surface's own normalised Lambert, N·L from the terrain normal.
+Mechanism and the "why not a cheaper normal" in
+[rendering/08-lighting-sky-fog.md](rendering/08-lighting-sky-fog.md#undraped-2d-content-takes-the-same-sun).
+
+**Method.** Crosscall HLTE556N (Adreno 610), two prebuilt APKs (no rebuild inside a pair), massif
+z13.6 / tilt 55 / lat 45.2442 lon 5.7606, contours over the whole frame,
+`--es terrainLight true --es ambient 0.35 --es sunHour 8`, 16 pan swipes after a 60 s settle, `PROF`
+windows longer than 1600 ms discarded, two cycles per configuration.
+
+| Configuration | GPU `layers` | GPU total | fps |
+|---|---|---|---|
+| shadows on (0.3), before | 4.83 / 4.87 ms | 32.4 / 36.6 ms | 15.1 / 15.7 |
+| shadows on (0.3), after | 4.88 / 4.78 ms | 35.0 / 32.2 ms | 16.1 / 15.3 |
+| shadows off, before | 1.29 / 1.30 ms | 18.8 / 18.8 ms | 20.8 / 22.0 |
+| shadows off, after | 2.55 / 2.47 ms | 20.2 / 20.0 ms | 20.6 / 20.3 |
+
+- **With shadows on the sun is free.** The 3×3 DEM stencil was already being run per fragment for
+  the shadow's slope bias; the lighting reuses that `ndl`. Both cycles land inside the run-to-run
+  spread, in opposite directions — no delta is claimed.
+- **With shadows off it costs the stencil**: `layers` doubles, +1.2 ms on a 19 ms GPU frame (+6%),
+  fps 21.4 → 20.5. Repeatable across both cycles, unlike the shadowed pair.
+- Reading `layers` rather than fps is what makes this measurable at all: the device presents at
+  43 Hz (§15.6) and the frame here is far from that ceiling, so ±1 fps of run-to-run noise swamps
+  a 1.2 ms section change.

--- a/docs/internals/rendering/08-lighting-sky-fog.md
+++ b/docs/internals/rendering/08-lighting-sky-fog.md
@@ -39,6 +39,34 @@ well, from the geometric normal — not from the hillshade's own exaggerated slo
 surface underneath leaves the shading over it unlit, and since a shadow multiplies the lit colour,
 nothing shows at all.
 
+### Undraped 2D content takes the same sun
+
+Content baked into the drape is lit once, by the surface draw that samples the drape texture. What
+is **not** baked is drawn live into the 3D scene and was therefore the only thing in the frame that
+kept its flat style colour: a `TerrainOptions.NoDrapeLayerFilter` layer (contours by default), and
+everything 2D when the drape is off. `GEOMETRY_LIGHT` in `renderTileGeometry` closes that — point,
+line and polygon programs multiply by the same normalised Lambert the surface uses, with N·L taken
+from the **terrain** normal (`terrainNdl`, the 3×3 DEM stencil), never from the geometry's own flat
+normal. Extrusions are excluded: they light by their own model (see [Buildings](#buildings)).
+
+Shadows already worked this way, so the shading and the shadow now share one `ndl` per fragment
+(`applyTerrainShading` in `commonFsh`, one helper for all three programs).
+
+**Cost** — Crosscall HLTE556N (Adreno 610), massif at z13.6 / tilt 55, contours over the whole
+frame, `--es terrainLight true --es ambient 0.35`, GPU timer, two paired runs per configuration:
+
+| | GPU `layers` | GPU total | fps |
+|---|---|---|---|
+| shadows on, before | 4.85 ms | 32.4–36.6 ms | 15.1–15.7 |
+| shadows on, after | 4.83 ms | 32.2–35.0 ms | 15.3–16.1 |
+| shadows off, before | 1.30 ms | 18.8 ms | 20.8–22.0 |
+| shadows off, after | 2.51 ms | 20.1 ms | 20.3–20.6 |
+
+With shadows on it is free: the stencil was already being paid for the shadow's slope bias. With
+shadows off the lighting is what pays for it, +1.2 ms of `layers` (+6% of the frame) — the price of
+a contour that shades like the ground under it. Cheaper normals were not tried: a different normal
+than the surface's would make the two disagree exactly where the eye compares them.
+
 ## Cast shadows
 
 `MapRenderer::applyTerrainShadows` + `TerrainShadowMap` (all/native/renderers/utils/).


### PR DESCRIPTION
## Summary

- A layer kept out of the drape bake (`TerrainOptions.NoDrapeLayerFilter`, `^contour.*` by
  default) is drawn live in the 3D pass, where nothing applied the terrain's sun — so contours
  kept their flat style colour beside a ground that is lit and shadowed. Same for every 2D layer
  when the drape is off. The fix is in `vt` (see **Depends on**); this PR carries the pointer
  bump, the docs and one `TerrainOptions.h` doc line.
- No API change: undraped content simply takes the sun that already lit everything else.

**Reproduce:** massif at `--es lat 45.2442 --es lon 5.7606 --es zoom 13.6 --es tilt 55
--es terrainLight true --es ambient 0.35 --es sunHour 8 --es contour true`. Before, the contours
are one uniform orange across lit and shaded slopes; after, they follow the shading of the ground.

## Testing

Device-verified on a Crosscall HLTE556N (Adreno 610), paired prebuilt APKs: contour pixels on a
shaded slope 177 → 112 red (−37%), on a sunlit slope 198 → 185 (−6%).

Cost, same camera, two cycles per configuration: free with shadows on (GPU `layers` 4.83/4.87 →
4.88/4.78 ms, sign reversing — the DEM stencil was already paid for the shadow's slope bias),
+1.2 ms of GPU `layers` on a 19 ms frame with shadows off (1.30 → 2.51 ms, +6% of the frame).
Camera, method and the full table in `docs/internals/performance-log.md` §16.

Docs verified with a production Docusaurus build — no broken-link block.

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/57 — merge that first, then rebase this
branch's pointer bump onto the merged `develop` commit rather than the branch commit.