### PR TITLE
feat(labels): let one style pick flat labels in 2D and billboard ones in 3D

### DIFF
--- a/all/native/layers/VectorTileLayer.cpp
+++ b/all/native/layers/VectorTileLayer.cpp
@@ -676,6 +676,10 @@ namespace massif {
         if (auto symbolizerContextSettings = _tileDecoder->getSymbolizerContextSettings()) {
             exprContext.setStyleParameterStore(symbolizerContextSettings->getStyleParameterStore());
         }
+        // Same source as the tiles use, so Map-block properties read the same render::3d
+        if (std::shared_ptr<vt::TileTransformer> tileTransformer = getTileTransformer()) {
+            exprContext.setRender3D(tileTransformer->isElevationBased());
+        }
         return exprContext;
     }
     

--- a/all/native/terrain/TerrainTileTransformer.h
+++ b/all/native/terrain/TerrainTileTransformer.h
@@ -81,6 +81,8 @@ namespace massif {
         int getMeshResolution() const { return _meshResolution; }
         int getMinZoom() const { return _minZoom; }
 
+        virtual bool isElevationBased() const override { return true; }
+
         virtual cglib::vec3<double> calculateTileOrigin(const vt::TileId& tileId) const override;
         virtual cglib::bbox3<double> calculateTileBBox(const vt::TileId& tileId) const override;
         virtual cglib::mat4x4<double> calculateTileMatrix(const vt::TileId& tileId, float coordScale) const override;

--- a/docs/features/3d-terrain.md
+++ b/docs/features/3d-terrain.md
@@ -137,6 +137,12 @@ At low zoom, `VectorLayer` **element** lines (e.g. long routes) can still leak t
 they are CPU-baked to a fine bilinear surface while the low-zoom occluder is coarse, and no depth
 bias wins that case. The fix (render-to-texture element draping across layers) is on the roadmap.
 
+## Styling differently in 3D
+
+A style reads `[render::3d]` to branch on whether it is drawn on terrain — flat labels in 2D,
+billboard ones in 3D, for instance. See
+[Live Style Parameters](/docs/features/style-parameters#the-render-mode-variable-render3d).
+
 ## See also
 
 - [Hillshade](/docs/features/hillshade) — shaded relief from the same DEM.

--- a/docs/features/label-styling.md
+++ b/docs/features/label-styling.md
@@ -167,6 +167,16 @@ which is what removed the blurred stems and the holes at stem/shoulder joins tha
 SDF produced. Nothing to configure — but it is why label appearance changed relative to older
 builds of this fork.
 
+## 2D and 3D from one style
+
+`text-orientation-mode` is fixed when the tile is decoded, so it cannot be switched by a style
+parameter — branch on the SDK's own
+[`render::3d`](/docs/features/style-parameters#the-render-mode-variable-render3d) instead:
+
+```css
+#road_label { text-orientation-mode: [render::3d] ? billboard-line : line; }
+```
+
 ## See also
 
 - [Composite Vector Tile Layer](/docs/features/composite-vector-tile-layer) — where a label group sits in the draw order.

--- a/docs/features/style-parameters.md
+++ b/docs/features/style-parameters.md
@@ -125,6 +125,35 @@ in the log naming the reason** — `selects` never fails silently:
   repaint can build geometry. Write the casing as a width and a colour instead of as a rule;
 - not on a **dashed** line whose width is selected: the dash raster is sized by the width.
 
+## The render-mode variable (`render::3d`)
+
+`render::3d` is **not** a style parameter: the SDK owns it, the app cannot set it. It is `true` while
+the layer draws on 3D terrain (`TerrainOptions.setEnabled(true)`), `false` otherwise — which lets one
+style carry both looks:
+
+```css
+#road_label {
+  text-name: [name];
+  text-orientation-mode: [render::3d] ? billboard-line : line;
+  text-size: [render::3d] ? 12 : 11;
+}
+
+#building['render::3d' = true] { building-height: [render_height]; }
+```
+
+In an expression it is written `[render::3d]`; in a **selector** it must be quoted,
+`['render::3d' = true]`, the same as `['param::x' > 0]` (the selector grammar has no `::` in a bare
+field name).
+
+It is resolved **at decode time**, like a feature field or the zoom — so it works everywhere,
+including on properties no repaint can change (`text-orientation-mode`, `text-name`, marker choice,
+filters), and it costs nothing per frame. Toggling terrain therefore re-decodes the tiles, but that
+already happened: the terrain switch drops every tile cache anyway, so reading `render::3d` is free.
+
+The value comes from the layer's tile transformer (elevation-based or not), which is the same object
+the tile cache is keyed against — a tile can never be drawn with the wrong answer baked in.
+
 ## See also
 
+- [3D Terrain](/docs/features/3d-terrain) — what switches `render::3d`.
 - [Composite Vector Tile Layer](/docs/features/composite-vector-tile-layer) — external sources configured from `param::`-dependent expressions.


### PR DESCRIPTION
## Summary

A style can now branch on whether it is being drawn on 3D terrain, via the new read-only
`render::3d` variable:

```css
#road_label { text-orientation-mode: [render::3d] ? billboard-line : line; }
#building['render::3d' = true] { building-height: [render_height]; }
```

- `TerrainTileTransformer` answers `isElevationBased()`, which is what the tile decoder reads for the
  variable. The transformer is the right source: the layer rebuilds it — and drops every tile cache
  with it — whenever the terrain is switched, so a tile can never be drawn with the wrong answer.
- The layer's own expression context (Map-block properties: background, pole, sky ground colour) is
  given the same value, so the ground and the tiles never disagree.
- Resolved at **decode** time, which is what makes it work on `text-orientation-mode` at all — that
  property is baked into the tile and no repaint can change it. Costs nothing: toggling terrain
  already re-decodes every tile.
- Docs: new section in `docs/features/style-parameters.md`, cross-linked from `3d-terrain.md` and
  `label-styling.md`.

Not an app-settable style parameter — the SDK owns it, so there is no new public API and nothing to
opt into. Styles that do not mention `render::3d` are unaffected.

## Testing

`clang++ -fsyntax-only -std=c++20` clean on `VectorTileLayer.cpp` and the touched mapnikvt units.
`npm run build` in `website/` clean, no broken-links block.

**Not device-verified.** A style branching on `[render::3d]` still needs a run to prove the label
switch. The demo's terrain toggle (`animateTerrain`) already flips `setEnabled` as the decode
boundary and holds the exaggeration ramp until the re-decoded tiles land, so the orientation should
switch exactly once per toggle:

```
--es demo terrain --es lon 5.7606 --es lat 45.2442 --es zoom 13.6 --es tilt 60
```

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/61 — merge that first, then rebase this
branch's pointer bump onto the merged commit (not the branch commit) before merging here.