### PR TITLE
perf(labels): fold a style transform into the vertices instead of the batch matrix

### DIFF
--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1376,6 +1376,48 @@ targeted and bought **zero frames** ([06-labels.mdx](rendering/06-labels.mdx#a-p
 and was reverted for correctness. Fewer label draws may go the same way — price it against the frame,
 not against the counter.
 
+### 16.8 A depth model for the flat map: built, measured, reverted
+
+The 2D pass disables the depth test entirely, so every fragment of every style layer is shaded and
+nothing can be rejected early. maplibre splits its frame into an opaque pass (depth-writing) and a
+translucent one; this round built that and threw it away.
+
+What was built (`debug.massif.depth2d`, reverted): a `DEPTH_2D` shader flag enabling
+`applyDepthBias`' painter-order term outside terrain mode, a per-style-layer ordinal handed out
+across the whole stack by `MapRenderer::drawLayers` (composite children included, so the ordinals
+span them), and two passes in `renderGeometry2D` — opaque fills first in **reverse** style layer
+order with depth write, everything else after in painter order testing against them, `GL_LEQUAL` in
+both because a layer's background and its geometry are coplanar at the same ordinal. Only a fill can
+be opaque: a line and a point antialias their own edges.
+
+It renders correctly — 0.382% of pixels differ at the city camera, the same order as the label churn
+between two runs of one build.
+
+| arm | fps | CPU frame | `layers` CPU | GPU total | GPU layers | mask draws / frame |
+|---|---|---|---|---|---|---|
+| baseline | 20.1 | 43.4 | 15.3 | 18.4 | 7.8 | 60 |
+| **depth2d** | **19.6** | 44.8 | 14.2 | 18.0 | 7.5 | 60 |
+| depth2d + no masks | 20.5 | 42.0 | **12.0** | 18.1 | 7.4 | 0 |
+
+**Early-Z on its own is a net loss.** It did exactly what it was designed to do — GPU `layers`
+7.8 → 7.5 ms — and that is 0.3 ms off a GPU which [16.2](#162-the-ab-that-proves-it) had already
+shown to be idle by 4.4 ms, while the opaque classification and the second pass put 1.4 ms back on a
+CPU-bound frame. The arithmetic said this before the code was written: **a fragment optimisation
+cannot move a frame whose GPU is not the critical path**, and the right move would have been to stop
+at that sentence.
+
+The second motivation was better founded and still did not pay. In a terrain frame, content writing
+depth is what **replaced the stencil tile masks** ([05-depth-model.md](rendering/05-depth-model.md)),
+and the masks are 60 draws a frame in 2D. Removing them with the depth model underneath is a real
+mechanism — `layers` CPU **15.3 → 12.0, −22%** — but it surfaces as **+2% fps**, and this bench's
+cross-session spread on an unchanged baseline has been 19.1–20.3. Two percent is not distinguishable
+from it.
+
+So the flat map keeps its stencil masks and its painter order. Two things a future attempt should
+know: the proxy-tile behaviour of the mask-less arm was **never checked** (only a pan was run, and
+what the masks protect against is a retained tile painting through the gaps of its replacement
+during a **zoom**), and the early-Z result is specific to a tiler with idle fragment capacity — on
+an immediate-mode GPU it could read differently, which is not measurable from here.
 ---
 
 ## 17. Lighting the undraped 2D content (2026-08-18)

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1418,6 +1418,39 @@ know: the proxy-tile behaviour of the mask-less arm was **never checked** (only 
 what the masks protect against is a retained tile painting through the gaps of its replacement
 during a **zoom**), and the early-Z result is specific to a tiler with idle fragment capacity — on
 an immediate-mode GPU it could read differently, which is not measurable from here.
+### 16.9 Label draws: the style transform folded into the vertices (-43%)
+
+[16.7](#167-label-batches-the-floor-is-one-glyph-atlas-per-font-render-size) left two reasons a
+label batch ends: the glyph atlas changing (33 a frame) and the style carrying a `transform` (26).
+Both were implemented; only one shipped.
+
+**The transform fold shipped.** The translate was a factor of the batch's `labelMatrix`, so a label
+carrying one was always a draw of its own. Conjugated by the tile matrix it is a *pure world
+translation*, so it is now added to that label's vertices after `calculateVertexData` and the label
+batches normally. Interleaved, three rounds, 58 one-second windows per arm:
+
+| | fps | CPU frame | label draws / frame | `labels2D` |
+|---|---|---|---|---|
+| before | 19.9 | 45.0 | 68.4 | 4.89 ms |
+| after | 20.1 | **43.2** | **38.7** | **4.24** |
+
+The frame rate is inside the noise; the CPU frame and the draw count are not. It also fixes a latent
+bug — consecutive same-style labels *did* share a batch, and its matrix was built from the **first**
+label's tile, so the others were translated by the wrong tile's frame.
+
+**The shared glyph atlas did not ship.** Keying `FontManager::_glyphMapMap` by glyph render size
+instead of by full font name collapses ~32 atlases to the ladder's three and takes the draws to
+**32.9** — and measured **no frame rate change** (CPU frame 43.6 → 43.7 over three rounds). It also
+buys a new failure mode: a 2048² atlas is ~1764 cells at render size 40 against ~200 glyphs per
+family, so shared across six families it runs ~68% full, and `GlyphMap::loadBitmapGlyph` returns 0
+once it is full — the glyph silently disappears. A silent-text-loss risk for an unmeasurable gain is
+the wrong trade; widen the atlas and measure its fill before retrying.
+
+Method note worth keeping: the fold's screenshot diff read **0.536%**, well above the 0.18–0.38% this
+camera usually shows, and it was **entirely label placement churn**. Running the same build twice
+measured **0.533%**, and a second run of it matched the baseline to **0.032%**. At a label-dense
+camera the churn floor is half a percent — establish it with a same-build control before reading a
+screenshot diff as a regression.
 ---
 
 ## 17. Lighting the undraped 2D content (2026-08-18)

--- a/docs/internals/rendering/06-labels.mdx
+++ b/docs/internals/rendering/06-labels.mdx
@@ -645,6 +645,23 @@ on Android instead of rendering as plain Roboto Regular.
   than on a large one, and up to **five times** what the single-raster build drew — a soft white
   glow instead of an outline, reported as "halo huge at radius 2, fine at 1". If halos ever look
   wrong again, check that term before the style.
+- **A style `transform` no longer ends the batch.** The translate was a factor of the batch's
+  `labelMatrix`, and the batch broke both when a label carried one and when the previous label did —
+  so every transformed label was a draw of its own, **30 of a city frame's 68 label draws**.
+  Conjugated by the tile matrix the translate is a *pure world translation*, so it is added to that
+  label's vertices after `calculateVertexData` instead, and the label batches with its neighbours.
+  Measured on the 2D city pan: **68.4 → 38.7 label draws a frame**, `labels2D` 4.89 → 4.24 ms, CPU
+  frame 45.0 → 43.2. It also fixes a latent bug: several same-style labels *did* share a batch, and
+  the matrix was built from the **first** label's tile, so the rest were translated by the wrong
+  tile's frame.
+- **One glyph atlas shared by every font at a render size — measured and dropped.** `FontManager`
+  keys `_glyphMapMap` by the full font name, so every (family, size) pair owns an atlas and the
+  16/28/40 ladder makes ~32 of them on a city screen; a batch ends whenever the atlas changes, which
+  is the other half of the label draws. Keying by render size instead took the draws to 32.9 and
+  bought **no frame rate**, and it makes overflow a live risk: a 2048² atlas is ~1764 cells at
+  render size 40 against ~200 glyphs per family, and `GlyphMap::loadBitmapGlyph` returns 0 when full
+  — glyphs vanish silently. Not worth a silent-text-loss failure mode for an unmeasurable gain. If it
+  is retried, widen the atlas first and measure the fill.
 - **The glyph atlas can be replaced under the batch loop.** `GlyphMap::getBitmapPattern()` returns
   the pattern **by value**, and a tile thread loading a new glyph resets `_bitmapPattern` — so the
   render thread's temporary can be the last owner. `renderLabelPass` bound its `labelBitmap`

--- a/docs/internals/rendering/10-performance.md
+++ b/docs/internals/rendering/10-performance.md
@@ -208,6 +208,13 @@ instead, so both live in one draw ([03-vt-renderer.md](03-vt-renderer.md#what-sp
 **584 → 363 draws a frame, 17.9 → 20.3 fps**, `layers` CPU 21.9 → 15.1 ms. The floor is one draw per
 (tile, style layer) — 337 — so what is left needs cross-tile batching, which nothing here does.
 
+**An opaque/translucent depth split (maplibre's model) was then built and reverted.** 2D disables the
+depth test entirely, so there is no early-Z at all — but a fragment optimisation cannot move a frame
+whose GPU is idle by 4.4 ms: it measured **20.1 → 19.6 fps**, the GPU saving 0.3 ms and the extra
+pass costing 1.4 ms of CPU. It also unlocks dropping the stencil tile masks (60 draws a frame,
+`layers` CPU −22%), and even that surfaces as +2% — inside this bench's drift.
+[performance-log.md 16.8](../performance-log.md).
+
 2D at the *mountain* camera measures 41 fps and is pinned against the device's 43 Hz present ceiling
 ([performance-log.md 15.6](../performance-log.md)), which is why this was never visible before: the
 conclusion "cutting 2D work cannot show up as frame rate" is true of that camera only.


### PR DESCRIPTION
## Summary

**Replaces #134**, which could not be rebased in place: #133 was squash-merged, so #134's branch
carried commits that no longer applied, and its pointer bump referenced a `libs-massif` commit that
never reached `develop` (see below). Same content, rebuilt on current `master`.

- **Label draws almost halved.** A style `transform` translate was a factor of the label batch's
  matrix, so every transformed label was a draw of its own — 30 of a city frame's 68 label draws.
  Folded onto the label's vertices instead: **68.4 → 38.7 label draws a frame, CPU frame 45.0 →
  43.2 ms.** It also fixes a latent bug where same-style labels sharing a batch were translated by
  the **first** label's tile frame.

- **Two dead ends recorded with their numbers**, because both look like obvious wins and neither is:
  - *One glyph atlas shared by every font at a render size.* Takes the draws to 32.9 and measures
    **no frame rate change**, while making a silently-overflowing atlas a live risk (2048² is ~1764
    cells at render size 40 against ~200 glyphs per family; `loadBitmapGlyph` returns 0 when full and
    the glyph just disappears). Implemented, measured, dropped.
  - *A depth model for the flat map + maplibre's opaque/translucent split.* 2D disables the depth
    test entirely so there is no early-Z at all — but a fragment optimisation cannot move a frame
    whose GPU is idle by 4.4 ms: **20.1 → 19.6 fps**.

- **A method note that cost real time here:** at a label-dense camera the screenshot churn floor is
  **half a percent**. The fold's diff read 0.536% and looked like a regression; the same build run
  twice reads 0.533%, and a second run matched the baseline to 0.032%.

## Testing

Full Android build; `clang++ -fsyntax-only` clean on top of current `develop`; Docusaurus production
build clean with no broken links.

Device — Crosscall HLTE556N, Grenoble z16.22 t26, terrain off, composite base, `--es style assets`,
scripted north pan, three interleaved rounds of 58 one-second windows per arm. The frame rate moved
19.9 → 20.1, which is inside the noise; the draw count and the CPU frame are not. Numbers were taken
before the rebase onto the merged `master` and were **not** re-benched after it.

**Still wants a reviewer's eye on device:** labels positioned with `text-dx`/`text-dy` should sit
exactly where they did, at a tilted city camera. That is the one thing the fold could get wrong, and
the screenshot churn at this camera is too high to prove it by diff alone.

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/60 — **merge that first**, then this pointer
bump is rebased onto the merged `develop` commit rather than the branch commit.

libs #59 was merged into `perf/merge-polygon-pattern-draws` instead of `develop`, and that branch had
already gone to `develop` via #58 — so the fold never reached `develop`. #60 re-lands it.