### PR TITLE
perf(labels): fold a style transform into the vertices instead of the batch matrix

### DIFF
--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1418,3 +1418,37 @@ know: the proxy-tile behaviour of the mask-less arm was **never checked** (only 
 what the masks protect against is a retained tile painting through the gaps of its replacement
 during a **zoom**), and the early-Z result is specific to a tiler with idle fragment capacity — on
 an immediate-mode GPU it could read differently, which is not measurable from here.
+
+### 16.9 Label draws: the style transform folded into the vertices (-43%)
+
+[16.7](#167-label-batches-the-floor-is-one-glyph-atlas-per-font-render-size) left two reasons a
+label batch ends: the glyph atlas changing (33 a frame) and the style carrying a `transform` (26).
+Both were implemented; only one shipped.
+
+**The transform fold shipped.** The translate was a factor of the batch's `labelMatrix`, so a label
+carrying one was always a draw of its own. Conjugated by the tile matrix it is a *pure world
+translation*, so it is now added to that label's vertices after `calculateVertexData` and the label
+batches normally. Interleaved, three rounds, 58 one-second windows per arm:
+
+| | fps | CPU frame | label draws / frame | `labels2D` |
+|---|---|---|---|---|
+| before | 19.9 | 45.0 | 68.4 | 4.89 ms |
+| after | 20.1 | **43.2** | **38.7** | **4.24** |
+
+The frame rate is inside the noise; the CPU frame and the draw count are not. It also fixes a latent
+bug — consecutive same-style labels *did* share a batch, and its matrix was built from the **first**
+label's tile, so the others were translated by the wrong tile's frame.
+
+**The shared glyph atlas did not ship.** Keying `FontManager::_glyphMapMap` by glyph render size
+instead of by full font name collapses ~32 atlases to the ladder's three and takes the draws to
+**32.9** — and measured **no frame rate change** (CPU frame 43.6 → 43.7 over three rounds). It also
+buys a new failure mode: a 2048² atlas is ~1764 cells at render size 40 against ~200 glyphs per
+family, so shared across six families it runs ~68% full, and `GlyphMap::loadBitmapGlyph` returns 0
+once it is full — the glyph silently disappears. A silent-text-loss risk for an unmeasurable gain is
+the wrong trade; widen the atlas and measure its fill before retrying.
+
+Method note worth keeping: the fold's screenshot diff read **0.536%**, well above the 0.18–0.38% this
+camera usually shows, and it was **entirely label placement churn**. Running the same build twice
+measured **0.533%**, and a second run of it matched the baseline to **0.032%**. At a label-dense
+camera the churn floor is half a percent — establish it with a same-build control before reading a
+screenshot diff as a regression.

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1175,3 +1175,108 @@ not a multiple of the 16.7 ms the panel reports.
 Crosscall's ceiling for a fullscreen GL surface, not our pacing, and 2D at 41 fps is already
 against it. Two consequences: cutting 2D work on this device cannot show up as frame rate, and
 any future fps comparison has 43, not 60, as its ceiling.
+
+---
+
+## 16. The 2D city frame, profiled for the first time (2026-08-18)
+
+Every 2D number before this round was taken at the mountain camera, where 2D runs at 41 fps against
+the device's 43 Hz present ceiling — so [15.6](#156-the-device-presents-at-43-hz-not-60---and-so-does-tangram)
+concluded that "cutting 2D work on this device cannot show up as frame rate". That holds **only for
+that camera**. The 2D *city* has 20 fps of headroom under the ceiling and had never been measured.
+
+Method: Crosscall HLTE556N, Grenoble 5.724/45.188 z16.22 tilt 26, `--es terrain false --es base
+composite --es style assets`, scripted north pan (`--es anim pan --es animLatDelta 0.06`),
+`bench/city2d.sh`, medians over 38 one-second windows per arm, arms interleaved over two rounds.
+
+### 16.1 It is CPU-bound on draw submission, not on fragments
+
+| | ms |
+|---|---|
+| CPU frame | **51.9** |
+| GPU frame | **20.4** |
+| fps | 17.6 |
+
+CPU sections: swap wait 12.2 · `layers` 21.5 · `layers3D` 10.1.
+GPU sections: sky 5.5 · background 3.4 · layers 9.8.
+
+Per frame: **606 geometry draws**, 1.57 M indices, 74 label draws, 62 stencil mask draws, 23
+per-tile background quads — **765 draws**. Label work on the GL thread is 9.6 ms/frame (2D pass
+4.97, 3D pass 2.14, build 2.50); masks 1.07.
+
+`simpleperf` over the GL thread (4144 of 12 802 samples) puts **60% of it outside our code**:
+
+| shared object | % of the GL thread |
+|---|---|
+| `libGLESv2_adreno.so` | **36.1** |
+| kernel | 24.1 |
+| `libmassif.so` | 23.9 |
+| `libc` | 7.1 |
+
+Inclusive: `renderGeometry2D` 53.8 → `renderTileGeometry` **45.3** · `renderLabels` **25.0**
+(`renderLabelBatch` 11.0, `Label::calculateVertexData` 8.2).
+
+This is the 3D city's answer inverted. There the frame is GPU-bound and the lever was triangles
+([10-performance.md](rendering/10-performance.md#the-undraped-line-cost-is-triangles-not-pixels-and-not-shading));
+here the GPU is idle-ish and the lever is the **number of draws**.
+
+### 16.2 The A/B that proves it
+
+| arm | fps | CPU frame | GPU total |
+|---|---|---|---|
+| base | 17.6 | 51.9 | 20.4 |
+| background plane off (`debug.massif.background 0`) | 18.1 | 50.9 | **16.0** |
+| stencil tile masks off (`debug.massif.tilemasks 0`) | 18.3 | **49.5** | 20.9 |
+| 3D buildings off (`--es bld3d false`) | 17.9 | 49.7 | 20.5 |
+
+Two results, read together:
+
+- Removing the background plane takes **22% off the GPU frame and buys nothing** — 4.4 ms of GPU
+  slack, confirming the frame does not wait on the GPU. The sky and the plane remain what
+  [15.5](#155-where-the-frame-is-not-measured-this-session) said they were: simplicity, not frame rate.
+- Removing the masks removes **62 of 765 draws (8%) and buys 4%** — roughly proportional. Draws are
+  the currency.
+
+**Do not re-run `--es labels false` at this camera**: that knob only strips the *inline* style's
+text rules, and this run uses `--es style assets`, so `labelDraws` was unchanged at 71/frame. The
+arm looked like +5% and measured nothing. Labels are priced by the profile above (25%) instead.
+
+### 16.3 `-PprofileRender` costs 13% — every CPU ms on this page is that much high
+
+`PROF` cannot compare two builds, so this is SurfaceFlinger `totalFrames` over an identical 20 s
+window, three interleaved pairs:
+
+| build | totalFrames |
+|---|---|
+| plain | 415 · 415 · 424 |
+| `-PprofileRender` | 363 · 366 · 371 |
+
+**13%, with no overlap between the arms** — `steady_clock::now()`/`clock_gettime` is 19.4% inclusive
+of the GL thread in the instrumented build. The shipped 2D city therefore sits at **~20 fps**, and
+any absolute CPU figure taken with the profilers on should be discounted by ~13% before it is
+compared with anything else.
+
+### 16.4 Found while benching: the label batch drew from a freed glyph atlas
+
+About half the startups at this camera died, as either a null `bitmap` in `renderLabelBatch` or
+`Scudo ERROR: invalid chunk state when deallocating`. `GlyphMap::getBitmapPattern()` returns the
+pattern **by value** and `renderLabelPass` bound a reference through that temporary's `->`, which
+extends nothing; a tile thread loading a glyph resets the map's pattern, so the render thread's
+temporary could be the last owner. 6/6 clean starts after the fix, 3/6 before.
+(libs-massif `83da937`, mobile-sdk `064ad2254`, [06-labels.mdx](rendering/06-labels.mdx#on-the-gl-thread))
+
+### 16.5 What this round retires, and what is left
+
+Retired as levers for the 2D city on this device:
+
+- **An opaque/translucent depth split** (maplibre's `renderPass` model). 2D disables the depth test
+  entirely, so there is no early-Z at all — but the frame is not fill-bound, and 4.4 ms of GPU slack
+  says early-Z has nothing to win here. Worth revisiting only on an immediate-mode GPU.
+- **The sky quad and the background plane.** 8.9 ms of GPU, 0 fps.
+- **Per-tile background meshes in 2D.** Tangram has none and dropping them is right, but they are
+  23 of 765 draws — 3%, not the frame.
+
+Left, in order: **merge geometry draws** (606 draws for 62 render tiles × 32 style layers is the
+frame), **drop the masks in 2D** (62 draws, +4%, `setTileMasks` already has the switch), and the
+**per-frame label batch rebuild** (25% of the GL thread, already open in
+[06-labels.mdx](rendering/06-labels.mdx#a-persistent-label-batch-and-what-blocks-it)).

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1375,3 +1375,46 @@ Worth remembering before either is attempted: the 3D label batch **cache** remov
 targeted and bought **zero frames** ([06-labels.mdx](rendering/06-labels.mdx#a-persistent-label-batch-and-what-blocks-it)),
 and was reverted for correctness. Fewer label draws may go the same way — price it against the frame,
 not against the counter.
+
+### 16.8 A depth model for the flat map: built, measured, reverted
+
+The 2D pass disables the depth test entirely, so every fragment of every style layer is shaded and
+nothing can be rejected early. maplibre splits its frame into an opaque pass (depth-writing) and a
+translucent one; this round built that and threw it away.
+
+What was built (`debug.massif.depth2d`, reverted): a `DEPTH_2D` shader flag enabling
+`applyDepthBias`' painter-order term outside terrain mode, a per-style-layer ordinal handed out
+across the whole stack by `MapRenderer::drawLayers` (composite children included, so the ordinals
+span them), and two passes in `renderGeometry2D` — opaque fills first in **reverse** style layer
+order with depth write, everything else after in painter order testing against them, `GL_LEQUAL` in
+both because a layer's background and its geometry are coplanar at the same ordinal. Only a fill can
+be opaque: a line and a point antialias their own edges.
+
+It renders correctly — 0.382% of pixels differ at the city camera, the same order as the label churn
+between two runs of one build.
+
+| arm | fps | CPU frame | `layers` CPU | GPU total | GPU layers | mask draws / frame |
+|---|---|---|---|---|---|---|
+| baseline | 20.1 | 43.4 | 15.3 | 18.4 | 7.8 | 60 |
+| **depth2d** | **19.6** | 44.8 | 14.2 | 18.0 | 7.5 | 60 |
+| depth2d + no masks | 20.5 | 42.0 | **12.0** | 18.1 | 7.4 | 0 |
+
+**Early-Z on its own is a net loss.** It did exactly what it was designed to do — GPU `layers`
+7.8 → 7.5 ms — and that is 0.3 ms off a GPU which [16.2](#162-the-ab-that-proves-it) had already
+shown to be idle by 4.4 ms, while the opaque classification and the second pass put 1.4 ms back on a
+CPU-bound frame. The arithmetic said this before the code was written: **a fragment optimisation
+cannot move a frame whose GPU is not the critical path**, and the right move would have been to stop
+at that sentence.
+
+The second motivation was better founded and still did not pay. In a terrain frame, content writing
+depth is what **replaced the stencil tile masks** ([05-depth-model.md](rendering/05-depth-model.md)),
+and the masks are 60 draws a frame in 2D. Removing them with the depth model underneath is a real
+mechanism — `layers` CPU **15.3 → 12.0, −22%** — but it surfaces as **+2% fps**, and this bench's
+cross-session spread on an unchanged baseline has been 19.1–20.3. Two percent is not distinguishable
+from it.
+
+So the flat map keeps its stencil masks and its painter order. Two things a future attempt should
+know: the proxy-tile behaviour of the mask-less arm was **never checked** (only a pan was run, and
+what the masks protect against is a retained tile painting through the gaps of its replacement
+during a **zoom**), and the early-Z result is specific to a tiler with idle fragment capacity — on
+an immediate-mode GPU it could read differently, which is not measurable from here.

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1280,3 +1280,55 @@ Left, in order: **merge geometry draws** (606 draws for 62 render tiles × 32 st
 frame), **drop the masks in 2D** (62 draws, +4%, `setTileMasks` already has the switch), and the
 **per-frame label batch rebuild** (25% of the GL thread, already open in
 [06-labels.mdx](rendering/06-labels.mdx#a-persistent-label-batch-and-what-blocks-it)).
+
+### 16.6 Merging the polygon-pattern draws: 584 -> 363 draws, +13% fps
+
+[16.1](#161-it-is-cpu-bound-on-draw-submission-not-on-fragments) said the currency is draws, so the
+next question was which of them are avoidable. A probe counting draws per (tile, style layer) pair:
+
+| per frame | |
+|---|---|
+| geometry draws | 584 |
+| pairs that drew anything | **337** (the floor a per-tile merge can reach) |
+| extra geometries inside a pair | **285** (49% of the draws) |
+
+and, by why the pair split:
+
+| reason | per frame |
+|---|---|
+| **pattern differs** | **278** |
+| already mergeable | 4 |
+| geometry type differs | 3 |
+| same atlas grown between packs | 0 |
+
+Every sampled pair was the same shape — `type=3 params=1/1 pattern '64x64' -> 'none'` — a POLYGON
+style layer alternating a `polygon-pattern-file` fill with a plain one, one style slot each. Not two
+competing patterns: **a pattern against no pattern**.
+
+That killed the atlas design this was scoped as. An atlas (mapbox's `fill-pattern` model) would have
+needed `fract()` into a sub-rect, 1-texel wrap padding and the loss of `GL_REPEAT` and of the
+mipmaps polygon patterns currently get. A **per-slot pattern flag** removes the same 278 splits with
+none of that: `patternScales` in the style table, `uPatternTable` in the shader, packed into `vUV.z`
+so it costs no extra varying vector, and `mix(vColor, texture2D(...) * vColor, vUV.z)` in the
+fragment shader. Only a second, *different* pattern still splits.
+
+Interleaved, three rounds, ~59 one-second windows per arm:
+
+| | fps | CPU frame | `layers` CPU | GPU total | GPU layers |
+|---|---|---|---|---|---|
+| before | 17.9 | 51.1 | 21.9 | 20.2 | 9.7 |
+| after | **20.3** | **43.2** | **15.1** | 18.4 | 7.6 |
+
+**584 -> 363 draws a frame (-38%), +13.4% fps**, and the `layers` section — the one that submits them
+— down 31%. The GPU moved too (layers 9.7 -> 7.6 ms) because a draw carries its uniform uploads and
+its texture bind with it, but the GPU was never the bound here.
+
+Verification: 0.28% of pixels differ at a landcover camera (z13.5, forest/scrub/water patterns on
+screen), all of it label churn between runs — the same 0.18-0.28% shows up comparing two runs of the
+*same* build. 3D terrain re-checked at the ridge camera on the INLINE style, unchanged;
+assets-over-terrain was not re-shot.
+
+Two notes for whoever goes further. The floor is **one draw per (tile, style layer)**; 363 against a
+floor of 337 means the remaining splits are the type/comp-op/16-slot ones, which are not worth
+chasing. Below the floor needs cross-tile batching (one VBO per style layer with per-vertex tile
+offsets), which nothing in this renderer does and which the tile lifecycle makes expensive.

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1332,3 +1332,46 @@ Two notes for whoever goes further. The floor is **one draw per (tile, style lay
 floor of 337 means the remaining splits are the type/comp-op/16-slot ones, which are not worth
 chasing. Below the floor needs cross-tile batching (one VBO per style layer with per-vertex tile
 offsets), which nothing in this renderer does and which the tile lifecycle makes expensive.
+
+### 16.7 Label batches: the floor is one glyph atlas per (font, render size)
+
+With the geometry draws down to their floor ([16.6](#166-merging-the-polygon-pattern-draws-584---363-draws-13-fps)),
+the next item on the 2D city frame is labels: `renderLabels` is **25% of the GL thread** in the
+simpleperf profile (`renderLabelBatch` 11%, `Label::calculateVertexData` 8.2%), and the frame issues
+**65 label draws**, each re-specifying five or six VBOs with `glBufferData`.
+
+A probe on why a batch ends:
+
+| break reason | per frame |
+|---|---|
+| **glyph atlas (bitmap) changes** | **33.1** |
+| **the style carries a `transform`** | **25.6** |
+| parameter table full | 3.4 |
+| scale / glyph render size | 0.0 |
+
+The obvious read — labels arrive in culler order, so the atlas thrashes A→B→A — is **wrong, and the
+experiment that would have exploited it is a dead end**. A stable sort of the pass by
+`style->glyphMap` before batching (`debug.massif.labelsort`, reverted) moved the atlas breaks
+**33.0 → 31.8** and the label draws 70.8 → 68.6. The atlases really are distinct: `FontManager`
+keys `_glyphMapMap` by the **full font name including its query parameters**, so every
+(font, glyph render size) pair owns its own `GlyphMap` — and with the 16/28/40 raster ladder a
+handful of font families becomes ~32 atlases on screen. Sorting can only ever reach
+one break per distinct atlas, which is what it did.
+
+Do not read a frame rate off that A/B either: it measured 19.1 fps against 20.8, and the same build
+had measured 20.3 an hour earlier in [16.6](#166-merging-the-polygon-pattern-draws-584---363-draws-13-fps).
+With the break counts flat there is no mechanism behind the difference — it is the session drift
+[Getting a trustworthy number](rendering/10-performance.md#getting-a-trustworthy-number) warns about,
+caught here only because the counters disagreed with the fps.
+
+So the label batching floor is the number of distinct (font, render size) pairs on screen, and the
+only way under it is **one shared glyph atlas for every font**, which is mapbox's model and a
+`FontManager` change (`_glyphMapMap` → a single map, bounded by `_maxGlyphMapWidth/Height`). Not
+attempted here. The `transform` breaks are a second, independent 25/frame: a style transform is
+folded into the batch's `labelMatrix`, so a transformed label cannot share a batch — applying it to
+the vertices in `calculateVertexData` instead would let it.
+
+Worth remembering before either is attempted: the 3D label batch **cache** removed the work it
+targeted and bought **zero frames** ([06-labels.mdx](rendering/06-labels.mdx#a-persistent-label-batch-and-what-blocks-it)),
+and was reverted for correctness. Fewer label draws may go the same way — price it against the frame,
+not against the counter.

--- a/docs/internals/rendering/03-vt-renderer.md
+++ b/docs/internals/rendering/03-vt-renderer.md
@@ -60,6 +60,27 @@ The counters split a draw into `geomProgramNs` (program selection + fog uniforms
 `geomStyleEvalNs` (the colour/width functions themselves), so a regression can be attributed without
 guessing.
 
+### What splits a tile's style layer into several draws
+
+`TileLayerBuilder` accumulates a style layer's features into one `TileGeometry` and calls
+`appendGeometry()` — one more draw — whenever the next feature cannot share the vertex format or the
+style table: a different geometry **type**, a different **comp-op** or **translate**, a full
+16-slot parameter table, or more than 65535 indices.
+
+**A polygon pattern is not one of them any more.** A style layer that alternates patterned and plain
+fills (`polygon-pattern-file` on some features) used to split at every alternation, and that was
+**48% of every geometry draw** in a 2D city frame — 584 draws where 337 (tile, style layer) pairs
+actually drew. Each slot of the style table now carries a **pattern flag** (`patternScales`,
+`uPatternTable`, packed into `vUV.z`), so a plain fill sits in the same geometry and the same draw as
+a patterned one and simply keeps its flat colour. Only a **second, different** pattern still splits.
+
+Measured on a Crosscall, 2D city pan: **584 → 363 draws a frame, 17.9 → 20.3 fps**, the `layers` CPU
+section 21.9 → 15.1 ms ([performance-log.md 16.6](../performance-log.md)).
+
+Lines never had the problem: they go through the shared `StrokeMap` atlas and select their dash by a
+per-slot stroke id, which is the same trick one level down. The remaining floor is one draw per
+(tile, style layer); going below it needs cross-tile batching, which nothing here does yet.
+
 ## Shaders
 
 Programs are built on demand from source in `GLTileRendererShaders.h` and cached by a key made of

--- a/docs/internals/rendering/06-labels.mdx
+++ b/docs/internals/rendering/06-labels.mdx
@@ -645,6 +645,13 @@ on Android instead of rendering as plain Roboto Regular.
   than on a large one, and up to **five times** what the single-raster build drew — a soft white
   glow instead of an outline, reported as "halo huge at radius 2, fine at 1". If halos ever look
   wrong again, check that term before the style.
+- **The glyph atlas can be replaced under the batch loop.** `GlyphMap::getBitmapPattern()` returns
+  the pattern **by value**, and a tile thread loading a new glyph resets `_bitmapPattern` — so the
+  render thread's temporary can be the last owner. `renderLabelPass` bound its `labelBitmap`
+  reference through that temporary's `->`, which extends nothing: the pattern died at the end of the
+  line and the batch then compared and copied a freed `shared_ptr`. Crashed about half of the
+  startups at a label-dense city camera, as either a null `bitmap` in `renderLabelBatch` or a
+  `Scudo ERROR: invalid chunk state`. Hold the pattern in a named `shared_ptr` for the iteration.
 - **Vertex data.** The glyph layout is already cached per label (`_cachedVertices`, `_cachedValid`)
   and the shader already expands the billboard from `offsets` + `uLabelAxisX/Y`. What runs every
   frame is re-emitting the **batch**: the anchor is camera-relative

--- a/docs/internals/rendering/06-labels.mdx
+++ b/docs/internals/rendering/06-labels.mdx
@@ -645,6 +645,23 @@ on Android instead of rendering as plain Roboto Regular.
   than on a large one, and up to **five times** what the single-raster build drew — a soft white
   glow instead of an outline, reported as "halo huge at radius 2, fine at 1". If halos ever look
   wrong again, check that term before the style.
+- **A style `transform` no longer ends the batch.** The translate was a factor of the batch's
+  `labelMatrix`, and the batch broke both when a label carried one and when the previous label did —
+  so every transformed label was a draw of its own, **30 of a city frame's 68 label draws**.
+  Conjugated by the tile matrix the translate is a *pure world translation*, so it is added to that
+  label's vertices after `calculateVertexData` instead, and the label batches with its neighbours.
+  Measured on the 2D city pan: **68.4 → 38.7 label draws a frame**, `labels2D` 4.89 → 4.24 ms, CPU
+  frame 45.0 → 43.2. It also fixes a latent bug: several same-style labels *did* share a batch, and
+  the matrix was built from the **first** label's tile, so the rest were translated by the wrong
+  tile's frame.
+- **One glyph atlas shared by every font at a render size — measured and dropped.** `FontManager`
+  keys `_glyphMapMap` by the full font name, so every (family, size) pair owns an atlas and the
+  16/28/40 ladder makes ~32 of them on a city screen; a batch ends whenever the atlas changes, which
+  is the other half of the label draws. Keying by render size instead took the draws to 32.9 and
+  bought **no frame rate**, and it makes overflow a live risk: a 2048² atlas is ~1764 cells at
+  render size 40 against ~200 glyphs per family, and `GlyphMap::loadBitmapGlyph` returns 0 when full
+  — glyphs vanish silently. Not worth a silent-text-loss failure mode for an unmeasurable gain. If it
+  is retried, widen the atlas first and measure the fill.
 - **The glyph atlas can be replaced under the batch loop.** `GlyphMap::getBitmapPattern()` returns
   the pattern **by value**, and a tile thread loading a new glyph resets `_bitmapPattern` — so the
   render thread's temporary can be the last owner. `renderLabelPass` bound its `labelBitmap`

--- a/docs/internals/rendering/10-performance.md
+++ b/docs/internals/rendering/10-performance.md
@@ -200,8 +200,13 @@ background), and `simpleperf` puts **60% of the GL thread in the driver and the 
 
 The two experiments that settle it: dropping the background plane takes **22% off the GPU frame and
 buys no fps**, while dropping the stencil masks removes **8% of the draws and buys 4%**. So on this
-camera fragments, triangles and shading are all free, and the only currency is the draw count —
-merging same-style-layer geometry per tile is the lever, not anything on the GPU side.
+camera fragments, triangles and shading are all free, and the only currency is the draw count.
+
+Acting on that: a style layer alternating patterned and plain polygon fills used to split into a
+draw per alternation — 48% of all geometry draws. Each style slot now carries a **pattern flag**
+instead, so both live in one draw ([03-vt-renderer.md](03-vt-renderer.md#what-splits-a-tiles-style-layer-into-several-draws)):
+**584 → 363 draws a frame, 17.9 → 20.3 fps**, `layers` CPU 21.9 → 15.1 ms. The floor is one draw per
+(tile, style layer) — 337 — so what is left needs cross-tile batching, which nothing here does.
 
 2D at the *mountain* camera measures 41 fps and is pinned against the device's 43 Hz present ceiling
 ([performance-log.md 15.6](../performance-log.md)), which is why this was never visible before: the

--- a/docs/internals/rendering/10-performance.md
+++ b/docs/internals/rendering/10-performance.md
@@ -190,6 +190,28 @@ source vertices before tesselation (the `simplify` mapnik property is parsed and
 Halving the triangles buys ~25%; removing them (drape) buys ~90%. At a tolerance anyone would ship,
 simplification is worth half a frame per second — not a lever. **Draping is.**
 
+### The 2D city is bound by the OPPOSITE thing: draw submission
+
+Terrain off, same city camera (`--es terrain false --es base composite --es style assets`,
+`bench/city2d.sh`): **CPU frame 51.9 ms against a GPU frame of 20.4** — the inverse of the 3D city
+above. The frame issues **765 draws** (606 geometry, 74 label, 62 stencil mask, 23 per-tile
+background), and `simpleperf` puts **60% of the GL thread in the driver and the kernel**
+(`libGLESv2_adreno.so` 36.1%, kernel 24.1%, our own code 23.9%).
+
+The two experiments that settle it: dropping the background plane takes **22% off the GPU frame and
+buys no fps**, while dropping the stencil masks removes **8% of the draws and buys 4%**. So on this
+camera fragments, triangles and shading are all free, and the only currency is the draw count —
+merging same-style-layer geometry per tile is the lever, not anything on the GPU side.
+
+2D at the *mountain* camera measures 41 fps and is pinned against the device's 43 Hz present ceiling
+([performance-log.md 15.6](../performance-log.md)), which is why this was never visible before: the
+conclusion "cutting 2D work cannot show up as frame rate" is true of that camera only.
+
+**`-PprofileRender` itself costs 13%** (SurfaceFlinger `totalFrames`, three interleaved pairs:
+415/415/424 plain against 363/366/371 instrumented) — `clock_gettime` is 19.4% inclusive of the GL
+thread. Discount any absolute CPU ms from a profiling build before comparing it with anything else.
+Numbers and the full A/B in [performance-log.md 16](../performance-log.md).
+
 ## Against tangram-ng, on the same device and camera
 
 Run back to back on the Crosscall at Grenoble 5.724/45.188 z15 tilt 45, their demo patched to that

--- a/docs/internals/rendering/10-performance.md
+++ b/docs/internals/rendering/10-performance.md
@@ -208,6 +208,13 @@ instead, so both live in one draw ([03-vt-renderer.md](03-vt-renderer.md#what-sp
 **584 → 363 draws a frame, 17.9 → 20.3 fps**, `layers` CPU 21.9 → 15.1 ms. The floor is one draw per
 (tile, style layer) — 337 — so what is left needs cross-tile batching, which nothing here does.
 
+**An opaque/translucent depth split (maplibre's model) was then built and reverted.** 2D disables the
+depth test entirely, so there is no early-Z at all — but a fragment optimisation cannot move a frame
+whose GPU is idle by 4.4 ms: it measured **20.1 → 19.6 fps**, the GPU saving 0.3 ms and the extra
+pass costing 1.4 ms of CPU. It also unlocks dropping the stencil tile masks (60 draws a frame,
+`layers` CPU −22%), and even that surfaces as +2% — inside this bench's drift.
+[performance-log.md 16.8](../performance-log.md).
+
 2D at the *mountain* camera measures 41 fps and is pinned against the device's 43 Hz present ceiling
 ([performance-log.md 15.6](../performance-log.md)), which is why this was never visible before: the
 conclusion "cutting 2D work cannot show up as frame rate" is true of that camera only.

--- a/scripts/android-dev/bench/city2d.sh
+++ b/scripts/android-dev/bench/city2d.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# The 2D city frame: Grenoble against the Saint-Eynard ridge, terrain OFF, composite base with the
+# bundled style project, panning north. The one 2D camera with headroom over the device's 43 Hz
+# present ceiling (docs/internals/performance-log.md, 15.6).
+# $1 = label, rest = extra extras.
+ANDROID_SERIAL="${ANDROID_SERIAL:?set it to the device serial}"; export ANDROID_SERIAL
+LABEL="$1"; shift
+adb shell am force-stop com.massifmaps.MassifDemo >/dev/null 2>&1
+adb shell input keyevent KEYCODE_WAKEUP >/dev/null 2>&1
+adb shell am start -n com.massifmaps.MassifDemo/.MainActivity --es ui false \
+  --es terrain false --es base composite --es style assets \
+  --es lat 45.188 --es lon 5.724 --es zoom 16.22 --es tilt 26 \
+  --es anim pan --es animDelay 40000 --es animDuration 25 --es animLatDelta 0.06 \
+  "$@" >/dev/null 2>&1
+i=0
+while [ $i -lt 8 ]; do sleep 5; adb shell input keyevent KEYCODE_WAKEUP >/dev/null 2>&1; i=$((i+1)); done
+adb logcat -c
+i=0
+while [ $i -lt 5 ]; do sleep 4; adb shell input keyevent KEYCODE_WAKEUP >/dev/null 2>&1; i=$((i+1)); done
+adb logcat -d -s massif | grep -E "PROF|RenderStats" | sed "s/^/[$LABEL] /"

--- a/scripts/android-dev/bench/city2dsf.sh
+++ b/scripts/android-dev/bench/city2dsf.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Cross-app instrument for the 2D city camera: SurfaceFlinger averageFPS of our SurfaceView layer.
+# The only way to compare two BUILDS (PROF does not exist in a plain one) - see 11-tangram-diff.md.
+# $1 = apk, $2 = label, rest = extra extras.
+ANDROID_SERIAL="${ANDROID_SERIAL:?set it to the device serial}"; export ANDROID_SERIAL
+APK="$1"; LABEL="$2"; shift 2
+adb install -r -t "$APK" >/dev/null 2>&1
+adb shell am force-stop com.massifmaps.MassifDemo >/dev/null 2>&1
+adb shell input keyevent KEYCODE_WAKEUP >/dev/null 2>&1
+adb shell am start -n com.massifmaps.MassifDemo/.MainActivity --es ui false \
+  --es terrain false --es base composite --es style assets \
+  --es lat 45.188 --es lon 5.724 --es zoom 16.22 --es tilt 26 \
+  --es anim pan --es animDelay 40000 --es animDuration 25 --es animLatDelta 0.06 \
+  "$@" >/dev/null 2>&1
+i=0
+while [ $i -lt 8 ]; do sleep 5; adb shell input keyevent KEYCODE_WAKEUP >/dev/null 2>&1; i=$((i+1)); done
+adb shell dumpsys SurfaceFlinger --timestats -disable >/dev/null 2>&1
+adb shell dumpsys SurfaceFlinger --timestats -clear >/dev/null 2>&1
+adb shell dumpsys SurfaceFlinger --timestats -enable >/dev/null 2>&1
+i=0
+while [ $i -lt 5 ]; do sleep 4; adb shell input keyevent KEYCODE_WAKEUP >/dev/null 2>&1; i=$((i+1)); done
+adb shell dumpsys SurfaceFlinger --timestats -dump --maxlayers 8 \
+  | grep -A 6 "SurfaceView\[com.massifmaps.MassifDemo" | grep -E "layerName|totalFrames|averageFPS" \
+  | sed "s/^/[$LABEL] /"
+adb shell dumpsys SurfaceFlinger --timestats -disable >/dev/null 2>&1

--- a/scripts/android-dev/bench/city2dsum.py
+++ b/scripts/android-dev/bench/city2dsum.py
@@ -1,0 +1,20 @@
+import re, sys, statistics
+# Median summary of the 2D city runs: PROF (CPU) and PROF GPU lines, grouped by [label].
+# Windows longer than 1600 ms are idle periods and are discarded (see render-perf-method).
+cpu = re.compile(r"\[(?P<label>[^\]]+)\].*PROF: (?P<frames>\d+) frames in (?P<ms>\d+) ms \((?P<fps>[\d.]+) fps\), frame avg (?P<avg>[\d.]+) max [\d.]+ \| sky (?P<sky>[\d.]+) prelude [\d.]+ prepare [\d.]+ cover [\d.]+ drape [\d.]+ layers (?P<layers>[\d.]+) layers3D (?P<l3d>[\d.]+)")
+gpu = re.compile(r"\[(?P<label>[^\]]+)\].*PROF GPU: \d+ frames.*\| sky (?P<sky>[\d.]+) background (?P<bg>[\d.]+) .*layers (?P<layers>[\d.]+) layers3D (?P<l3d>[\d.]+) .*total (?P<total>[\d.]+)")
+c, g = {}, {}
+for line in sys.stdin:
+    m = cpu.search(line)
+    if m and float(m.group("ms")) <= 1600:
+        c.setdefault(m.group("label"), []).append(m)
+    m = gpu.search(line)
+    if m:
+        g.setdefault(m.group("label"), []).append(m)
+med = lambda ms, k: statistics.median(float(x.group(k)) for x in ms)
+print(f"{'config':<22} {'n':>3} {'fps':>6} {'cpuFrm':>7} {'swait':>6} {'layers':>7} {'lyr3D':>6} | {'gpuTot':>7} {'gSky':>5} {'gBg':>5} {'gLyr':>6}")
+for label in c:
+    m, gm = c[label], g.get(label, [])
+    row = f"{label:<22} {len(m):>3} {med(m,'fps'):>6.1f} {med(m,'avg'):>7.1f} {med(m,'sky'):>6.1f} {med(m,'layers'):>7.1f} {med(m,'l3d'):>6.1f}"
+    row += f" | {med(gm,'total'):>7.1f} {med(gm,'sky'):>5.1f} {med(gm,'bg'):>5.1f} {med(gm,'layers'):>6.1f}" if gm else " |"
+    print(row)


### PR DESCRIPTION
## Summary

- **Label draws almost halved.** A style `transform` translate was a factor of the label batch's
  matrix, so every transformed label was a draw of its own — 30 of a city frame's 68 label draws.
  Folded onto the label's vertices instead: **68.4 → 38.7 label draws a frame, CPU frame 45.0 →
  43.2 ms.** It also fixes a latent bug where same-style labels sharing a batch were translated by
  the **first** label's tile frame.

- **Two dead ends recorded with their numbers**, because both look like obvious wins and neither is:
  - *One glyph atlas shared by every font at a render size.* Takes the draws to 32.9 and measures
    **no frame rate change**, while making a silently-overflowing atlas a live risk (2048² is ~1764
    cells at render size 40 against ~200 glyphs per family; `loadBitmapGlyph` returns 0 when full and
    the glyph just disappears). Implemented, measured, dropped.
  - *A depth model for the flat map + maplibre's opaque/translucent split.* 2D disables the depth
    test entirely so there is no early-Z at all — but a fragment optimisation cannot move a frame
    whose GPU is idle by 4.4 ms: **20.1 → 19.6 fps**. Even the part that is well-founded — dropping
    the stencil tile masks once content writes depth, 60 draws a frame, `layers` CPU −22% — reaches
    only +2%, inside this bench's drift.

- **A method note that cost real time here:** at a label-dense camera the screenshot churn floor is
  **half a percent**. The fold's diff read 0.536% and looked like a regression; the same build run
  twice reads 0.533%, and a second run matched the baseline to 0.032%. Take a same-build control
  before reading a screenshot diff as a regression.

## Testing

Full Android build; `clang++ -fsyntax-only` clean; Docusaurus production build clean with no broken
links.

Device numbers as above — Crosscall HLTE556N, Grenoble z16.22 t26, terrain off, composite base,
`--es style assets`, scripted north pan, three interleaved rounds of 58 one-second windows per arm.

**Still wants a reviewer's eye on device:** labels positioned with `text-dx`/`text-dy` should sit
exactly where they did, at a tilted city camera. That is the one thing the fold could get wrong, and
the screenshot churn at this camera is too high to prove it by diff alone.

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/59 — **merge that first.**

Stacked on `perf/merge-polygon-pattern-draws` (PR #133) and based on it, so the diff shown is this
change alone. Merge order: libs #58 → MassifMaps #133 → libs #59 → this one, with each pointer bump
rebased onto the merged submodule commit rather than the branch commit.