### PR TITLE
feat!: compile the shaders as GLSL ES 3.00, keeping app shaders unchanged

### DIFF
--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -596,6 +596,14 @@ namespace massif {
             return false;
         }
 
+        // vt has no logger of its own, so the fallback is invisible without this. It means a
+        // program would not build at '#version 300 es' and was rebuilt at 1.00 - the map still
+        // draws, which is exactly why it needs saying out loud.
+        if (!_essl3FallbackReported && tileRenderer->hasShaderVersionFallback()) {
+            _essl3FallbackReported = true;
+            Log::Warn("TileRenderer: a shader fell back from GLSL ES 3.00 to 1.00");
+        }
+
         cglib::mat4x4<double> modelViewMat = viewState.getModelviewMat() * cglib::translate4_matrix(cglib::vec3<double>(_horizontalLayerOffset, 0, 0));
         vt::ViewState vtViewState(viewState.getProjectionMat(), modelViewMat, viewState.getZoom(), viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewState.getNormalizedResolution());
         vtViewState.planarProjection = isPlanarProjectionMode(); // labels rescale by view depth, so neither terrain elevation nor a tilt blows up their screen size

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -252,6 +252,7 @@ namespace massif {
         float _hillshadeExaggeration;
         float _hillshadeIntensity;
         bool _terrainDepthWriteMode = false;
+        bool _essl3FallbackReported = false;  // the ESSL 3.00 -> 1.00 fallback warning is logged once
         bool _terrainPaintEnabled = false; // this renderer shades the DEM instead of drawing tiles
         bool _terrainPaintFullDetail = true; // shade from the DEM's own max zoom, not the mesh's level
         bool prepareFrameUnsafe(float deltaSeconds, const ViewState& viewState); // caller holds _mutex

--- a/all/native/renderers/utils/Shader.cpp
+++ b/all/native/renderers/utils/Shader.cpp
@@ -2,9 +2,54 @@
 #include "renderers/utils/GLResourceManager.h"
 #include "utils/Log.h"
 
+#include <cstdlib>
 #include <vector>
 
 namespace massif {
+
+    namespace {
+        // tangram's preamble, verbatim from core/src/gl/shaderSource.cpp. The shader sources - and
+        // the application GLSL spliced into them through SkyOptions/FogOptions/TerrainOptions/
+        // CustomRasterTileLayer/PostProcessEffect - stay written in ESSL 1.00 and are translated
+        // here, so an app's shader needs no migration.
+        //
+        // '#define gl_FragColor' is legal: ESSL reserves the GL_ prefix for MACRO names, while
+        // gl_FragColor is a built-in variable that ESSL 3.00 does not declare. Measured through
+        // ANGLE's translator, not assumed - see docs/internals/rendering/16-graphics-api-migration.md.
+        const std::string ESSL3_VERSION = "#version 300 es\n";
+
+        const std::string ESSL3_VERT_HEADER = R"GLSL(
+#define texture2D texture
+#define attribute in
+#define varying out
+)GLSL";
+
+        const std::string ESSL3_FRAG_HEADER = R"GLSL(
+#define texture2D texture
+#define varying in
+#define gl_FragColor TANGRAM_FragColor
+layout (location = 0) out highp vec4 TANGRAM_FragColor;
+)GLSL";
+    }
+
+    std::string Shader::TranslateToESSL3(const std::string& source, GLenum shaderType) {
+        const std::string& header = (shaderType == GL_VERTEX_SHADER ? ESSL3_VERT_HEADER : ESSL3_FRAG_HEADER);
+
+        // '#version' must be on the FIRST LINE - not merely preceded by whitespace. These sources
+        // are raw literals that open with a newline and an indent, so the directive is emitted at
+        // offset 0 and whatever came before it is pushed after the header.
+        std::size_t versionPos = source.find("#version");
+        if (versionPos == std::string::npos) {
+            return ESSL3_VERSION + header + source;
+        }
+        std::size_t eol = source.find('\n', versionPos);
+        if (eol == std::string::npos) {
+            eol = source.size();
+        } else {
+            eol += 1;
+        }
+        return ESSL3_VERSION + header + source.substr(0, versionPos) + source.substr(eol);
+    }
 
     Shader::~Shader() {
     }
@@ -150,7 +195,8 @@ namespace massif {
             return 0;
         }
 
-        const char* sourceBuf = source.c_str();
+        std::string translatedSource = TranslateToESSL3(source, shaderType);
+        const char* sourceBuf = translatedSource.c_str();
         glShaderSource(shaderId, 1, &sourceBuf, NULL);
 
         glCompileShader(shaderId);
@@ -165,6 +211,23 @@ namespace massif {
                 glGetShaderInfoLog(shaderId, infoLen, &charsWritten, infoBuf.data());
                 std::string msg(infoBuf.begin(), infoBuf.begin() + charsWritten);
                 Log::Errorf("Shader::LoadShader: Failed to compile shader type %i in '%s' shader \n Error: %s", shaderType, name.c_str(), msg.c_str());
+                // The reported line is into the TRANSLATED source, which nothing on disk matches -
+                // quote it, or every compile error costs a round of guessing.
+                std::size_t colon = msg.find(':');
+                if (colon != std::string::npos) {
+                    int line = std::atoi(msg.c_str() + colon + 1);
+                    std::size_t pos = 0;
+                    for (int i = 1; i < line && pos != std::string::npos; i++) {
+                        pos = translatedSource.find('\n', pos);
+                        if (pos != std::string::npos) {
+                            pos++;
+                        }
+                    }
+                    if (pos != std::string::npos && line > 0) {
+                        std::size_t eol = translatedSource.find('\n', pos);
+                        Log::Errorf("Shader::LoadShader: line %d is: %s", line, translatedSource.substr(pos, eol == std::string::npos ? eol : eol - pos).c_str());
+                    }
+                }
             }
             glDeleteShader(shaderId);
             shaderId = 0;

--- a/all/native/renderers/utils/Shader.h
+++ b/all/native/renderers/utils/Shader.h
@@ -32,6 +32,10 @@ namespace massif {
         virtual void destroy();
 
     private:
+        // Rewrites a '#version 100' shader to ESSL 3.00 with tangram's preamble, so the sources
+        // stay written once. See Shader.cpp for why the shaders are not migrated by hand.
+        static std::string TranslateToESSL3(const std::string& source, GLenum shaderType);
+
         static GLuint LoadProg(const std::string& name, GLuint vertShaderId, GLuint fragShaderId);
         static GLuint LoadShader(const std::string& name, const std::string& source, GLenum shaderType);
 

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -11,9 +11,10 @@ move to an OpenGL ES 3.0 baseline (dropping ES 2.0), the Apple situation (Metal)
 Windows/Linux/macOS need later. Does **not** cover what the renderer draws — that is the rest of
 [this set](index.mdx).
 
-Status as of 2026-08-18: Phase 0 run. Gates 0.1 and 0.2 pass, gate 0.3 is **not answered** — see
-[Phase 0 results](#phase-0--results). The Apple source was decided against upstream ANGLE, see
-[MetalANGLE master, not upstream](#metalangle-master-not-upstream-angle).
+Status as of 2026-08-18: Phase 0 run — gates 0.1 and 0.2 pass, gate 0.3 is **not answered** (see
+[Phase 0 results](#phase-0--results)). Phases 2 and 3 are code-complete; Phase 3 is verified on the
+iOS simulator, and **neither is verified on hardware**. The Apple source was decided against
+upstream ANGLE, see [MetalANGLE master, not upstream](#metalangle-master-not-upstream-angle).
 
 ## Where we are
 
@@ -361,16 +362,57 @@ has been rendered on hardware.
 
 ### Phase 3 — GLSL ES 3.00
 
-The reference is already in the tree, and it is tangram, not mapbox-gl-js:
-`core/src/gl/shaderSource.cpp` gates `#version 300 es` plus a vertex/fragment header on
-`Hardware::glVersion >= 300`.
+Done on the simulator; the device leg is still owed. tangram's preamble
+(`core/src/gl/shaderSource.cpp`) is ported verbatim into three places, and **not one of the 27
+shader literals was edited** — they stay written in ESSL 1.00 and are translated on the way to the
+driver, which is what keeps application GLSL working unchanged:
 
-- Port that preamble into `all/native/renderers/utils/Shader.cpp`; flip `ESSL3_FLAG` on globally in
-  `vt`; same for `nml`.
-- Keep `vt`'s per-program 1.00 fallback for one release as the canary, then delete it.
+| Where | How |
+|---|---|
+| `all/native` | `Shader::TranslateToESSL3` rewrites the source in `LoadShader` |
+| `vt` | `buildShaderProgram` ORs in `ESSL3_FLAG` for every program, not at the 20-odd call sites |
+| `nml` | `GLResourceManager::createShader` gained a shader-type parameter so it can pick the right header |
+
+Because the app's GLSL is spliced *into* the SDK's own literals, one translation point covers all
+five public setters. `vt`'s per-program 1.00 fallback stays one release as a canary.
+
+**`hasShaderVersionFallback()` had no callers.** vt sets `_essl3Failed` with the comment "the owner
+logs it once", and no owner ever did — so the phase's own success criterion was unobservable.
+`TileRenderer::onDrawFrame` now logs it once. Without that, a program silently rebuilt at 1.00 looks
+exactly like success: the map still draws.
+
+#### `#version` must be on the first line, not merely preceded by whitespace
+
+The one real trap, and it failed *every* shader on the first run:
+
+```
+ERROR: 0:2: '' : #version directive must occur on the first line of the shader
+```
+
+The shader literals are raw strings that open with a newline and an indent, so replacing the
+`#version 100` line in place leaves the new directive on line 2. Whitespace on the *same* line is
+allowed; a preceding newline is not. The directive is emitted at offset 0 and whatever preceded it
+is pushed after the header.
+
+Worth noting how this was caught: the Android build was **green**, because a C++ build never
+compiles a shader — that happens at runtime. Only running it found this.
 
 **Done when**: every program compiles at `300 es` on both device families and
 `hasShaderVersionFallback()` returns false.
+
+Where that stands, measured on the iPhone 16 Pro simulator through ANGLE (the strict translator) at
+lon 5.7606 / lat 45.2442 / z13.6 / tilt 55, terrain on:
+
+| | |
+|---|---|
+| shader compile / link failures | **0** |
+| ESSL 3.00 → 1.00 fallbacks | **0** |
+| GL errors | **0** |
+| frame vs the ESSL 1.00 build, identical launch args | **every map band 0.00% different** |
+
+The only differing pixels are the status-bar clock and the home indicator — 0.28% of the frame, all
+of it iOS chrome. Still owed: the same on an Adreno 610 and a real iOS device, where the drivers are
+not ANGLE.
 
 #### The `gl_FragColor` disagreement — settled, tangram was right
 

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -12,9 +12,9 @@ Windows/Linux/macOS need later. Does **not** cover what the renderer draws — t
 [this set](index.mdx).
 
 Status as of 2026-08-18: Phase 0 run — gates 0.1 and 0.2 pass, gate 0.3 is **not answered** (see
-[Phase 0 results](#phase-0--results)). Phases 2 and 3 are code-complete; Phase 3 is verified on the
-iOS simulator, and **neither is verified on hardware**. The Apple source was decided against
-upstream ANGLE, see [MetalANGLE master, not upstream](#metalangle-master-not-upstream-angle).
+[Phase 0 results](#phase-0--results)). Phases 2 and 3 are done and **verified on an Adreno 610
+device**; an iOS device is still owed. The Apple source was decided against upstream ANGLE, see
+[MetalANGLE master, not upstream](#metalangle-master-not-upstream-angle).
 
 ## Where we are
 
@@ -357,8 +357,9 @@ iOS 13 floor — where every device is A7+ — that is a rounding error. The app
 in [migration.md](../../migration.md#opengl-es-30-is-required).
 
 **Done when**: an Adreno 610 device and one iOS device show no regression at the bench cameras.
-Neither has been run — the Android APK builds and the manifest merges at `0x00030000`, but nothing
-has been rendered on hardware.
+The Adreno 610 leg is done — see [Phase 3](#phase-3--glsl-es-300), which was verified on the same
+device and run, and exercises this phase's context and capability changes on the way. An iOS device
+is still owed.
 
 ### Phase 3 — GLSL ES 3.00
 
@@ -400,19 +401,31 @@ compiles a shader — that happens at runtime. Only running it found this.
 **Done when**: every program compiles at `300 es` on both device families and
 `hasShaderVersionFallback()` returns false.
 
-Where that stands, measured on the iPhone 16 Pro simulator through ANGLE (the strict translator) at
-lon 5.7606 / lat 45.2442 / z13.6 / tilt 55, terrain on:
+Measured at lon 5.7606 / lat 45.2442 / z13.6 / tilt 55, terrain on, on two unrelated GL stacks:
 
-| | |
-|---|---|
-| shader compile / link failures | **0** |
-| ESSL 3.00 → 1.00 fallbacks | **0** |
-| GL errors | **0** |
-| frame vs the ESSL 1.00 build, identical launch args | **every map band 0.00% different** |
+| | iPhone 16 Pro simulator (ANGLE/Metal) | Crosscall HLTE556N, **Adreno 610**, ES 3.2 |
+|---|---|---|
+| shader compile / link failures | 0 | **0** |
+| ESSL 3.00 → 1.00 fallbacks | 0 | **0** |
+| GL errors | 0 | **0** |
+| frame vs the ESSL 1.00 build | every map band 0.00% | see below |
 
-The only differing pixels are the status-bar clock and the home indicator — 0.28% of the frame, all
-of it iOS chrome. Still owed: the same on an Adreno 610 and a real iOS device, where the drivers are
-not ANGLE.
+The Adreno is the one that matters, because its driver is a real Qualcomm GLSL compiler rather than
+ANGLE's translator, and it is where `GLContext::VERSION` first met a vendor version string —
+`OpenGL ES 3.2 V@0502.0 (GIT@...)` parses to `320`, as tangram's parser is meant to.
+
+The device A/B needs its control quoted or it says nothing. Same build run twice differs by 0.19%
+of sampled pixels (labels are placed as tiles arrive, so no two runs match exactly). ESSL 1.00 vs
+3.00 differs by 0.37%, and the per-band profile is the same shape — the excess is confined to
+glyph pixels, black text against landcover green in both directions, i.e. sub-pixel label
+antialiasing. Cropped and compared by eye, the two frames are indistinguishable: same contours, same
+labels, same positions.
+
+One thing the A/B settled that inspection alone would not: a **route line that draws in broken
+chunks** over terrain is present *identically in both builds*. It is the known open terrain
+line-following issue, not a regression from this phase.
+
+Still owed: a real iOS device (Apple's driver, not the simulator's).
 
 #### The `gl_FragColor` disagreement — settled, tangram was right
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -163,8 +163,22 @@ Devices lost are pre-2013 GPUs: Mali-400, Adreno 200/305, Tegra 3, PowerVR SGX. 
 an iOS 13 floor — where every device is A7 or newer — that is a rounding error. On desktop the
 equivalent floor is D3D feature level 10_1 (Sandy Bridge, 2011), which Windows 11 already exceeds.
 
-The shaders are unaffected: they are still GLSL ES 1.00, which an ES 3.0 context compiles. Moving
-them to `#version 300 es` is a separate, later change.
+### Shaders moved to GLSL ES 3.00 — and your shaders still work
+
+The SDK's shaders now compile as `#version 300 es`. **This is not a breaking change for
+application GLSL.** If you pass a shader to `SkyOptions.shaderSource`, `FogOptions.shaderSource`,
+`TerrainOptions.surfaceShaderSource`, `CustomRasterTileLayer.shaderSource` or `PostProcessEffect`,
+keep writing it exactly as before — `attribute`, `varying`, `texture2D` and `gl_FragColor` all still
+work.
+
+They keep working because the SDK prepends tangram's compatibility preamble, which maps the ESSL
+1.00 spellings onto their 3.00 equivalents, including `#define gl_FragColor`. That is legal: ESSL
+reserves the `GL_` prefix for *macro* names, and `gl_FragColor` is a built-in *variable* that ESSL
+3.00 does not declare.
+
+You may now also use ESSL 3.00 features directly (`in`/`out`, `texture()`, integer operations) — but
+do not declare your own `#version` line, and do not declare a fragment output named
+`TANGRAM_FragColor`, which the preamble already provides at location 0.
 
 ### `LightOptions.shadowDistance` is a factor, not metres
 


### PR DESCRIPTION
## Summary

Phase 3 of #126, tracked in #139. tangram's preamble (`core/src/gl/shaderSource.cpp`) is ported verbatim into three places — and **not one of the 27 shader literals was edited**. They stay written in ESSL 1.00 and are translated on the way to the driver.

| Where | How |
|---|---|
| `all/native` | `Shader::TranslateToESSL3`, applied in `LoadShader` |
| `vt` | `buildShaderProgram` ORs in `ESSL3_FLAG` for every program |
| `nml` | `createShader` gained a shader-type parameter |

Application GLSL is spliced **into** the SDK's own literals, so one translation point covers all five public setters. Gate 0.2 (#141) established the `#define gl_FragColor` form by running it through ANGLE's translator, which is why this is not a breaking change for app shaders.

### Two things worth a reviewer's attention

**`#version` must be on the first line — not merely preceded by whitespace.** The literals are raw strings opening with a newline and an indent, so replacing the directive in place leaves it on line 2 and *every* shader fails:

```
ERROR: 0:2: '' : #version directive must occur on the first line of the shader
```

The Android build was **green** throughout that failure, because a C++ build never compiles a shader — that happens at runtime. Only running it found this.

**`hasShaderVersionFallback()` had no callers.** vt sets `_essl3Failed` with the comment "the owner logs it once", and no owner ever did — so #139's own success criterion was unobservable, and a program silently rebuilt at 1.00 looks exactly like success: the map still draws. `TileRenderer::onDrawFrame` now logs it once.

## Testing

**Verified on device — Crosscall HLTE556N, Adreno 610, OpenGL ES 3.2**, at lon 5.7606 / lat 45.2442 / z13.6 / tilt 55 with terrain on. A real Qualcomm GLSL compiler, not ANGLE's translator:

| | Adreno 610 | iPhone 16 Pro simulator (ANGLE/Metal) |
|---|---|---|
| shader compile / link failures | **0** | 0 |
| ESSL 3.00 → 1.00 fallbacks | **0** | 0 |
| GL errors | **0** | 0 |

The device also exercised `GLContext::VERSION` against a real vendor string for the first time: `OpenGL ES 3.2 V@0502.0 (GIT@...)` parses to `320`, which ANGLE's tidy `OpenGL ES 3.0.0` never tested.

**A/B against the ESSL 1.00 build, with its control** — the number means nothing without it. Same build run twice differs by **0.19%** of sampled pixels, because labels are placed as tiles arrive. ESSL 1.00 vs 3.00 differs by **0.37%**, same per-band profile, and the excess is confined to glyph pixels — black text against landcover green in both directions, i.e. sub-pixel label antialiasing. Cropped and compared by eye, the frames are indistinguishable. On the simulator every map band was 0.00%.

**One thing the A/B settled that inspection would not:** a route line drawing in broken chunks over terrain appears **identically in both builds**, so it is the known open terrain line-following issue rather than a regression here.

Still owed: a real iOS device, where the driver is Apple's rather than the simulator's.

## Depends on

- massif-maps/massif-maps-libs#63 — the `vt`/`nml` half. **Merges first**, then the pointer bump here is rebased onto the merged commit.
- #142 (Phase 2) — this PR is **based on that branch**, not `master`, so the diff shows Phase 3 alone. Retarget once #142 lands. That chain in turn sits on #141.

## Breaking changes

Shaders are compiled as `#version 300 es`. **Application GLSL needs no migration** — keep writing `attribute`, `varying`, `texture2D`, `gl_FragColor`. But an app shader must not declare its own `#version` line, nor a fragment output named `TANGRAM_FragColor`, which the preamble provides at location 0. Migration note in `docs/migration.md`.

Refs #139
Part of #126