### PR TITLE
fix(ios): restore the iOS build broken by a mistyped data source import

### DIFF
--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -11,7 +11,9 @@ move to an OpenGL ES 3.0 baseline (dropping ES 2.0), the Apple situation (Metal)
 Windows/Linux/macOS need later. Does **not** cover what the renderer draws — that is the rest of
 [this set](index.mdx).
 
-Status as of 2026-08-18: investigation and plan. Nothing below Phase 0 has been executed.
+Status as of 2026-08-18: Phase 0 run. Gates 0.1 and 0.2 pass, gate 0.3 is **not answered** — see
+[Phase 0 results](#phase-0--results). The Apple source was decided against upstream ANGLE, see
+[MetalANGLE master, not upstream](#metalangle-master-not-upstream-angle).
 
 ## Where we are
 
@@ -120,30 +122,110 @@ The reference implementation is a non-participant, which matters here more than 
 backend permanently ends the copy-from-tangram workflow that
 [the rest of these pages](11-tangram-diff.md) depend on.
 
-## ANGLE upstream, not MetalANGLE
+## MetalANGLE master, not upstream ANGLE
 
-`libs-external/angle-metal` is a prebuilt of `kakashidinho/metalangle` at commit `8ef9aba`,
-originally vendored as `nutiteq/angle-metal`. That fork is dead by its author's own statement: most
-of its ES 3.0 Metal implementation was merged into official ANGLE by June 2021, and the repo has
-been inactive since he joined Google, with all development redirected upstream. Apple contributes
-there too.
+Decided 2026-08-18, reversing this page's first draft. **MetalANGLE is itself a fork of Google's
+ANGLE** — its README's first line says so — so there is no Google-free option here, only a choice of
+revision.
 
-Upstream ANGLE's Metal backend is complete for **ES 2.0 and ES 3.0** on macOS and iOS (not
-ES 3.1/3.2 — irrelevant here).
+`libs-external/angle-metal` is a **nested submodule** (`massif-maps/angle-metal`) holding prebuilt
+binaries only: one `libangle.a` per arch plus headers, no ANGLE source. Last pushed 2021-08-31,
+built from `kakashidinho/metalangle` at `8ef9aba` (2021-06-30). There is nothing to rebase; either
+direction means building from source and re-dropping the `.a`.
 
-Porting cost is bounded and specific: the GL API surface is identical, so `all/native`, `vt` and
-`nml` are untouched. What is **not** upstream is **MGLKit**, MetalANGLE's Objective-C lookalike for
-Apple's deprecated EAGL/GLKit — which is exactly the `MSFGLContext` / `MSFGLKView` typedefs in
-`ios/objc/ui/MapView.h` and the drawable-format block in `MapView.mm`. Those get rewritten onto
-plain EGL + `CAMetalLayer`.
+What decided it is the build path, not the code:
 
-Two things to carry into the work:
+| | MetalANGLE | upstream ANGLE |
+|---|---|---|
+| Build tooling | `ios/xcode/OpenGLES.xcodeproj` + `fetchDependencies.sh` — plain `xcodebuild` | depot_tools + gclient + gn, ~10 GB sync |
+| Builds under Xcode 26.5 | **yes, unpatched** (measured, see below) | unmeasured |
+| MGLKit | included — `MSFGLContext`/`MSFGLKView` keep working | absent; Phase 1 must write the EGL + `CAMetalLayer` bootstrap |
 
-- Apple's upstream contributions prioritised WebGL conformance over speed (rewriting index buffers
-  on the fly for provoking-vertex rules, for one). Upstream may be **slower** than the fork on some
-  paths. Bench it, do not assume it.
-- Upstream drops the fork's ES2-downgrade patch and the armv7/i386 slices, both obsolete under the
-  iOS 13.0 deployment floor.
+What this costs, accepted knowingly:
+
+- MetalANGLE's own README grades its **ES 3.0 at "90% complete"**, with Primitive Restart
+  ("doesn't work reliably") and last-provoking-vertex flat shading unimplemented. Neither is used
+  by this renderer today; both become blockers if that changes.
+- The fork's last code commit is Mar 2022. Four years of upstream Metal-backend fixes are foregone.
+- **Two divergent ANGLE forks stay vendored**: `angle-metal` (2021) and `angle-uwp` (2022 binaries).
+  Upstream would have collapsed them to one.
+- Phase 5 loses its cheap path: MetalANGLE has no Win32/D3D and no AppKit slice, so Windows and
+  native macOS need upstream ANGLE anyway, or another source.
+
+The one argument *for* the fork on the merits — that Apple's upstream contributions prioritised
+WebGL conformance over speed, rewriting index buffers on the fly for provoking-vertex rules — is a
+hypothesis gate 0.3 was meant to test and **did not**. It remains unmeasured in both directions.
+
+MGLKit is still the piece that is not upstream anywhere: `MSFGLContext` / `MSFGLKView` in
+`ios/objc/ui/MapView.h` and the drawable-format block in `MapView.mm`. Staying on the fork defers
+rewriting them onto plain EGL + `CAMetalLayer`; it does not remove the job, because Phase 5 needs
+that bootstrap for Win32 and AppKit regardless.
+
+## Phase 0 — results
+
+Run 2026-08-18 on macOS 15 / Xcode 26.5, against `kakashidinho/metalangle` master `ec925142e`.
+Build commands are in [`docs/maintenance/angle.md`](../../maintenance/angle.md).
+
+### 0.1 — build and run on arm64-simulator: **PASS**
+
+`MetalANGLE_static` built for `iphonesimulator`, `arm64-apple-ios13.0-simulator`, against
+`iPhoneSimulator26.5.sdk`. **No patches were needed** — the 2022 tree compiles unmodified on a 2026
+toolchain, which was the main risk of staying on the fork. `scripts/ios-dev` linked against it with
+no API drift and ran:
+
+```
+GLContext::LoadExtensions: OpenGL ES 3.0.0 (ANGLE 2.1.0.ec925142edeb), depth texture 1, shadow samplers 0
+MapRenderer::onSurfaceCreated: renderer 'ANGLE (Metal Renderer: Apple iOS simulator GPU)', depth bits 24, stencil bits 8
+```
+
+The commit suffix in the version string is how you tell the slices apart: the vendored 2021 build
+reports a bare `ANGLE 2.1.0.`. Frames at lon 5.7606 / lat 45.2442 / z13.6 / tilt 55 are identical
+between the two builds bar the status-bar clock — 1259 of 3162132 pixels, bbox `(227,79)-(288,117)`.
+
+Stripped with the vendoring settings the slice is **14.2 MB**, against the vendored 15.2 MB. That
+also fills one of this page's old gaps: the settings in the `angle-metal` README do reproduce the
+shipped artefact, and the difference is Xcode 26.5 with no bitcode rather than anything structural.
+
+`shadow samplers 0` is worth carrying into Phase 3 — the hardware-PCF program is the one place
+`ESSL3_FLAG` is used today, and the Metal backend is not offering `sampler2DShadow` here.
+
+### 0.2 — `#define gl_FragColor`: **ACCEPTED, so Phase 3 is not breaking**
+
+Run through the real translator (`SH_GLSL_METAL_OUTPUT`, `SH_GLES3_SPEC`, with `CompilerMtl` /
+`ShaderMtl`'s own compile options), not inferred from the spec:
+
+| case | result |
+|---|---|
+| tangram header, shader body writes `gl_FragColor` | **PASS** |
+| vt header, body writes `glFragColor` | PASS |
+| tangram vertex header (`#define attribute in` …) | PASS |
+| control — same body, no header | FAIL: `'varying' : Illegal use of reserved word` |
+| control — header **minus only the two `gl_FragColor` lines** | FAIL: `'gl_FragColor' : undeclared identifier` |
+
+The macro is applied, not ignored: `gl_FragColor = texture2D(uTex, vUV) * …` translates to
+`_uTANGRAM_FragColor = texture(_uuTex, _uvUV) * …`.
+
+So the comment in `GLTileRenderer::createShaderProgram` — *"a name starting with `gl_` cannot be
+`#define`d, so that one had to be a real rename"* — **is wrong**. ESSL reserves the `GL_` prefix for
+*macro* names; `gl_FragColor` is a built-in *variable*, and in ESSL 3.00 it is not declared at all.
+Consequence: the five public GLSL setters (`SkyOptions`, `FogOptions`, `TerrainOptions`,
+`CustomRasterTileLayer`, `PostProcessEffect`) need **no migration**, and Phase 3 can adopt tangram's
+`shaderSource.cpp` preamble verbatim instead of renaming.
+
+### 0.3 — frame-time A/B: **NOT ANSWERED**
+
+Blocked on hardware, and the plan under-specified it:
+
+- The **EAGL leg is impossible on any Apple-Silicon simulator** — it has no OpenGL ES at all, which
+  is why `scripts/ios-dev` links ANGLE in the first place. EAGL vs Metal is a device-only comparison.
+- No physical iOS device was attached (`xcrun devicectl list devices` → *No devices found*).
+- The leg that *was* in reach — master vs `8ef9aba`, both on Metal — **saturated**: four interleaved
+  75 s runs of the scripted pan returned exactly 60.0 fps for both. That is the simulator's vsync
+  cap, not a tie. A capped test has no discriminating power and is not evidence of equal cost.
+
+To answer it properly: build both with `MASSIF_FRAME_PROFILER=1 MASSIF_VT_RENDER_STATS=1` so the
+per-section CPU/GPU milliseconds are visible *below* the vsync cap, and run on a device at a camera
+that is actually GPU-bound. Frame rate against a 60 Hz cap cannot resolve this either way.
 
 ## What ES 3.0 actually buys
 
@@ -166,28 +248,22 @@ reference implementation to copy from.
 
 ### Phase 0 — decision gates
 
-Three measurements, no production code. Everything after this is conditional on them.
+Three measurements, no production code. Results are in [Phase 0 — results](#phase-0--results):
+0.1 pass, 0.2 answered (not breaking), 0.3 unanswered.
 
-1. Build upstream ANGLE for `arm64-simulator`, run `scripts/ios-dev` against it. Confirms
-   Metal-backend ES 3.0 in practice rather than from a support matrix.
-2. Compile a `#version 300 es` shader containing `#define gl_FragColor TANGRAM_FragColor` through
-   ANGLE's translator. See [the `gl_FragColor` disagreement](#the-gl_fragcolor-disagreement) below —
-   this decides whether Phase 3 is a breaking change.
-3. Frame-time A/B at a fixed bench camera: upstream ANGLE vs the vendored MetalANGLE vs EAGL.
-
-**Gate**: if (1) fails or (3) is bad, this plan stops and the native question reopens.
+**Gate**: if (1) fails or (3) is bad, this plan stops and the native question reopens. (1) passed.
+(3) is still open, so the native question is deferred rather than closed — but on the evidence of
+0.1 nothing blocks Phase 1 starting.
 
 ### Phase 1 — ANGLE is the Apple graphics layer
 
-- Re-vendor upstream ANGLE into `libs-external`. Slices: ios-arm64, ios-sim-arm64, catalyst
-  arm64 + x86_64, macos arm64 + x86_64. Drop armv7 and i386.
-- **One shared EGL bootstrap, parameterized by view class** — not `#ifdef`s inside `MapView.mm`.
-  It will have four callers (UIKit, AppKit, Catalyst, later Win32), and MGLKit has to be replaced
-  regardless; build it for that now.
-- Delete: the EAGL path, `MSFGLContext`/`MSFGLKView`, `_MASSIF_USE_METALANGLE` and
-  `--use-metalangle` (unconditional now), the `ios/glwrapper` OpenGLES fallbacks, and Xamarin
-  (unmaintained; it is also the only binding that blocks an ANGLE-only iOS).
-- `docs/maintenance/angle.md` with the exact build commands, versions and every fork patch.
+- Re-vendor MetalANGLE master `ec925142e` into `massif-maps/angle-metal`. Slices: ios-arm64,
+  ios-sim-arm64, catalyst arm64 + x86_64. Drop armv7 and i386. Carry the one fork patch on
+  `MGLContext.h` (see [`angle.md`](../../maintenance/angle.md)).
+- MGLKit survives this phase — that is what choosing the fork bought. The EGL + `CAMetalLayer`
+  bootstrap moves to Phase 5, where Win32 and AppKit force it anyway.
+- Delete: the EAGL path, `--use-metalangle` (unconditional now), the `ios/glwrapper` OpenGLES
+  fallbacks, and Xamarin (unmaintained; it is also the only binding that blocks an ANGLE-only iOS).
 
 **Done when**: `scripts/ios-dev` runs on device and simulator, Catalyst builds, and a screenshot at
 a fixed camera matches the EAGL build.
@@ -222,19 +298,22 @@ The reference is already in the tree, and it is tangram, not mapbox-gl-js:
 **Done when**: every program compiles at `300 es` on both device families and
 `hasShaderVersionFallback()` returns false.
 
-#### The `gl_FragColor` disagreement
+#### The `gl_FragColor` disagreement — settled, tangram was right
 
-The two implementations contradict each other, and the answer decides whether this phase breaks the
+The two implementations contradicted each other and the answer decided whether this phase breaks the
 public API.
 
 - **tangram** does `#define gl_FragColor TANGRAM_FragColor` plus a `layout(location = 0) out`
   declaration. App shaders keep writing `gl_FragColor` and need no migration.
-- **`vt`** renames instead, and its comment states the reason: a name starting with `gl_` cannot be
-  `#define`d.
+- **`vt`** renames instead, and its comment claims a name starting with `gl_` cannot be `#define`d.
 
-Tangram ships its form and it works on their device matrix — but tangram uses EAGL and has never run
-under ANGLE, whose shader translator is the strict one. If ANGLE accepts the macro, the five public
-GLSL setters need no migration and Phase 3 stops being a breaking change. That is Phase 0, item 2.
+Gate 0.2 put both through ANGLE's translator: **the macro is accepted and applied**. vt's comment is
+wrong — ESSL reserves the `GL_` prefix for *macro* names, while `gl_FragColor` is a built-in
+*variable* that ESSL 3.00 does not declare at all. So Phase 3 adopts tangram's preamble verbatim,
+the five public GLSL setters need no migration, and this phase is **not** a breaking change.
+
+vt's rename is still harmless and need not be undone; only the comment is misleading, and only the
+`all/native` side has to choose. Full method and controls in [Phase 0 — results](#02--define-gl_fragcolor-accepted-so-phase-3-is-not-breaking).
 
 ### Phase 4 — harvest
 
@@ -244,9 +323,11 @@ label streaming.
 
 ### Phase 5 — desktop
 
-No renderer change. Per platform: one context/window file and one build script.
+No renderer change, but this is where the MetalANGLE choice is paid for: the fork has no Win32/D3D
+and no AppKit slice, so this phase needs upstream ANGLE *and* the EGL + `CAMetalLayer` bootstrap
+that Phase 1 no longer writes.
 
-- **macOS native (AppKit)** — reuse the Phase 1 bootstrap, swap the view class.
+- **macOS native (AppKit)** — upstream ANGLE on Metal, plus the shared EGL bootstrap.
 - **Windows** — ANGLE on D3D11, reusing the UWP EGL wrapper shape.
 - **Linux** — native EGL against Mesa's GLES 3.2. Pull in ANGLE-on-Vulkan only if a driver forces it.
 
@@ -258,18 +339,26 @@ adopting is the cheaper discipline: new GL calls go through the `renderers/utils
 into logic files. Retrofitting the 898 already-scattered calls in `all/native` is its own priced
 job and is not part of this.
 
-**No native Metal.** Reopen only if the Phase 0 bench shows ANGLE costing real frames at the city
-camera — and price it against the table above, including the loss of tangram as a reference.
+**No native Metal.** Reopen only if the gate 0.3 bench shows ANGLE costing real frames at the city
+camera — and price it against the table above, including the loss of tangram as a reference. That
+bench has not been run, so this is deferred, not decided.
 
 ## Known gaps
 
-- Every number in "Where we are" is from static analysis of the tree. Nothing in Phase 0 has been
-  run; the ES 3.0 conformance of ANGLE's Metal backend is taken from its support matrix, not
-  observed here.
-- The binary-size delta of a linked upstream ANGLE is unmeasured. The vendored MetalANGLE static
-  slice is 15.2 MB for arm64 before dead-stripping, which is not the shipped cost.
-- Whether ANGLE adds measurable per-draw overhead versus EAGL is unknown, and it is the one result
-  that could send this back to a native backend.
+- **Gate 0.3 is unmeasured.** Whether ANGLE adds per-draw overhead versus EAGL is the one result
+  that could send this back to a native backend, and it needs a physical iOS device: the
+  Apple-Silicon simulator has no OpenGL ES to compare against, and its 60 Hz vsync cap hides any
+  delta the scene does not already exceed. Use `MASSIF_FRAME_PROFILER=1` per-section timings, not
+  frame rate.
+- Every number in "Where we are" is from static analysis of the tree, unchanged since.
+- ES 3.0 on the Metal backend is confirmed **on the simulator only** (gate 0.1). No device run yet,
+  and the fork's own README grades its ES 3.0 at 90%.
+- `shadow samplers 0` on the simulator: the hardware-PCF path, the only current `ESSL3_FLAG` user,
+  is not available there. Unknown whether that is a simulator limitation or the backend.
+- The linked (as opposed to static-slice) binary-size delta is still unmeasured. The stripped
+  arm64-simulator slice is 14.2 MB at master, 15.2 MB at the vendored 2021 build.
 - Xamarin is assumed droppable. If it is not, it blocks an ANGLE-only iOS on its own.
+- Whether MetalANGLE's two unimplemented ES 3.0 features (primitive restart, last-provoking-vertex
+  flat shading) matter to this renderer has not been checked against the draw calls it makes.
 - No decision on whether Windows should use ANGLE-on-D3D11 or ANGLE-on-Vulkan; D3D11 is assumed on
   maturity grounds only.

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -227,6 +227,46 @@ To answer it properly: build both with `MASSIF_FRAME_PROFILER=1 MASSIF_VT_RENDER
 per-section CPU/GPU milliseconds are visible *below* the vsync cap, and run on a device at a camera
 that is actually GPU-bound. Frame rate against a 60 Hz cap cannot resolve this either way.
 
+### What still needs a physical device
+
+Nothing below has been observed on real Apple hardware. The `arm64` and Catalyst slices are built
+and staged, so this is a session with a phone, not more build work.
+
+```sh
+cd scripts/ios-dev && PROFILE_RENDER=1 ./bootstrap.sh device
+```
+
+| # | Check | Why it needs a device |
+|---|---|---|
+| 1 | `scripts/ios-dev` runs at all on `arm64` | The device slice has only ever been built, never linked or launched |
+| 2 | Startup reports `OpenGL ES 3.0.0 (ANGLE 2.1.0.ec925142edeb)` | Gate 0.1 is simulator-only; confirms the version string on the real backend |
+| 3 | The ESSL 3.00 shadow program compiles — `hasShaderVersionFallback()` false, no `_essl3Failed` | It is the only current `ESSL3_FLAG` user, so it is the one existing proof that ANGLE takes a `300 es` program at all. Ignore the `shadow samplers` log field, see below |
+| 4 | **Gate 0.3**, the real one — EAGL vs MetalANGLE `8ef9aba` vs master | EAGL does not exist on an Apple Silicon simulator at all |
+| 5 | A screenshot at a fixed camera matches the EAGL build | Phase 1's "done when" |
+| 6 | Catalyst still builds and runs | The Catalyst slices were rebuilt at master and are otherwise untested |
+
+For (4), follow `scripts/android-dev/bench/README.md`'s discipline rather than a single run:
+interleave the builds (A/B/A/B) and take medians over many windows — same-build drift on a device
+was 14.6–17.4 fps across one morning. Read `PROF` / `RenderStats` from the device console. The
+expected loss, if there is one, is **per-draw** — this renderer's uniform volume, not its shaders —
+so the city camera with many small draws is the case to bench, not the terrain.
+
+Bench a **Release** build. `RelWithDebInfo` is plain `-O2 -g`, while Release applies `-Oz` and thin
+LTO; a number from the wrong configuration is not the shipped one.
+
+#### `shadow samplers 0` is a red herring
+
+The startup line reports it and it means nothing here. `GLContext` probes
+`HasGLExtension("GL_EXT_shadow_samplers")`, which is an **ES 2.0** extension: in ES 3.0
+`sampler2DShadow` and depth comparison are core, so a driver has no reason to export the old string
+on an ES 3.0 context, and most do not.
+
+`GLContext::SHADOW_SAMPLERS` is then **never read** — it is logged and nothing else. Hardware PCF is
+gated on `_depthTextureMode && GLContext::ES3` in `TerrainShadowMap::create`, both true on the
+simulator run. The probe is dead code and a deletion candidate for Phase 2, which already collapses
+the `GLContext` extension probes; the log field should go with it or be re-pointed at
+`GLContext::ES3`.
+
 ## What ES 3.0 actually buys
 
 Nothing lands from the version bump itself. The wins are the work it unblocks:
@@ -353,8 +393,8 @@ bench has not been run, so this is deferred, not decided.
 - Every number in "Where we are" is from static analysis of the tree, unchanged since.
 - ES 3.0 on the Metal backend is confirmed **on the simulator only** (gate 0.1). No device run yet,
   and the fork's own README grades its ES 3.0 at 90%.
-- `shadow samplers 0` on the simulator: the hardware-PCF path, the only current `ESSL3_FLAG` user,
-  is not available there. Unknown whether that is a simulator limitation or the backend.
+- `GLContext::SHADOW_SAMPLERS` is dead — probed from an ES 2.0 extension string, logged, never read.
+  Phase 2 should delete it along with the other extension probes.
 - The linked (as opposed to static-slice) binary-size delta is still unmeasured. The stripped
   arm64-simulator slice is 14.2 MB at master, 15.2 MB at the vendored 2021 build.
 - Xamarin is assumed droppable. If it is not, it blocks an ANGLE-only iOS on its own.

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -371,6 +371,28 @@ that Phase 1 no longer writes.
 - **Windows** — ANGLE on D3D11, reusing the UWP EGL wrapper shape.
 - **Linux** — native EGL against Mesa's GLES 3.2. Pull in ANGLE-on-Vulkan only if a driver forces it.
 
+#### What the ES 3.0 baseline costs on desktop
+
+Almost nothing, and it settles the Windows backend question. ANGLE's D3D11 backend caps the ES
+version by feature level (`GetMaximumClientVersion` in `renderer11_utils.cpp`; `Renderer11.cpp`
+puts it plainly — *"Can't support ES3 at all without feature level 10.1"*):
+
+| D3D feature level | max ES |
+|---|---|
+| 11_0 / 11_1 | 3.1 |
+| **10_1** | **3.0** |
+| 10_0 and below | 2.0 |
+
+So the Windows floor is **FL 10_1**: Sandy Bridge (2011) and AMD HD 3000 (2007) clear it, NVIDIA
+GeForce 8/9 (10_0) and pre-2011 Intel GMA (9_x) do not. Windows 11 already requires a DX12-capable
+GPU, so it excludes nobody there, and WARP — what VMs and RDP sessions fall back to — reports 11_1.
+
+That is the argument for **D3D11 over Vulkan** on Windows, which this plan previously assumed on
+maturity grounds alone: ANGLE-on-Vulkan needs a 2016-or-later driver, so it is *narrower* in the
+tail than D3D11's 2011 floor. Linux and macOS have no equivalent cut — Mesa serves GLES 3.x on
+anything post-2012 (llvmpipe does 3.2 in software), and the macOS floor is "Metal-capable", which
+macOS 10.14+ requires anyway.
+
 ## What this plan deliberately does not do
 
 **No graphics abstraction layer.** MapLibre needed one because they were adding real backends; we

--- a/docs/maintenance/angle.md
+++ b/docs/maintenance/angle.md
@@ -67,20 +67,38 @@ Per slice, change `-sdk` and `-arch`:
 | `arm64` | `iphoneos` | `arm64` | `Release-iphoneos` |
 | `x86_64` | `iphonesimulator` | `x86_64` | `Release-iphonesimulator` |
 
-Mac Catalyst uses the scheme rather than the target, and is then split with `lipo`:
+Mac Catalyst uses `-scheme`, plus the same settings block, once per architecture:
 
 ```sh
 xcodebuild -project OpenGLES.xcodeproj -scheme MetalANGLE_static -sdk macosx \
   -configuration Release -destination 'platform=macOS,variant=Mac Catalyst' \
-  build SUPPORTS_MACCATALYST=YES
-lipo <output>/libMetalANGLE_static.a -extract arm64  -output libangle.a   # -> arm64-maccatalyst/
-lipo <output>/libMetalANGLE_static.a -extract x86_64 -output libangle.a   # -> x86_64-maccatalyst/
+  SUPPORTS_MACCATALYST=YES CODE_SIGNING_ALLOWED=NO <same settings as above> build
+# and for the Intel slice:
+#   -destination 'platform=macOS,variant=Mac Catalyst,arch=x86_64' ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO
 ```
+
+Two traps here, both different from the 2021 recipe in the `angle-metal` README:
+
+- **`-scheme` writes to DerivedData, not `build/`.** The `-target` invocations above land in
+  `ios/xcode/build/Release-<sdk>/`; the Catalyst ones land in
+  `~/Library/Developer/Xcode/DerivedData/OpenGLES-*/Build/Products/Release-maccatalyst/`. Read the
+  `Libtool`/`Strip` line at the end of the build log for the actual path rather than guessing.
+- **The result is thin, not fat.** The old recipe built one archive and split it with
+  `lipo -extract`. On Xcode 26.5 the build resolves to the host architecture only (`-arch_only
+  arm64` in the libtool line), so there is nothing to extract — build each architecture separately
+  and copy each straight to its `<arch>-maccatalyst/libangle.a`.
 
 See [Mac Catalyst](mac-catalyst.md) for why those slices behave like a macOS build at link time.
 
 `armv7` and `i386` slices still exist in the submodule and are dead — the deployment floor is
 iOS 13.0. Do not rebuild them.
+
+### Bitcode is gone, and that is most of the size drop
+
+The vendored 2021 device slice is **51.7 MB**; rebuilt at master it is **14.2 MB**. Almost all of
+that is bitcode — the old README added `OTHER_CFLAGS="-fembed-bitcode"` for the arm64 and armv7
+device targets. Apple removed bitcode in Xcode 14, so the flag is not carried forward and must not
+be re-added. The simulator slices never had it, which is why they were 15.2 MB then and 14.2 MB now.
 
 ### Why each strip setting is there
 
@@ -124,7 +142,7 @@ suffix did not change, the link picked up the old one.
 `scripts/ios-dev` is the fastest way to exercise it:
 
 ```sh
-cd scripts/ios-dev && ./bootstrap.sh
+cd scripts/ios-dev && ./bootstrap.sh            # or './bootstrap.sh device'
 xcodebuild -project MassifDemo.xcodeproj -scheme MassifDemo -sdk iphonesimulator \
   -destination 'id=<simulator-udid>' build
 ```
@@ -132,10 +150,20 @@ xcodebuild -project MassifDemo.xcodeproj -scheme MassifDemo -sdk iphonesimulator
 `-destination` needs the UDID from `xcrun simctl list devices available`; the by-name form fails
 with *"no available devices matched the request"* even when the name is right.
 
+For a frame-time comparison add `PROFILE_RENDER=1` to the bootstrap — it compiles in
+`MASSIF_FRAME_PROFILER` / `MASSIF_VT_RENDER_STATS` and their `PROF` / `RenderStats` lines, the
+counterpart of android-dev's `-PprofileRender`. It is a compile-time flag, so switching it needs a
+re-bootstrap.
+
 ## Known gaps
 
-- Only `arm64-simulator` has actually been rebuilt at master. The device, x86_64 and Catalyst slices
-  in the submodule are still the 2021 `8ef9aba` builds.
-- No device run: ES 3.0 on the Metal backend is confirmed on the simulator only.
+- All five live slices are rebuilt at master `ec925142e` — `arm64`, `arm64-simulator`,
+  `arm64-maccatalyst`, `x86_64-maccatalyst`, `x86_64`. `armv7` and `i386` are dead and were not.
+  **They are built but not yet vendored**: the submodule still carries the 2021 binaries.
+- **Nothing has been run on a physical device** — ES 3.0 on the Metal backend is confirmed on the
+  simulator only, and Catalyst was rebuilt but not launched. The checklist is in
+  [Graphics API migration](../internals/rendering/16-graphics-api-migration.md#what-still-needs-a-physical-device).
 - MetalANGLE's own README grades its ES 3.0 at 90% — primitive restart and last-provoking-vertex
-  flat shading are unimplemented. Not yet checked against what this renderer draws.
+  flat shading are unimplemented. Checked against this renderer: **neither is used** (no
+  `PRIMITIVE_RESTART` call sites, no `flat` qualifiers in the vt shaders), so the gap does not bite
+  today. Re-check if either appears.

--- a/docs/maintenance/angle.md
+++ b/docs/maintenance/angle.md
@@ -1,0 +1,141 @@
+---
+title: Rebuilding the ANGLE slices
+description: How to rebuild the vendored MetalANGLE static libraries for iOS, the simulator and Mac Catalyst, and the fork patches that must survive.
+---
+
+# Rebuilding the ANGLE slices
+
+`libs-external/angle-metal` is a **nested submodule** (`massif-maps/angle-metal`) that contains
+prebuilt binaries only — one `libangle.a` per architecture plus the headers. There is no ANGLE
+source in it, so "updating ANGLE" means building the `.a` files elsewhere and dropping them in.
+
+Why MetalANGLE rather than upstream `google/angle`, and what it costs, is in
+[Graphics API migration](../internals/rendering/16-graphics-api-migration.md). The short version:
+MetalANGLE ships an Xcode project, so this page is `xcodebuild` and nothing else — upstream would
+need depot_tools, gclient and a ~10 GB sync.
+
+Verified 2026-08-18 with Xcode 26.5 (17F42), `iPhoneSimulator26.5.sdk`, on macOS 15 / arm64,
+building `kakashidinho/metalangle` master `ec925142e`.
+
+## Layout
+
+| Path | Contents |
+|---|---|
+| `libs-external/angle-metal/<arch>/libangle.a` | the static slice; `<arch>` is `arm64`, `arm64-simulator`, `arm64-maccatalyst`, `x86_64`, `x86_64-maccatalyst` |
+| `libs-external/angle-metal/include/` | `EGL/ GLES/ GLES2/ GLES3/ KHR/`, `angle_gl.h`, `export.h`, and the `MGL*.h` MGLKit headers |
+
+`scripts/ios-dev/bootstrap.sh` symlinks `.angle` at one of those arch directories and
+`project.yml` links `$(SRCROOT)/.angle/libangle.a`, so switching slice is a symlink swap and a
+relink — no reconfigure.
+
+## Build
+
+```sh
+git clone https://github.com/kakashidinho/metalangle.git
+cd metalangle/ios/xcode
+./fetchDependencies.sh
+```
+
+`fetchDependencies.sh` clones four pinned revisions (glslang, SPIRV-Cross, jsoncpp and its source)
+from the chromium.googlesource.com mirrors into `third_party/`. It only clones; nothing is executed.
+
+Then one `xcodebuild` per slice. The settings after `build` are **not optional** — they are what
+turns a 446 MB archive into the ~14 MB slice that ships, and what makes the symbols link from a
+static library into dependent projects:
+
+```sh
+xcodebuild -project OpenGLES.xcodeproj -target MetalANGLE_static \
+  -configuration Release -arch arm64 -sdk iphonesimulator \
+  IPHONEOS_DEPLOYMENT_TARGET=13.0 \
+  ONLY_ACTIVE_ARCH=YES \
+  DEPLOYMENT_POSTPROCESSING=YES STRIP_INSTALLED_PRODUCT=YES STRIP_STYLE=non-global \
+  GENERATE_MASTER_OBJECT_FILE=YES KEEP_PRIVATE_EXTERNS=NO \
+  GCC_SYMBOLS_PRIVATE_EXTERN=NO GCC_INLINES_ARE_PRIVATE_EXTERN=YES \
+  GCC_PREPROCESSOR_DEFINITIONS='$(inherited) ANGLE_PLATFORM_EXPORT= ANGLE_EXPORT= ANGLE_UTIL_EXPORT=' \
+  GCC_ENABLE_CPP_EXCEPTIONS=YES GCC_ENABLE_CPP_RTTI=YES GCC_ENABLE_OBJC_EXCEPTIONS=YES \
+  build
+```
+
+Output: `build/Release-iphonesimulator/libMetalANGLE_static.a` → copy to
+`libs-external/angle-metal/arm64-simulator/libangle.a` (note the rename).
+
+Per slice, change `-sdk` and `-arch`:
+
+| Slice | `-sdk` | `-arch` | Output dir |
+|---|---|---|---|
+| `arm64-simulator` | `iphonesimulator` | `arm64` | `Release-iphonesimulator` |
+| `arm64` | `iphoneos` | `arm64` | `Release-iphoneos` |
+| `x86_64` | `iphonesimulator` | `x86_64` | `Release-iphonesimulator` |
+
+Mac Catalyst uses the scheme rather than the target, and is then split with `lipo`:
+
+```sh
+xcodebuild -project OpenGLES.xcodeproj -scheme MetalANGLE_static -sdk macosx \
+  -configuration Release -destination 'platform=macOS,variant=Mac Catalyst' \
+  build SUPPORTS_MACCATALYST=YES
+lipo <output>/libMetalANGLE_static.a -extract arm64  -output libangle.a   # -> arm64-maccatalyst/
+lipo <output>/libMetalANGLE_static.a -extract x86_64 -output libangle.a   # -> x86_64-maccatalyst/
+```
+
+See [Mac Catalyst](mac-catalyst.md) for why those slices behave like a macOS build at link time.
+
+`armv7` and `i386` slices still exist in the submodule and are dead — the deployment floor is
+iOS 13.0. Do not rebuild them.
+
+### Why each strip setting is there
+
+Without them the archive keeps every object's debug info and every private symbol:
+**446 MB unstripped vs 14.2 MB with them**, for the same code. `GENERATE_MASTER_OBJECT_FILE`
+(single-object prelink) plus `STRIP_STYLE=non-global` is the pair that does most of it.
+`GCC_SYMBOLS_PRIVATE_EXTERN=NO` must stay `NO` or the SDK cannot see the GL entry points.
+The three empty `*_EXPORT=` macros neutralise ANGLE's dllexport attributes, which are meaningless
+in a static library and produce visibility warnings otherwise.
+
+C++/ObjC exceptions must be **on**: they are off by default for this project, and a build with them
+off breaks exception propagation in *dependent* projects, not in ANGLE itself.
+
+## Fork patches that must survive an update
+
+Only one, and it is in the headers rather than the source:
+
+- **`include/MGLContext.h`** — the `#include "EGL/egl.h"` is commented out and `eglDisplay` is typed
+  `void*` instead of `EGLDisplay`, so that including `MGLContext.h` does not drag EGL's headers into
+  the SDK's Objective-C surface. Re-apply after copying headers from a new MetalANGLE checkout; the
+  rest of `include/` is byte-identical to the upstream tree.
+
+The `angle-metal` README also documents an ES2-downgrade patch (`kEAGLRenderingAPIOpenGLES3` →
+`...ES2` in `DisplayEAGL.mm`) for 32-bit devices. **Do not re-apply it** — it caps the context at
+ES 2.0, which is the opposite of where the SDK is going, and the devices it was for are below the
+deployment floor.
+
+## Checking the result
+
+Launch anything that creates a map and read the two startup lines:
+
+```
+GLContext::LoadExtensions: OpenGL ES 3.0.0 (ANGLE 2.1.0.ec925142edeb), depth texture 1, shadow samplers 0
+MapRenderer::onSurfaceCreated: renderer 'ANGLE (Metal Renderer: Apple iOS simulator GPU)', depth bits 24, stencil bits 8
+```
+
+The **commit suffix on the ANGLE version is how you tell slices apart** — the 2021 vendored build
+reports a bare `ANGLE 2.1.0.` with nothing after the last dot. If you swapped the `.a` and the
+suffix did not change, the link picked up the old one.
+
+`scripts/ios-dev` is the fastest way to exercise it:
+
+```sh
+cd scripts/ios-dev && ./bootstrap.sh
+xcodebuild -project MassifDemo.xcodeproj -scheme MassifDemo -sdk iphonesimulator \
+  -destination 'id=<simulator-udid>' build
+```
+
+`-destination` needs the UDID from `xcrun simctl list devices available`; the by-name form fails
+with *"no available devices matched the request"* even when the name is right.
+
+## Known gaps
+
+- Only `arm64-simulator` has actually been rebuilt at master. The device, x86_64 and Catalyst slices
+  in the submodule are still the 2021 `8ef9aba` builds.
+- No device run: ES 3.0 on the Metal backend is confirmed on the simulator only.
+- MetalANGLE's own README grades its ES 3.0 at 90% — primitive restart and last-provoking-vertex
+  flat shading are unimplemented. Not yet checked against what this renderer draws.

--- a/docs/maintenance/index.md
+++ b/docs/maintenance/index.md
@@ -14,3 +14,4 @@ they were run with, what breaks when a step is skipped, and the dead ends.
 |------|----------------|
 | [`valhalla-upgrade.md`](valhalla-upgrade.md) | Merging a new upstream Valhalla release into `mbtiles-support`, regenerating protos / locales / the tz database, and the fork patches that must survive |
 | [`mac-catalyst.md`](mac-catalyst.md) | Why the Catalyst slices are a macOS project in disguise, what that breaks at link time, and what the build gives up to work around it |
+| [`angle.md`](angle.md) | Rebuilding the vendored MetalANGLE static slices, the strip settings that make them shippable, and the one fork patch to re-apply |

--- a/ios/objc/MassifMaps.h
+++ b/ios/objc/MassifMaps.h
@@ -39,7 +39,7 @@
 #import "MSFTileDownloadListener.h"
 #import "MSFMultiTileDataSource.h"
 #import "MSFPMTilesTileDataSource.h"
-#import "MSFPContourTileDataSource.h"
+#import "MSFContourTileDataSource.h"
 
 #import "MSFFeature.h"
 #import "MSFFeatureCollection.h"

--- a/scripts/ios-dev/MassifDemo/DemoConfig.m
+++ b/scripts/ios-dev/MassifDemo/DemoConfig.m
@@ -75,9 +75,11 @@ static NSMutableDictionary *sValues = nil;
 
         // --- fog / view distance / sky ---
         @"fog":                 @NO,
-        @"fogStart":            @1500.0f,
-        @"fogDistance":         @0.0f,
-        @"fogBlend":            @12.0f,
+        // Ranges are multiples of the camera-to-focus distance, not metres, so one pair holds at
+        // every zoom. Same names and values as the Android demo's FOG_* fields.
+        @"fogRangeStart":       @0.8f,
+        @"fogRangeEnd":         @8.0f,
+        @"fogBlend":            @(12.0f / 90.0f),
         @"fogHorizon":          @(-1.0f),
         @"viewDistance":        @1.0f,
         @"viewDistanceMeters":  @170000.0f,

--- a/scripts/ios-dev/MassifDemo/DemoMap.h
+++ b/scripts/ios-dev/MassifDemo/DemoMap.h
@@ -50,6 +50,7 @@ typedef NS_ENUM(NSInteger, DemoFeature) {
 @property (nonatomic, readonly) MSFTerrainOptions *terrainOptions;
 @property (nonatomic, readonly) MSFLightOptions *lightOptions;
 @property (nonatomic, readonly) MSFSkyOptions *skyOptions;
+@property (nonatomic, readonly) MSFFogOptions *fogOptions;
 /** Sun, moon and their daily paths - demo content built on the generic celestial API. */
 @property (nonatomic, readonly) DemoCelestial *celestial;
 /** The bright-star catalogue, the constellation figures and the planets - same API. */
@@ -80,6 +81,7 @@ typedef NS_ENUM(NSInteger, DemoFeature) {
 - (void)applyTerrainOptions;
 - (void)applyLightOptions;
 - (void)applySkyOptions;
+- (void)applyFogOptions;
 - (void)applyHillshadeConfig;
 - (void)applyContourConfig;
 - (void)applyDebugConfig;

--- a/scripts/ios-dev/MassifDemo/DemoMap.m
+++ b/scripts/ios-dev/MassifDemo/DemoMap.m
@@ -806,10 +806,8 @@ static const DemoFeature LAYER_ORDER[] = {
         [_terrainOptions setMaxTileZoomOffset:[DemoConfig intFor:@"maxTileZoomOffset"]];
     }
     // Fog and view distance go together: the distance ENDS the ground, the fog is what makes it
-    // fade out instead of being cut off.
-    [_terrainOptions setFogColor:[DemoMap colorFromHex:[DemoConfig boolFor:@"fog"] ? @"#b8c6d8" : @"#00000000"]];
-    [_terrainOptions setFogStartDistance:[DemoConfig floatFor:@"fogStart"]];
-    [_terrainOptions setFogDistance:[DemoConfig floatFor:@"fogDistance"]];
+    // fade out instead of being cut off. The fog itself lives on FogOptions now.
+    [self applyFogOptions];
     [_terrainOptions setViewDistanceFactor:[DemoConfig floatFor:@"viewDistance"]];
     [_terrainOptions setViewDistance:[DemoConfig floatFor:@"viewDistanceMeters"]];
     [_terrainOptions setMaxTileZoomCoarsening:[DemoConfig intFor:@"coarsening"]];
@@ -848,6 +846,23 @@ static const DemoFeature LAYER_ORDER[] = {
     [self updateSky];
 }
 
+/** Fog is its own options object and is independent of the terrain - it fogs a plain 2D map too. */
+- (void)applyFogOptions {
+    if (!_fogOptions) {
+        _fogOptions = [[MSFFogOptions alloc] init];
+        [[self.mapView getOptions] setFogOptions:_fogOptions];
+    }
+    [_fogOptions setEnabled:[DemoConfig boolFor:@"fog"]];
+    [_fogOptions setColor:[DemoMap colorFromHex:@"#b8c6d8"]];
+    [_fogOptions setRangeStart:[DemoConfig floatFor:@"fogRangeStart"]];
+    [_fogOptions setRangeEnd:[DemoConfig floatFor:@"fogRangeEnd"]];
+    // How much of the sky the haze takes: HorizonBlend is the fade width, HorizonAngle the angle
+    // it is still at full strength at (negative = from the terrain, 0 = from the horizon).
+    [_fogOptions setHorizonBlend:[DemoConfig floatFor:@"fogBlend"]];
+    [_fogOptions setHorizonAngle:[DemoConfig floatFor:@"fogHorizon"]];
+    [self requestRender];
+}
+
 /** The sky is always attached so the panel can toggle it live; disabled = no sky at all. */
 - (void)applySkyOptions {
     if (!_skyOptions) {
@@ -855,10 +870,6 @@ static const DemoFeature LAYER_ORDER[] = {
         [[self.mapView getOptions] setSkyOptions:_skyOptions];
     }
     [_skyOptions setEnabled:[DemoConfig boolFor:@"sky"]];
-    // How much of the sky the terrain haze takes: FogBlend is the fade width, FogHorizon the angle
-    // it is still at full strength at (negative = from the terrain, 0 = from the horizon).
-    [_skyOptions setFogBlend:[DemoConfig floatFor:@"fogBlend"]];
-    [_skyOptions setFogHorizon:[DemoConfig floatFor:@"fogHorizon"]];
     // In the relief view the sky is part of the palette: a light one over the paper, a night one
     // over the ink.
     if ([DemoConfig boolFor:@"reliefSurface"] || [DemoConfig boolFor:@"peakfinder"]) {

--- a/scripts/ios-dev/MassifDemo/DemoPanel.m
+++ b/scripts/ios-dev/MassifDemo/DemoPanel.m
@@ -129,6 +129,7 @@ typedef NS_ENUM(NSInteger, DemoEntryKind) {
     void (^terrain)(void) = ^{ [demo applyTerrainOptions]; };
     void (^light)(void) = ^{ [demo applyLightOptions]; };
     void (^sky)(void) = ^{ [demo applySkyOptions]; };
+    void (^fog)(void) = ^{ [demo applyFogOptions]; };
     void (^hillshade)(void) = ^{ [demo applyHillshadeConfig]; };
     void (^contours)(void) = ^{ [demo applyContourConfig]; };
     void (^camera)(void) = ^{ [demo applyCamera]; };
@@ -324,13 +325,14 @@ typedef NS_ENUM(NSInteger, DemoEntryKind) {
         ]],
         [self section:@"SKY" entries:@[
             [DemoEntry toggle:@"sky" label:@"sky" apply:sky],
-            [DemoEntry slider:@"fogBlend" label:@"sky fog blend (deg)" min:0 max:45 apply:sky],
-            [DemoEntry slider:@"fogHorizon" label:@"sky fog horizon (deg, <0=auto)" min:-1 max:30 apply:sky],
+            [DemoEntry slider:@"fogBlend" label:@"sky fog blend (0-1)" min:0 max:0.5 apply:fog],
+            [DemoEntry slider:@"fogHorizon" label:@"sky fog horizon (deg, <0=auto)" min:-1 max:30 apply:fog],
         ]],
         [self section:@"FOG / DISTANCE" entries:@[
-            [DemoEntry toggle:@"fog" label:@"fog" apply:terrain],
-            [DemoEntry slider:@"fogStart" label:@"fog start (m)" min:0 max:40000 apply:terrain],
-            [DemoEntry slider:@"fogDistance" label:@"fog distance (m, 0=off)" min:0 max:120000 apply:terrain],
+            [DemoEntry toggle:@"fog" label:@"fog" apply:fog],
+            // Multiples of the camera-to-focus distance, so one pair holds at every zoom.
+            [DemoEntry slider:@"fogRangeStart" label:@"fog range start (x cam dist)" min:0 max:4 apply:fog],
+            [DemoEntry slider:@"fogRangeEnd" label:@"fog range end (x cam dist)" min:0 max:20 apply:fog],
             [DemoEntry slider:@"lodFactor" label:@"tile LOD (x tangram)" min:0 max:4 apply:^{
                 [demo applyOptions];
             }],

--- a/scripts/ios-dev/README.md
+++ b/scripts/ios-dev/README.md
@@ -8,10 +8,18 @@ gradle gives on Android.
 ## Setup
 
 ```sh
-./bootstrap.sh              # arm64 simulator (the usual dev target)
-./bootstrap.sh device       # arm64 device
-PROFILE=lite ./bootstrap.sh # a different feature profile
+./bootstrap.sh                  # arm64 simulator (the usual dev target)
+./bootstrap.sh device           # arm64 device
+PROFILE=lite ./bootstrap.sh     # a different feature profile
+PROFILE_RENDER=1 ./bootstrap.sh # per-frame timings, android-dev's -PprofileRender
 ```
+
+`PROFILE_RENDER=1` compiles in `MASSIF_FRAME_PROFILER` and `MASSIF_VT_RENDER_STATS` — the per-frame
+section timings and the vt draw/label/tile counters, printed as `PROF` and `RenderStats` lines.
+Neither exists in the binary otherwise, so switching it is a re-bootstrap, not a launch argument.
+Read them with `xcrun simctl spawn <udid> log stream` on the simulator, or the device console.
+Method for an A/B is [`scripts/android-dev/bench/README.md`](../android-dev/bench/README.md): the
+numbers drift, so only interleaved runs with medians over many windows count.
 
 That regenerates the Objective-C bindings, configures the SDK with CMake's Xcode generator, and
 writes `MassifDemo.xcodeproj` with [XcodeGen](https://github.com/yonaskolb/XcodeGen) (`brew install

--- a/scripts/ios-dev/bootstrap.sh
+++ b/scripts/ios-dev/bootstrap.sh
@@ -5,6 +5,7 @@
 #   ./bootstrap.sh                  # arm64 simulator (the usual dev target)
 #   ./bootstrap.sh device           # arm64 device
 #   PROFILE=lite ./bootstrap.sh     # a different feature profile
+#   PROFILE_RENDER=1 ./bootstrap.sh # per-frame timings, the counterpart of -PprofileRender
 #
 # Re-run it after changing the profile or the platform. Day to day you do not: once the project
 # exists, build from Xcode or with 'xcodebuild -project MassifDemo.xcodeproj'.
@@ -23,6 +24,17 @@ case "${1:-simulator}" in
 esac
 ARCH=arm64
 BUILD_DIR="$BASE_DIR/build/ios_metal-$PLATFORM-$ARCH"
+
+# Render profiling, off unless asked for - the counterpart of android-dev's '-PprofileRender'.
+# Turns on the per-frame section timings (utils/FrameProfiler.h) and the vt draw/label/tile
+# counters (vt/RenderStats.h); neither exists in the binary otherwise. Read the 'PROF' and
+# 'RenderStats' lines with 'xcrun simctl spawn <udid> log stream' or the device console.
+# Changing it needs this re-run: it is a compile-time flag, not a launch argument.
+PROFILER_DEFINES=""
+if [ -n "$PROFILE_RENDER" ]; then
+  PROFILER_DEFINES="-DMASSIF_FRAME_PROFILER=1 -DMASSIF_VT_RENDER_STATS=1"
+  echo "==> Render profiling ON"
+fi
 
 if [ ! -x "$SWIG" ]; then
   echo "SWIG executable not found at $SWIG - set SWIG=/path/to/mobile-swig/swig" >&2
@@ -60,7 +72,7 @@ cmake -G Xcode $OPTIONS \
   -DSINGLE_LIBRARY:BOOL=ON \
   -DSHARED_LIBRARY:BOOL=OFF \
   -DWRAPPER_DIR="$BASE_DIR/generated/ios-objc/proxies" \
-  -DSDK_CPP_DEFINES="$DEFINES -D_MASSIF_USE_METALANGLE -DZSTD_STATIC_LINKING_ONLY" \
+  -DSDK_CPP_DEFINES="$DEFINES -D_MASSIF_USE_METALANGLE -DZSTD_STATIC_LINKING_ONLY $PROFILER_DEFINES" \
   -DSDK_VERSION=Devel \
   -DSDK_PLATFORM=iOS \
   -DSDK_IOS_ARCH="$ARCH" \


### PR DESCRIPTION
## Summary

Phase 0 of #126 — the decision gates, plus the two build breakages hit on the way in.

- **The iOS build was broken on `master`.** `ios/objc/MassifMaps.h` imports `MSFPContourTileDataSource.h`; SWIG generates `MSFContourTileDataSource.h`. Stray `P`, copy-pasted from the `MSFPMTilesTileDataSource` line above it, and it fails at the first file that includes the umbrella header. This is the only change here an SDK user sees.
- **`scripts/ios-dev` predated the FogOptions migration** and no longer compiled: it still drove fog through `TerrainOptions.FogColor/FogStartDistance/FogDistance` and `SkyOptions.FogBlend/FogHorizon`. Ported to `MSFFogOptions` mirroring `DemoMap.java`, including the unit change — ranges are multiples of the camera-to-focus distance now, so `fogStart 1500` becomes `fogRangeStart 0.8`.
- **`PROFILE_RENDER=1 ./bootstrap.sh`**, the iOS counterpart of android-dev's `-PprofileRender`. The iOS demo had no way to get per-section frame timings at all, which is exactly what gate 0.3 turned out to need.
- **Phase 0 results recorded**, plus a new `docs/maintenance/angle.md` with the ANGLE rebuild procedure.

No renderer or SDK behaviour changes. Nothing is re-vendored: `libs-external/angle-metal` still carries the 2021 binaries, so what ships is unchanged.

### Phase 0 outcomes

| gate | result |
|---|---|
| 0.1 build + run ES 3.0 on ANGLE/Metal | **pass** (simulator) |
| 0.2 does ANGLE accept `#define gl_FragColor` | **yes** — Phase 3 is *not* a breaking change |
| 0.3 frame-time A/B vs EAGL | **not answered** — needs a device |

Two findings worth a reviewer's attention:

**Gate 0.2 reverses a plan assumption.** ANGLE's translator accepts and *applies* `#define gl_FragColor TANGRAM_FragColor` — the app's write comes out as `_uTANGRAM_FragColor = …`. So the comment in `GLTileRenderer::createShaderProgram` ("a name starting with `gl_` cannot be `#define`d") is wrong: ESSL reserves the `GL_` prefix for *macro* names, and `gl_FragColor` is a built-in *variable* that ESSL 3.00 does not declare. Phase 3 can take tangram's preamble verbatim, and the five public GLSL setters need no migration.

**Gate 0.3 is recorded as unanswered rather than passed.** The EAGL leg cannot run on an Apple Silicon simulator — it has no OpenGL ES at all. The leg that could run saturated: four interleaved 75 s runs returned exactly 60.0 fps for *both* builds, which is the vsync cap, not a tie. A capped test proves nothing either way, so the native-Metal question is deferred, not closed.

The source decision also changed: **MetalANGLE master rather than upstream ANGLE**, because the fork ships an Xcode project where upstream needs depot_tools and a ~10 GB sync. The costs are stated in the page rather than glossed — ES 3.0 at 90% upstream-of-us, two vendored ANGLE forks kept, and Phase 5 needing upstream anyway for Win32/AppKit.

## Testing

- No C++ touched, so `-fsyntax-only` does not apply. The changes are Objective-C (demo), shell, and docs.
- `scripts/ios-dev` **builds and runs** on the iPhone 16 Pro simulator: ES 3.0 context on the Metal backend, map renders, frame identical to the pre-change build bar the status-bar clock (1259/3162132 px). That covers both build fixes.
- `PROFILE_RENDER=1` verified by configuring with it and grepping the generated Xcode project for `MASSIF_FRAME_PROFILER=1` / `MASSIF_VT_RENDER_STATS=1` (8 hits each) — `add_definitions` runs before the subprojects, so it reaches `vt` too. Not assumed from reading the CMake.
- `cd website && npm run build` clean, no broken-link block.
- **Not verified on a physical device.** Nothing in this PR ships to devices, but the Phase 0 findings are simulator-only and the page says so. The device checklist is in the migration page under "What still needs a physical device"; the camera for gate 0.3 is the city one, since the expected cost is per-draw (uniform volume), not shader translation.

Refs #126