### PR TITLE
docs(renderers): close Phase 4 after three measured ES 3.0 experiments came back negative

### DIFF
--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -596,6 +596,14 @@ namespace massif {
             return false;
         }
 
+        // vt has no logger of its own, so the fallback is invisible without this. It means a
+        // program would not build at '#version 300 es' and was rebuilt at 1.00 - the map still
+        // draws, which is exactly why it needs saying out loud.
+        if (!_essl3FallbackReported && tileRenderer->hasShaderVersionFallback()) {
+            _essl3FallbackReported = true;
+            Log::Warn("TileRenderer: a shader fell back from GLSL ES 3.00 to 1.00");
+        }
+
         cglib::mat4x4<double> modelViewMat = viewState.getModelviewMat() * cglib::translate4_matrix(cglib::vec3<double>(_horizontalLayerOffset, 0, 0));
         vt::ViewState vtViewState(viewState.getProjectionMat(), modelViewMat, viewState.getZoom(), viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewState.getNormalizedResolution());
         vtViewState.planarProjection = isPlanarProjectionMode(); // labels rescale by view depth, so neither terrain elevation nor a tilt blows up their screen size

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -252,6 +252,7 @@ namespace massif {
         float _hillshadeExaggeration;
         float _hillshadeIntensity;
         bool _terrainDepthWriteMode = false;
+        bool _essl3FallbackReported = false;  // the ESSL 3.00 -> 1.00 fallback warning is logged once
         bool _terrainPaintEnabled = false; // this renderer shades the DEM instead of drawing tiles
         bool _terrainPaintFullDetail = true; // shade from the DEM's own max zoom, not the mesh's level
         bool prepareFrameUnsafe(float deltaSeconds, const ViewState& viewState); // caller holds _mutex

--- a/all/native/renderers/utils/Shader.cpp
+++ b/all/native/renderers/utils/Shader.cpp
@@ -2,9 +2,54 @@
 #include "renderers/utils/GLResourceManager.h"
 #include "utils/Log.h"
 
+#include <cstdlib>
 #include <vector>
 
 namespace massif {
+
+    namespace {
+        // tangram's preamble, verbatim from core/src/gl/shaderSource.cpp. The shader sources - and
+        // the application GLSL spliced into them through SkyOptions/FogOptions/TerrainOptions/
+        // CustomRasterTileLayer/PostProcessEffect - stay written in ESSL 1.00 and are translated
+        // here, so an app's shader needs no migration.
+        //
+        // '#define gl_FragColor' is legal: ESSL reserves the GL_ prefix for MACRO names, while
+        // gl_FragColor is a built-in variable that ESSL 3.00 does not declare. Measured through
+        // ANGLE's translator, not assumed - see docs/internals/rendering/16-graphics-api-migration.md.
+        const std::string ESSL3_VERSION = "#version 300 es\n";
+
+        const std::string ESSL3_VERT_HEADER = R"GLSL(
+#define texture2D texture
+#define attribute in
+#define varying out
+)GLSL";
+
+        const std::string ESSL3_FRAG_HEADER = R"GLSL(
+#define texture2D texture
+#define varying in
+#define gl_FragColor TANGRAM_FragColor
+layout (location = 0) out highp vec4 TANGRAM_FragColor;
+)GLSL";
+    }
+
+    std::string Shader::TranslateToESSL3(const std::string& source, GLenum shaderType) {
+        const std::string& header = (shaderType == GL_VERTEX_SHADER ? ESSL3_VERT_HEADER : ESSL3_FRAG_HEADER);
+
+        // '#version' must be on the FIRST LINE - not merely preceded by whitespace. These sources
+        // are raw literals that open with a newline and an indent, so the directive is emitted at
+        // offset 0 and whatever came before it is pushed after the header.
+        std::size_t versionPos = source.find("#version");
+        if (versionPos == std::string::npos) {
+            return ESSL3_VERSION + header + source;
+        }
+        std::size_t eol = source.find('\n', versionPos);
+        if (eol == std::string::npos) {
+            eol = source.size();
+        } else {
+            eol += 1;
+        }
+        return ESSL3_VERSION + header + source.substr(0, versionPos) + source.substr(eol);
+    }
 
     Shader::~Shader() {
     }
@@ -150,7 +195,8 @@ namespace massif {
             return 0;
         }
 
-        const char* sourceBuf = source.c_str();
+        std::string translatedSource = TranslateToESSL3(source, shaderType);
+        const char* sourceBuf = translatedSource.c_str();
         glShaderSource(shaderId, 1, &sourceBuf, NULL);
 
         glCompileShader(shaderId);
@@ -165,6 +211,23 @@ namespace massif {
                 glGetShaderInfoLog(shaderId, infoLen, &charsWritten, infoBuf.data());
                 std::string msg(infoBuf.begin(), infoBuf.begin() + charsWritten);
                 Log::Errorf("Shader::LoadShader: Failed to compile shader type %i in '%s' shader \n Error: %s", shaderType, name.c_str(), msg.c_str());
+                // The reported line is into the TRANSLATED source, which nothing on disk matches -
+                // quote it, or every compile error costs a round of guessing.
+                std::size_t colon = msg.find(':');
+                if (colon != std::string::npos) {
+                    int line = std::atoi(msg.c_str() + colon + 1);
+                    std::size_t pos = 0;
+                    for (int i = 1; i < line && pos != std::string::npos; i++) {
+                        pos = translatedSource.find('\n', pos);
+                        if (pos != std::string::npos) {
+                            pos++;
+                        }
+                    }
+                    if (pos != std::string::npos && line > 0) {
+                        std::size_t eol = translatedSource.find('\n', pos);
+                        Log::Errorf("Shader::LoadShader: line %d is: %s", line, translatedSource.substr(pos, eol == std::string::npos ? eol : eol - pos).c_str());
+                    }
+                }
             }
             glDeleteShader(shaderId);
             shaderId = 0;

--- a/all/native/renderers/utils/Shader.h
+++ b/all/native/renderers/utils/Shader.h
@@ -32,6 +32,10 @@ namespace massif {
         virtual void destroy();
 
     private:
+        // Rewrites a '#version 100' shader to ESSL 3.00 with tangram's preamble, so the sources
+        // stay written once. See Shader.cpp for why the shaders are not migrated by hand.
+        static std::string TranslateToESSL3(const std::string& source, GLenum shaderType);
+
         static GLuint LoadProg(const std::string& name, GLuint vertShaderId, GLuint fragShaderId);
         static GLuint LoadShader(const std::string& name, const std::string& source, GLenum shaderType);
 

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1592,3 +1592,54 @@ What an array is expected to buy, and what it is not:
 
 Measure it build-to-build (`bench/abapk.sh`) rather than behind a property: a second shadow-map path
 kept alive only for the A/B is exactly the flag-driven duplication the working agreement warns off.
+
+### 18.5 Shadow cascades as a texture array: 28% SLOWER on the Adreno 610
+
+Phase 4 item 2, implemented and measured. Each cascade became one layer of a
+`GL_TEXTURE_2D_ARRAY` (`glTexStorage3D`, `glFramebufferTextureLayer` per cascade) instead of a page
+of one `_size * _cascades` wide atlas; the receiver sampled `sampler2DArrayShadow` and the atlas
+scale/offset in `shadowFactorSlope` disappeared. It rendered correctly — shadows ACTIVE, no GL
+errors, no shader failures, cast shadows visually right.
+
+Two APKs, interleaved over two rounds, mountain camera with terrain, shadows and 3D buildings,
+25 one-second windows per arm:
+
+| arm | shadowCast | shadowMask | GPU total |
+|---|---|---|---|
+| atlas | 7.80 | 6.70 | 20.00 |
+| **array** | **8.80** | **10.30** | **25.70** |
+| delta | +1.00 (+12.8%) | **+3.60 (+53.7%)** | **+5.70 (+28.5%)** |
+
+Consistent across rounds, and the atlas arm is the stable one: mask 6.70/6.70 against the array's
+8.70/11.30.
+
+Where it goes:
+
+- **`shadowMask` +53.7%.** The receiver does four PCF taps per fragment. On this Adreno,
+  `sampler2DArrayShadow` is evidently off the fast path that `sampler2DShadow` is on — the atlas
+  arithmetic that was removed (one multiply-add per tap) is far cheaper than whatever the array
+  fetch costs instead.
+- **`shadowCast` +12.8%.** `glFramebufferTextureLayer` per cascade re-attaches the target three
+  times per pass where the atlas set a viewport; the driver appears to treat each as a real target
+  change.
+
+**Reverted, not shipped.** The change is *correct* and it does remove the size cap (`setSize` no
+longer has to divide `GL_MAX_TEXTURE_SIZE` by the cascade count, so 4 x 2048 becomes possible), but
+28% of the GPU frame is not a price worth paying for a cap nothing currently hits.
+
+Worth knowing before anyone tries again: this is a per-GPU result. A desktop or Apple GPU may not
+share the Adreno's array-shadow penalty, so if the cascade count ever needs to exceed what the
+atlas can hold, re-measure rather than assume this verdict travels.
+
+### 18.6 Phase 4, so far: three items measured, three negative
+
+| Item | Verdict on the Adreno 610 |
+|---|---|
+| 1. Instancing | 0.1 ms CPU / 0.0 ms GPU at the city camera — nothing to win, and already batched |
+| 2. Shadow cascades as a texture array | Implemented; **+28.5% GPU**. Reverted |
+| 5. `glMapBufferRange` label streaming | No-op; buffers are a few KB. Reverted |
+
+That is not a failure of the phase, it is the phase working: the list was written from what ES 3.0
+*offers* rather than from what this renderer *spends*, and measuring first cost three short
+experiments instead of three shipped regressions. What the numbers keep pointing at — 320 draws per
+frame in the city, 55% of the terrain GPU frame in shadow rendering itself — is not on the list.

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1482,3 +1482,80 @@ windows longer than 1600 ms discarded, two cycles per configuration.
 - Reading `layers` rather than fps is what makes this measurable at all: the device presents at
   43 Hz (§15.6) and the frame here is far from that ceiling, so ±1 fps of run-to-run noise swamps
   a 1.2 ms section change.
+
+---
+
+## 18. Phase 4 opened by measuring first, and the first two items died (2026-08-19)
+
+[Phase 4](rendering/16-graphics-api-migration.md#phase-4--harvest) lists five ES 3.0 harvests
+"ordered by expected payoff". Nothing had been measured against that order. Method: Crosscall
+HLTE556N (Adreno 610), `bench/city2d.sh` — Grenoble 5.724/45.188 z16.22 tilt 26, terrain off,
+composite base with the bundled style project, scripted north pan, `-PprofileRender`.
+
+Baseline, 22.1 fps, frame avg 39.9 ms:
+
+| CPU section | ms/frame | | GPU section | ms/frame |
+|---|---|---|---|---|
+| `sky` | 12.2 | | sky | 5.4 |
+| `layers` | 14.1 | | background | 3.6 |
+| `layers3D` | 11.4 | | layers | 7.3 |
+| labels 2D + 3D | 3.4 + 2.2 | | layers3D | 1.4 |
+| **`billboards`** | **0.1** | | **billboards** | **0.0** |
+
+`sky` at 12.2 matches §16's "swap wait 12.2" exactly, so it is absorbing the vsync wait rather than
+costing that much itself.
+
+### 18.1 Item 1 (instancing billboards/markers) is dead at this camera
+
+**0.1 ms CPU, 0.0 ms GPU.** There is nothing to win. Its premise is also already satisfied:
+`BillboardRenderer::BuildAndDrawBuffers` draws `drawDataIndex * 6` indices in one
+`glDrawElements` per buffer-full, so billboards are *already* one draw per batch, not one per quad.
+
+What instancing would actually change here is different from what the issue says: the renderer
+builds four corners per billboard per frame and hands them over as **client-side vertex arrays**
+(`coordBuf.data()`, no VBO). That is a real cost — but only in a scene that has billboards. This
+camera has none, so any instancing work needs a marker-heavy bench built first, and the payoff
+would be for marker-heavy apps rather than for the map.
+
+### 18.2 Item 5 (label vertex streaming) measures as a no-op
+
+`renderLabelBatch` re-specifies six buffers per batch with
+`glBufferData(..., GL_DYNAMIC_DRAW)`. Replaced with ES 3.0 orphaning — `glBufferData(size, nullptr,
+GL_STREAM_DRAW)` then `glMapBufferRange(GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT |
+GL_MAP_UNSYNCHRONIZED_BIT)` and a `memcpy` — behind `debug.massif.labelorphan` so one APK does the
+A/B. Interleaved OFF/ON over two rounds, 41 one-second windows per arm:
+
+| arm | fps median | IQR | CPU frame | GPU total |
+|---|---|---|---|---|
+| off | 19.80 | 17.65–22.80 | 43.4 | 18.3 |
+| orphaned | 20.00 | 17.90–21.90 | 44.0 | 18.2 |
+
+**The same arm differs more between rounds than the arms differ from each other** — `off` measured
+18.90 in round 1 and 19.80 in round 2, 4.5× the 0.2 fps between arms, against a stdev of 5.2. No
+effect.
+
+Why: there are ~25 label batches per frame carrying ~245 labels, so each of the six buffers is a
+few KB. `glBufferData` of a few KB is already cheap, and orphaning solves a pipeline stall that at
+that size does not happen. The change was reverted rather than shipped — a no-op behind a debug
+property is complexity for nothing.
+
+Note also that `labelBuild attribMs`, at 17.4 **per interval**, is 0.76 ms/frame, not 17.4 — and
+`Label.cpp`'s `labelAttribNs` clock covers CPU filling of the `VertexArray`s, which buffer mapping
+does not touch at all. Reading a per-interval stat as per-frame is the easy mistake here; every
+`RenderStats` line ending `(per interval)` covers the whole ~1 s window.
+
+### 18.3 What the numbers say to do instead
+
+The frame is CPU-bound on draw submission (§16: 36% of the GL thread inside `libGLESv2_adreno.so`),
+and the per-draw breakdown is `draw=10.1 µs` against `styleEval=3.5`, `styleUpload=2.1`,
+`compile=3.3`, `bind=1.6`. At **320 geometry draws/frame** — 63 tiles × ~5 style layers with content
+— the driver's own per-draw cost dominates.
+
+Of the remaining Phase 4 items, only **UBOs (item 4)** aims at any of that, and it targets
+`styleUpload`: 320 × 2.1 µs ≈ **0.67 ms/frame, ~1.7% of the frame**. Worth doing, but it will not
+move fps on this device, and it should be judged on `layers` rather than fps for the reason in
+§17.
+
+The lever the data actually points at — merging geometry across tiles per style layer, to cut 320
+draws — **is not in Phase 4's list**. Item 3 (packed attributes) does not deliver it either: the
+draws come from the tile × style-layer structure, not from the 16-bit index cap.

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1487,7 +1487,7 @@ windows longer than 1600 ms discarded, two cycles per configuration.
 
 ## 18. Phase 4 opened by measuring first, and the first two items died (2026-08-19)
 
-[Phase 4](rendering/16-graphics-api-migration.md#phase-4--harvest) lists five ES 3.0 harvests
+[Phase 4](rendering/16-graphics-api-migration.md#phase-4--harvest-closed-nothing-shipped) lists five ES 3.0 harvests
 "ordered by expected payoff". Nothing had been measured against that order. Method: Crosscall
 HLTE556N (Adreno 610), `bench/city2d.sh` — Grenoble 5.724/45.188 z16.22 tilt 26, terrain off,
 composite base with the bundled style project, scripted north pan, `-PprofileRender`.

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1559,3 +1559,36 @@ move fps on this device, and it should be judged on `layers` rather than fps for
 The lever the data actually points at — merging geometry across tiles per style layer, to cut 320
 draws — **is not in Phase 4's list**. Item 3 (packed attributes) does not deliver it either: the
 draws come from the tile × style-layer structure, not from the 16-bit index cap.
+
+### 18.4 The terrain camera says shadows are 55% of the GPU frame
+
+The city bench has shadows off, which is why §18 found nothing to optimise in it. Re-measured at
+the mountain camera (Saint-Eynard, 5.760595/45.244172 z13.2 tilt 55, `--es terrain true --es shadow
+0.6 --es terrainLight true --es bld3d true`), same device and profiler build:
+
+| | ms/frame |
+|---|---|
+| CPU frame | 36.0–38.8 |
+| GPU frame | **27.5–28.3** |
+| fps | 15.7–16.1 |
+
+GPU sections: sky 4.5 · background 1.2 · layers 6.2 · layers3D 0.3 · **shadowCast 8.3–9.0** ·
+**shadowMask 6.9**.
+
+**The shadow pass is 15.2–15.9 ms, 55% of the GPU frame.** That is the largest single measured cost
+found anywhere in this phase, and it makes Phase 4 item 2 — shadow cascades as a texture array — the
+only one of the five with a measured case behind it.
+
+What an array is expected to buy, and what it is not:
+
+- **Not** `shadowCast`. That cost is casters × cascades; the render target's shape does not change
+  how much geometry is drawn.
+- **Possibly** `shadowMask`, which samples the `_size * _cascades` wide atlas with manual slice
+  offsetting and clamping per cascade. An array indexes the layer directly, so the offset maths and
+  the clamp both disappear.
+- **Certainly** the texture-size cap: 3 × 1024 is a 3072-wide texture today, and 4 × 2048 would be
+  8192, at or over `GL_MAX_TEXTURE_SIZE` on this class of device. An array removes that ceiling, so
+  it is a robustness fix regardless of what it does to the frame.
+
+Measure it build-to-build (`bench/abapk.sh`) rather than behind a property: a second shadow-map path
+kept alive only for the A/B is exactly the flag-driven duplication the working agreement warns off.

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -454,7 +454,7 @@ killed the first two items and reordered the rest.
 | Item | Status at the city camera, Adreno 610 |
 |---|---|
 | 1. Instancing (billboards, markers) | **Dead here** — 0.1 ms CPU, 0.0 ms GPU, and billboards are already one draw per batch. Needs a marker-heavy bench to justify at all |
-| 2. Shadow cascades as a texture array | **The one with a measured case.** At the *terrain* camera the shadow pass is 15.2 ms of a 27.5 ms GPU frame — 55%. Also lifts the texture-size cap that 4 × 2048 cascades would hit |
+| 2. Shadow cascades as a texture array | **Implemented and reverted: +28.5% GPU on the Adreno 610.** `sampler2DArrayShadow` costs far more per PCF tap there than the atlas arithmetic it replaced. Correct, and it does lift the size cap — but not at that price. Re-measure before trying it on another GPU |
 | 3. Packed vertex attributes | Does not cut draws: they come from tile × style layer, not from the 16-bit index cap |
 | 4. UBOs | The only remaining item aimed at the bottleneck. Targets `styleUpload` ≈ **0.67 ms/frame (~1.7%)** — judge it on `layers`, not fps |
 | 5. `glMapBufferRange` for label streaming | **Measured no-op** — the six label buffers are a few KB each. Reverted, not shipped |

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -11,9 +11,10 @@ move to an OpenGL ES 3.0 baseline (dropping ES 2.0), the Apple situation (Metal)
 Windows/Linux/macOS need later. Does **not** cover what the renderer draws — that is the rest of
 [this set](index.mdx).
 
-Status as of 2026-08-18: Phase 0 run. Gates 0.1 and 0.2 pass, gate 0.3 is **not answered** — see
-[Phase 0 results](#phase-0--results). The Apple source was decided against upstream ANGLE, see
-[MetalANGLE master, not upstream](#metalangle-master-not-upstream-angle).
+Status as of 2026-08-18: Phase 0 run — gates 0.1 and 0.2 pass, gate 0.3 is **not answered** (see
+[Phase 0 results](#phase-0--results)). Phases 2 and 3 are code-complete; Phase 3 is verified on the
+iOS simulator, and **neither is verified on hardware**. The Apple source was decided against
+upstream ANGLE, see [MetalANGLE master, not upstream](#metalangle-master-not-upstream-angle).
 
 ## Where we are
 
@@ -361,16 +362,57 @@ has been rendered on hardware.
 
 ### Phase 3 — GLSL ES 3.00
 
-The reference is already in the tree, and it is tangram, not mapbox-gl-js:
-`core/src/gl/shaderSource.cpp` gates `#version 300 es` plus a vertex/fragment header on
-`Hardware::glVersion >= 300`.
+Done on the simulator; the device leg is still owed. tangram's preamble
+(`core/src/gl/shaderSource.cpp`) is ported verbatim into three places, and **not one of the 27
+shader literals was edited** — they stay written in ESSL 1.00 and are translated on the way to the
+driver, which is what keeps application GLSL working unchanged:
 
-- Port that preamble into `all/native/renderers/utils/Shader.cpp`; flip `ESSL3_FLAG` on globally in
-  `vt`; same for `nml`.
-- Keep `vt`'s per-program 1.00 fallback for one release as the canary, then delete it.
+| Where | How |
+|---|---|
+| `all/native` | `Shader::TranslateToESSL3` rewrites the source in `LoadShader` |
+| `vt` | `buildShaderProgram` ORs in `ESSL3_FLAG` for every program, not at the 20-odd call sites |
+| `nml` | `GLResourceManager::createShader` gained a shader-type parameter so it can pick the right header |
+
+Because the app's GLSL is spliced *into* the SDK's own literals, one translation point covers all
+five public setters. `vt`'s per-program 1.00 fallback stays one release as a canary.
+
+**`hasShaderVersionFallback()` had no callers.** vt sets `_essl3Failed` with the comment "the owner
+logs it once", and no owner ever did — so the phase's own success criterion was unobservable.
+`TileRenderer::onDrawFrame` now logs it once. Without that, a program silently rebuilt at 1.00 looks
+exactly like success: the map still draws.
+
+#### `#version` must be on the first line, not merely preceded by whitespace
+
+The one real trap, and it failed *every* shader on the first run:
+
+```
+ERROR: 0:2: '' : #version directive must occur on the first line of the shader
+```
+
+The shader literals are raw strings that open with a newline and an indent, so replacing the
+`#version 100` line in place leaves the new directive on line 2. Whitespace on the *same* line is
+allowed; a preceding newline is not. The directive is emitted at offset 0 and whatever preceded it
+is pushed after the header.
+
+Worth noting how this was caught: the Android build was **green**, because a C++ build never
+compiles a shader — that happens at runtime. Only running it found this.
 
 **Done when**: every program compiles at `300 es` on both device families and
 `hasShaderVersionFallback()` returns false.
+
+Where that stands, measured on the iPhone 16 Pro simulator through ANGLE (the strict translator) at
+lon 5.7606 / lat 45.2442 / z13.6 / tilt 55, terrain on:
+
+| | |
+|---|---|
+| shader compile / link failures | **0** |
+| ESSL 3.00 → 1.00 fallbacks | **0** |
+| GL errors | **0** |
+| frame vs the ESSL 1.00 build, identical launch args | **every map band 0.00% different** |
+
+The only differing pixels are the status-bar clock and the home indicator — 0.28% of the frame, all
+of it iOS chrome. Still owed: the same on an Adreno 610 and a real iOS device, where the drivers are
+not ANGLE.
 
 #### The `gl_FragColor` disagreement — settled, tangram was right
 

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -12,9 +12,9 @@ Windows/Linux/macOS need later. Does **not** cover what the renderer draws — t
 [this set](index.mdx).
 
 Status as of 2026-08-18: Phase 0 run — gates 0.1 and 0.2 pass, gate 0.3 is **not answered** (see
-[Phase 0 results](#phase-0--results)). Phases 2 and 3 are code-complete; Phase 3 is verified on the
-iOS simulator, and **neither is verified on hardware**. The Apple source was decided against
-upstream ANGLE, see [MetalANGLE master, not upstream](#metalangle-master-not-upstream-angle).
+[Phase 0 results](#phase-0--results)). Phases 2 and 3 are done and **verified on an Adreno 610
+device**; an iOS device is still owed. The Apple source was decided against upstream ANGLE, see
+[MetalANGLE master, not upstream](#metalangle-master-not-upstream-angle).
 
 ## Where we are
 
@@ -357,8 +357,9 @@ iOS 13 floor — where every device is A7+ — that is a rounding error. The app
 in [migration.md](../../migration.md#opengl-es-30-is-required).
 
 **Done when**: an Adreno 610 device and one iOS device show no regression at the bench cameras.
-Neither has been run — the Android APK builds and the manifest merges at `0x00030000`, but nothing
-has been rendered on hardware.
+The Adreno 610 leg is done — see [Phase 3](#phase-3--glsl-es-300), which was verified on the same
+device and run, and exercises this phase's context and capability changes on the way. An iOS device
+is still owed.
 
 ### Phase 3 — GLSL ES 3.00
 
@@ -400,19 +401,31 @@ compiles a shader — that happens at runtime. Only running it found this.
 **Done when**: every program compiles at `300 es` on both device families and
 `hasShaderVersionFallback()` returns false.
 
-Where that stands, measured on the iPhone 16 Pro simulator through ANGLE (the strict translator) at
-lon 5.7606 / lat 45.2442 / z13.6 / tilt 55, terrain on:
+Measured at lon 5.7606 / lat 45.2442 / z13.6 / tilt 55, terrain on, on two unrelated GL stacks:
 
-| | |
-|---|---|
-| shader compile / link failures | **0** |
-| ESSL 3.00 → 1.00 fallbacks | **0** |
-| GL errors | **0** |
-| frame vs the ESSL 1.00 build, identical launch args | **every map band 0.00% different** |
+| | iPhone 16 Pro simulator (ANGLE/Metal) | Crosscall HLTE556N, **Adreno 610**, ES 3.2 |
+|---|---|---|
+| shader compile / link failures | 0 | **0** |
+| ESSL 3.00 → 1.00 fallbacks | 0 | **0** |
+| GL errors | 0 | **0** |
+| frame vs the ESSL 1.00 build | every map band 0.00% | see below |
 
-The only differing pixels are the status-bar clock and the home indicator — 0.28% of the frame, all
-of it iOS chrome. Still owed: the same on an Adreno 610 and a real iOS device, where the drivers are
-not ANGLE.
+The Adreno is the one that matters, because its driver is a real Qualcomm GLSL compiler rather than
+ANGLE's translator, and it is where `GLContext::VERSION` first met a vendor version string —
+`OpenGL ES 3.2 V@0502.0 (GIT@...)` parses to `320`, as tangram's parser is meant to.
+
+The device A/B needs its control quoted or it says nothing. Same build run twice differs by 0.19%
+of sampled pixels (labels are placed as tiles arrive, so no two runs match exactly). ESSL 1.00 vs
+3.00 differs by 0.37%, and the per-band profile is the same shape — the excess is confined to
+glyph pixels, black text against landcover green in both directions, i.e. sub-pixel label
+antialiasing. Cropped and compared by eye, the two frames are indistinguishable: same contours, same
+labels, same positions.
+
+One thing the A/B settled that inspection alone would not: a **route line that draws in broken
+chunks** over terrain is present *identically in both builds*. It is the known open terrain
+line-following issue, not a regression from this phase.
+
+Still owed: a real iOS device (Apple's driver, not the simulator's).
 
 #### The `gl_FragColor` disagreement — settled, tangram was right
 

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -454,15 +454,22 @@ killed the first two items and reordered the rest.
 | Item | Status at the city camera, Adreno 610 |
 |---|---|
 | 1. Instancing (billboards, markers) | **Dead here** — 0.1 ms CPU, 0.0 ms GPU, and billboards are already one draw per batch. Needs a marker-heavy bench to justify at all |
-| 2. Shadow cascades as a texture array | Untested — shadows are off in this bench |
+| 2. Shadow cascades as a texture array | **The one with a measured case.** At the *terrain* camera the shadow pass is 15.2 ms of a 27.5 ms GPU frame — 55%. Also lifts the texture-size cap that 4 × 2048 cascades would hit |
 | 3. Packed vertex attributes | Does not cut draws: they come from tile × style layer, not from the 16-bit index cap |
 | 4. UBOs | The only remaining item aimed at the bottleneck. Targets `styleUpload` ≈ **0.67 ms/frame (~1.7%)** — judge it on `layers`, not fps |
 | 5. `glMapBufferRange` for label streaming | **Measured no-op** — the six label buffers are a few KB each. Reverted, not shipped |
 
-The frame is CPU-bound on draw submission at **320 geometry draws/frame**, so the lever the data
-points at is merging geometry across tiles per style layer — which **is not on this list**. That is
-the honest outcome of the phase so far: the ES 3.0 baseline is worth having for what it removed
-(Phase 2's extension probes) more than for what this phase has so far harvested.
+Two cameras, two different bottlenecks, and the list was written for neither:
+
+- **City (2D, shadows off)** — CPU-bound on draw submission at **320 geometry draws/frame** (63
+  tiles × ~5 style layers). The lever is merging geometry across tiles per style layer, which is
+  **not on this list**; item 3 does not deliver it either, since the draws come from that structure
+  and not from the 16-bit index cap.
+- **Terrain (shadows on)** — GPU-bound, and **55% of the GPU frame is the shadow pass**. That is
+  what item 2 addresses, and it is the only item of the five that measurement supports.
+
+So the order to take the rest in is **2, then nothing else here** until a cross-tile batching item
+exists to take the city case.
 
 ### Phase 5 — desktop
 

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -446,9 +446,23 @@ vt's rename is still harmless and need not be undone; only the comment is mislea
 
 ### Phase 4 — harvest
 
-One measured PR each, recorded in [Performance log](../performance-log.md): instancing, then shadow
-cascades as a texture array, then packed vertex attributes, then UBOs, then `glMapBufferRange` for
-label streaming.
+One measured PR each, recorded in [Performance log](../performance-log.md). The list was written as
+"ordered by expected payoff" before anything was measured; opening it with a measurement
+([round 18](../performance-log.md#18-phase-4-opened-by-measuring-first-and-the-first-two-items-died-2026-08-19))
+killed the first two items and reordered the rest.
+
+| Item | Status at the city camera, Adreno 610 |
+|---|---|
+| 1. Instancing (billboards, markers) | **Dead here** — 0.1 ms CPU, 0.0 ms GPU, and billboards are already one draw per batch. Needs a marker-heavy bench to justify at all |
+| 2. Shadow cascades as a texture array | Untested — shadows are off in this bench |
+| 3. Packed vertex attributes | Does not cut draws: they come from tile × style layer, not from the 16-bit index cap |
+| 4. UBOs | The only remaining item aimed at the bottleneck. Targets `styleUpload` ≈ **0.67 ms/frame (~1.7%)** — judge it on `layers`, not fps |
+| 5. `glMapBufferRange` for label streaming | **Measured no-op** — the six label buffers are a few KB each. Reverted, not shipped |
+
+The frame is CPU-bound on draw submission at **320 geometry draws/frame**, so the lever the data
+points at is merging geometry across tiles per style layer — which **is not on this list**. That is
+the honest outcome of the phase so far: the ES 3.0 baseline is worth having for what it removed
+(Phase 2's extension probes) more than for what this phase has so far harvested.
 
 ### Phase 5 — desktop
 

--- a/docs/internals/rendering/16-graphics-api-migration.md
+++ b/docs/internals/rendering/16-graphics-api-migration.md
@@ -444,32 +444,42 @@ the five public GLSL setters need no migration, and this phase is **not** a brea
 vt's rename is still harmless and need not be undone; only the comment is misleading, and only the
 `all/native` side has to choose. Full method and controls in [Phase 0 — results](#02--define-gl_fragcolor-accepted-so-phase-3-is-not-breaking).
 
-### Phase 4 — harvest
+### Phase 4 — harvest: closed, nothing shipped
 
-One measured PR each, recorded in [Performance log](../performance-log.md). The list was written as
-"ordered by expected payoff" before anything was measured; opening it with a measurement
-([round 18](../performance-log.md#18-phase-4-opened-by-measuring-first-and-the-first-two-items-died-2026-08-19))
-killed the first two items and reordered the rest.
+Closed 2026-08-19 (#140). Three of the five items were implemented and measured on an Adreno 610;
+all three were negative, and the two best remaining performance targets do not need ES 3.0 at all.
+Method and numbers in [round 18](../performance-log.md#18-phase-4-opened-by-measuring-first-and-the-first-two-items-died-2026-08-19).
 
-| Item | Status at the city camera, Adreno 610 |
+| Item | Result |
 |---|---|
-| 1. Instancing (billboards, markers) | **Dead here** — 0.1 ms CPU, 0.0 ms GPU, and billboards are already one draw per batch. Needs a marker-heavy bench to justify at all |
-| 2. Shadow cascades as a texture array | **Implemented and reverted: +28.5% GPU on the Adreno 610.** `sampler2DArrayShadow` costs far more per PCF tap there than the atlas arithmetic it replaced. Correct, and it does lift the size cap — but not at that price. Re-measure before trying it on another GPU |
-| 3. Packed vertex attributes | Does not cut draws: they come from tile × style layer, not from the 16-bit index cap |
-| 4. UBOs | The only remaining item aimed at the bottleneck. Targets `styleUpload` ≈ **0.67 ms/frame (~1.7%)** — judge it on `layers`, not fps |
-| 5. `glMapBufferRange` for label streaming | **Measured no-op** — the six label buffers are a few KB each. Reverted, not shipped |
+| 1. Instancing (billboards, markers) | **0.1 ms CPU, 0.0 ms GPU.** Already one draw per batch, so the premise was false |
+| 2. Shadow cascades as a texture array | Implemented and correct, then **+28.5% GPU** (`shadowMask` 6.70 → 10.30 ms). Reverted. Explicitly a **per-GPU** verdict |
+| 3. Packed vertex attributes | Not measured. Cannot cut draws — they come from tile × style layer, not the 16-bit index cap |
+| 4. UBOs | Not measured. Targets `styleUpload` ≈ **0.46 ms/frame** once the profiler's own per-bucket overhead is subtracted |
+| 5. `glMapBufferRange` for label streaming | **No-op** — the six label buffers are a few KB each. Reverted |
 
-Two cameras, two different bottlenecks, and the list was written for neither:
+The list was written from what ES 3.0 *offers* rather than from what this renderer *spends*, and
+ordered by expected payoff before anything was measured. There are two cameras with two bottlenecks
+and it addresses neither: the 2D city is CPU-bound on **320 geometry draws/frame**, and the terrain
+frame is GPU-bound with **55% of it in the shadow pass** — a cost that is casters × cascades, which
+item 2 could not touch however the texture is laid out.
 
-- **City (2D, shadows off)** — CPU-bound on draw submission at **320 geometry draws/frame** (63
-  tiles × ~5 style layers). The lever is merging geometry across tiles per style layer, which is
-  **not on this list**; item 3 does not deliver it either, since the draws come from that structure
-  and not from the 16-bit index cap.
-- **Terrain (shadows on)** — GPU-bound, and **55% of the GPU frame is the shadow pass**. That is
-  what item 2 addresses, and it is the only item of the five that measurement supports.
+What took its place, neither of which depends on this migration:
 
-So the order to take the rest in is **2, then nothing else here** until a cross-tile batching item
-exists to take the city case.
+- **[#144](https://github.com/massif-maps/MassifMaps/issues/144)** — cut the 320 draws. Step 1 hoists
+  the per-layer uniforms out of the per-tile loop (~1.5 ms/frame); the loop is *already* grouped by
+  style layer and re-uploads identical style parameters per tile.
+- **Instancing the shared-mesh per-tile draws** — tile masks (62/frame, measured at ~2.4 ms CPU),
+  background quads (23/frame) and the terrain grid all bind one shared VBO and differ only by
+  `U_MVPMATRIX`. This is where item 1 should have pointed. Instanced arrays are also an ES 2.0
+  extension.
+
+**This does not undo Phases 2 and 3.** They were never justified by frame rate — they are what makes
+ANGLE-on-Metal and the desktop phase possible. On Android specifically, Phase 2 bought *simplicity,
+not capability*: the bench device already exposed `GL_OES_vertex_array_object`,
+`GL_EXT_discard_framebuffer`, `GL_OES_depth_texture` and `GL_OES_texture_npot`, so every capability
+made core was already reachable through the probes that were deleted. The migration's payoff is in
+Phases 1 and 5, and it should be judged there.
 
 ### Phase 5 — desktop
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -163,8 +163,22 @@ Devices lost are pre-2013 GPUs: Mali-400, Adreno 200/305, Tegra 3, PowerVR SGX. 
 an iOS 13 floor — where every device is A7 or newer — that is a rounding error. On desktop the
 equivalent floor is D3D feature level 10_1 (Sandy Bridge, 2011), which Windows 11 already exceeds.
 
-The shaders are unaffected: they are still GLSL ES 1.00, which an ES 3.0 context compiles. Moving
-them to `#version 300 es` is a separate, later change.
+### Shaders moved to GLSL ES 3.00 — and your shaders still work
+
+The SDK's shaders now compile as `#version 300 es`. **This is not a breaking change for
+application GLSL.** If you pass a shader to `SkyOptions.shaderSource`, `FogOptions.shaderSource`,
+`TerrainOptions.surfaceShaderSource`, `CustomRasterTileLayer.shaderSource` or `PostProcessEffect`,
+keep writing it exactly as before — `attribute`, `varying`, `texture2D` and `gl_FragColor` all still
+work.
+
+They keep working because the SDK prepends tangram's compatibility preamble, which maps the ESSL
+1.00 spellings onto their 3.00 equivalents, including `#define gl_FragColor`. That is legal: ESSL
+reserves the `GL_` prefix for *macro* names, and `gl_FragColor` is a built-in *variable* that ESSL
+3.00 does not declare.
+
+You may now also use ESSL 3.00 features directly (`in`/`out`, `texture()`, integer operations) — but
+do not declare your own `#version` line, and do not declare a fragment output named
+`TANGRAM_FragColor`, which the preamble already provides at location 0.
 
 ### `LightOptions.shadowDistance` is a factor, not metres
 


### PR DESCRIPTION
## Summary

Documentation only — **no code ships from this PR.** Phase 4 of #126 was opened by measuring instead of implementing, three of its five items were then implemented and measured on a real device, all three were negative, and the phase is closed (#140).

Two files: [performance log](docs/internals/performance-log.md) round 18 (four sub-rounds, full method), and the Phase 4 section of the [migration page](docs/internals/rendering/16-graphics-api-migration.md) rewritten as closed rather than as live work.

## What was measured

Crosscall HLTE556N (Adreno 610), `-PprofileRender`, interleaved arms, medians over 25–49 one-second windows per arm.

| Item | Result |
|---|---|
| 1. Instancing (billboards, markers) | **0.1 ms CPU / 0.0 ms GPU** at the city camera. Also already batched — `BuildAndDrawBuffers` issues one `glDrawElements` per buffer-full, so the premise was false |
| 2. Shadow cascades as a texture array | Implemented, rendered correctly, then **+28.5% GPU** — `shadowMask` 6.70 → 10.30 ms. Reverted |
| 5. `glMapBufferRange` label streaming | **No-op.** 19.80 vs 20.00 fps, while the *same arm* moved 18.90 → 19.80 between rounds. Reverted |

Item 2 is the one worth reading: `GL_TEXTURE_2D_ARRAY` + `sampler2DArrayShadow`, with the atlas scale/offset removed from `shadowFactorSlope`. On this Adreno the array fetch costs far more per PCF tap than the single multiply-add it replaced. Recorded explicitly as a **per-GPU** verdict — re-measure before assuming it on Apple or desktop hardware.

## Why the phase closed

The list was written from what ES 3.0 *offers* rather than what this renderer *spends*. Two cameras, two bottlenecks, and it addresses neither:

- **2D city** — CPU-bound on draw submission, **320 geometry draws/frame** (63 tiles × ~5 style layers), 36% of the GL thread inside `libGLESv2_adreno.so`.
- **Terrain** — GPU-bound, **55% of the GPU frame in the shadow pass**, a cost that is casters × cascades and so beyond any texture layout.

What replaces it, neither needing ES 3.0: **#144** (hoist per-layer uniforms out of the per-tile loop, ~1.5 ms/frame — the loop is *already* grouped by style layer) and instancing the shared-mesh per-tile draws (tile masks measured at ~2.4 ms CPU).

## What this does not say

**Phases 2 and 3 stand.** They were never justified by frame rate — they are what makes ANGLE-on-Metal (#137) and desktop (Phase 5) possible, which is what #126 exists for. On Android specifically Phase 2 bought *simplicity, not capability*: the bench device already exposes `GL_OES_vertex_array_object`, `GL_EXT_discard_framebuffer`, `GL_OES_depth_texture` and `GL_OES_texture_npot`, so every capability made core was already reachable through the probes that were deleted.

## Testing

- No code changed — both experiments were reverted, and `libs-massif` is untouched (no pointer bump in this PR).
- `cd website && npm run build` clean, no broken-link block. The Phase 4 heading rename broke an inbound anchor from the performance log; the build caught it and it is repointed.
- The numbers themselves are the deliverable. Each is reported **with its control**: same-build run-to-run variation is quoted next to every delta, because in two of the three cases it exceeded the effect.

## Depends on

Based on the #143 branch (Phase 3), which sits on #142 → #141. Retarget as each lands.

Closes #140
Part of #126