### PR TITLE
feat(labels)!: repeat a road shield along its road without turning it with the road

### DIFF
--- a/docs/features/label-styling.md
+++ b/docs/features/label-styling.md
@@ -58,6 +58,35 @@ A style without `shield-anchors` builds no variants and takes exactly the old pa
 anchored (~2300 labels, 4 sides + icon-only) a placement pass measured **20.8 ms against 16.3 ms**
 unset, and frame time moved by under 1 ms.
 
+## Repeating a shield along its road
+
+`shield-placement` / `text-placement` decide two things at once — how often the label is placed along
+a line, and whether its glyphs follow the line's direction:
+
+| Placement | Repeats at `spacing` | Glyphs |
+|---|---|---|
+| `point` | no — one label per line | flat on the ground, swivelling to face the camera |
+| `billboard` | no — one label per line | upright, facing the camera |
+| `line` | yes | flat on the ground, following the line |
+| `billboard-line` | yes | upright, following the line |
+| `billboard-line-repeat` | yes | upright, **not** following the line |
+
+`billboard-line-repeat` is the road-shield combination and is what **shields default to**: a route
+number repeated along its motorway has to stay readable, not turn with the bend. On a feature that
+is not a line it behaves as `billboard`.
+
+```css
+#road_shield {
+  shield-name: [ref];
+  shield-file: url(shields/motorway.svg);
+  shield-spacing: 200;                       /* ground distance between repeats */
+  shield-min-distance: 100;                  /* ... and the screen-space guarantee */
+  /* shield-placement: billboard-line-repeat;   the default; 'point' is the old one */
+}
+```
+
+Text still defaults to `point`. `text-spacing: 0` means one label for the whole line.
+
 ## Font icons
 
 `shield-icon-name` is a run of glyphs from an icon face, drawn before the text with its own colour

--- a/docs/internals/rendering/06-labels.mdx
+++ b/docs/internals/rendering/06-labels.mdx
@@ -96,25 +96,37 @@ above): `allowOverlapSameFeatureId`, `sameFeatureIdDependent`, and group ids wit
 
 ### Line runs: `line` lies flat, `billboard-line` stays upright
 
-Both orientations lay the glyph run out **along the line** (`Label::isLineRun`); they differ only in
-the plane it is laid out in, which `buildLineVertexData` picks:
+Three placements walk the line at `text-spacing`. Two of them lay a glyph **run** out along it
+(`Label::isLineRun`) and differ only in the plane `buildLineVertexData` picks; the third lays out no
+run at all:
 
 | `text-placement` | `LabelOrientation` | run laid out on | drawn as |
 |---|---|---|---|
 | `line` | `LINE` | the placement's own tangent frame (`placement->xAxis/yAxis`), no projection | flat on the surface, `WORLD_OFFSET` |
 | `billboard-line` | `LINE_BILLBOARD_3D` | the camera axes, through the view-projection | upright, `CAMERA_AXIS_OFFSET` |
+| `billboard-line-repeat` | *(never reaches vt — becomes `BILLBOARD_3D`)* | not laid out on the line: one label per step, in its own box | upright, `CAMERA_AXIS_OFFSET` |
 
 `line` is the map-like one: the text lies in the ground plane like the line it names, so it tilts and
 foreshortens with the map. `billboard-line` keeps its size and its shape at any tilt, at the cost of
 no longer lying on the surface — which is what a road name usually wants and a route distance usually
-does not.
+does not. `billboard-line-repeat` is the road-shield case: the repeat along the line is wanted, the
+run following it is not.
+
+`billboard-line-repeat` is resolved in the **symbolizers**, not in vt: they repeat it like the other
+line placements, hand the label a `BILLBOARD_3D` style and, unlike a run, **no line** — `Label` snaps
+a placement to `_tileLines` in preference to `_tilePoints`, and `TileLayerBuilder` tesselates a line
+a billboard would never read. On a feature that is not a line it is the plain billboard its name
+says (`repeat` is decided per feature). It is also what `nutibillboardline` now maps to, which is
+what that spelling meant in 5.x.
 
 **This was a regression between 5.x and 6.0.** `LINE` was moved to the camera-axis layout wholesale
 ("lay line labels out in screen space"), so `text-placement: line` silently became a billboard and
 there was no way back to the flat run; the only thing still drawing text flat was `text-clip`, which
 is not a label at all (see below). The two layouts are now separate orientations, `line` is flat
 again, and `billboard-line` — which used to place one upright point label per `text-spacing` step,
-ignoring the line direction — takes the run that follows the line.
+ignoring the line direction — takes the run that follows the line. That 5.x behaviour is
+`billboard-line-repeat`, added once the split turned out to have removed the only way to repeat a
+shield along a road without turning it with the road.
 
 Consequences of the split, all keyed on `isLineRun()` / `isScreenLineRun()`:
 
@@ -124,9 +136,10 @@ Consequences of the split, all keyed on `isLineRun()` / `isScreenLineRun()`:
   which is the camera basis for one and the tangent frame for the other.
 - Anchor pixel-snapping is skipped for both: it snaps the anchor to a quarter-pixel grid, which is
   meaningless once the glyphs are laid out along a line rather than in a box.
-- `TextSymbolizer` feeds both the same way — the anchors, `text-spacing` and the measured run length
-  a line placement needs (`linePlacement`). It used to hand `billboard-line` a bare vertex with an
-  empty vertex list, which is exactly why that placement could not follow anything.
+- `TextSymbolizer` feeds all three the same anchors, `text-spacing` and measured run length
+  (`repeatAlongLine`), and hands the line itself only to the two that lay a run out (`lineRun`). The
+  bare vertex with an empty vertex list — why `billboard-line` could not follow anything before the
+  split — is now exactly what `billboard-line-repeat` asks for.
 
 **A layout fails in two different ways, and they are held differently** (`Label::LineLayout`):
 
@@ -175,7 +188,7 @@ everything the label pipeline is:
 | culling, `text-allow-overlap`, `text-min-distance` | yes | **none** — there is no `vt::Label` to cull |
 | placement along the line | per glyph, follows the run (`buildLineVertexData`) | whole run rotated by its segment's angle |
 | `text-spacing: 0` (the default) | ONE label for the whole line | one at the **midpoint of every segment** |
-| orientation | `line` / `billboard-line` / `billboard` / `point` | always flat — geometry has no camera basis |
+| orientation | `line` / `billboard-line` / `billboard-line-repeat` / `billboard` / `point` | always flat — geometry has no camera basis |
 | tile border | the label is placed across it | glyphs are **cut**, that is what clip means |
 
 **It used to default to `text-allow-overlap`** (upstream, 2019, no rationale recorded), so a style
@@ -186,7 +199,10 @@ table. It now defaults to `false`, its own declared default, and the same applie
 
 Under clip, `billboard-line` is treated as `line` — the run is rotated by its segment's angle rather
 than left horizontal. Clipped text cannot be a billboard at all, and leaving it unrotated was the one
-combination that neither followed the line nor stayed upright.
+combination that neither followed the line nor stayed upright. `billboard-line-repeat` is the
+exception: it has no run to follow the line with, so its repeats keep the style's own angle
+(`generateLinePoints(..., applyAngle = lineRun)`), which is the closest the geometry path gets to a
+billboard.
 
 Over 3D terrain its glyph quads take the line shader's rule: the terrain is sampled at the
 **extruded corner** (`applyTerrain(pos + delta)` in `pointVsh`), not at the anchor. A quad placed at

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -83,7 +83,7 @@ old spelling will be removed in a later release.
 | `[nuti::x]` | `[param::x]` | app-supplied runtime parameter, joining `mapnik::` and `view::` |
 | `"nutiparameters"` (project.json) | `"styleparameters"` | the block declaring those parameters |
 | `text-placement: nutibillboard` | `billboard` | fully screen-aligned |
-| `text-placement: nutibillboardline` | `billboard-line` | screen-aligned, laid along a line |
+| `text-placement: nutibillboardline` | `billboard-line-repeat` | screen-aligned, repeated along a line |
 | `text-placement: nutipoint` | `flat` | flat in the placement plane, no camera facing |
 | `text-placement: nuticallout` | `callout` | screen-aligned with a leader line |
 
@@ -101,8 +101,25 @@ instead of placing one upright label per `text-spacing` step.
 |---|---|
 | the 5.x look, text in the ground plane (route distances, contour heights) | `text-placement: line` — no change needed |
 | the 6.0.0 look, text upright and readable at any tilt | `text-placement: billboard-line` |
+| one upright label per `text-spacing` step, not turning with the line (road shields) | `text-placement: billboard-line-repeat` |
 
-See [Labels](internals/rendering/06-labels.mdx) for the two layouts.
+See [Labels](internals/rendering/06-labels.mdx) for the three layouts.
+
+### `shield-placement` defaults to `billboard-line-repeat` (breaking change after 6.0.1)
+
+`billboard-line-repeat` is new: it repeats along the line at `shield-spacing` like `line` does, but
+lays no glyph run on it, so each repeat stays an upright camera-facing box. That is what a road
+shield is, and until now no placement gave both — `billboard-line` turns the shield with the road,
+`billboard` draws one per line. It is now the **default** for shields, so a style that never set
+`shield-placement` changes twice:
+
+| Feature | Before (`point`) | Now |
+|---|---|---|
+| line | one shield, flat on the ground at the line's midpoint | one per `shield-spacing` step, facing the camera |
+| point / polygon | flat on the ground, foreshortening with the tilt | facing the camera |
+
+`shield-placement: point` restores the old default exactly. `text-placement` is unchanged — text
+still defaults to `point`.
 
 ### `text-clip` / `shield-clip` no longer follow `allow-overlap` (behaviour change in 6.0.1)
 

--- a/scripts/android-dev/app/src/main/assets/style/shared/labels.less
+++ b/scripts/android-dev/app/src/main/assets/style/shared/labels.less
@@ -366,7 +366,7 @@
       shield-placement-priority: 10;
       shield-size: @shield-size;
       shield-line-spacing: @shield-line-spacing;
-      shield-placement: billboard-line;
+      shield-placement: billboard-line-repeat;
       shield-spacing: [param::road_shield_spacing];
       shield-min-distance: [param::road_shield_min_dist];
       shield-face-name: @mont_bd;

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoPanel.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoPanel.java
@@ -720,7 +720,7 @@ public final class DemoPanel {
         check(context, "text-allow-overlap", DemoConfig.BUG_TEXT_ALLOW_OVERLAP, new BoolSetting() {
             public void set(boolean value) { DemoConfig.BUG_TEXT_ALLOW_OVERLAP = value; reloadBugs(demo); }
         });
-        final String[] placements = { "line", "billboard-line", "billboard", "point" };
+        final String[] placements = { "line", "billboard-line", "billboard-line-repeat", "billboard", "point" };
         choice(context, "text-placement", placements, indexOf(placements, DemoConfig.BUG_TEXT_PLACEMENT), new IntSetting() {
             public void set(int index) { DemoConfig.BUG_TEXT_PLACEMENT = placements[index]; reloadBugs(demo); }
         });


### PR DESCRIPTION
## Summary

- Picks up the new `billboard-line-repeat` placement: a road shield now repeats along its motorway at `shield-spacing` **and** stays an upright camera-facing box. `billboard-line` turns it with the road, `billboard` draws one per road — until now nothing gave both.
- It is the new **default** for `shield-placement` (breaking, see below).
- Docs: the third line placement in [`06-labels.mdx`](docs/internals/rendering/06-labels.mdx), a user-facing "repeating a shield along its road" section in [`label-styling.md`](docs/features/label-styling.md), and the default change + migration path in [`migration.md`](docs/migration.md).
- Demo: `billboard-line-repeat` in the panel's `text-placement` picker, and the demo style's road shields moved onto it.

## Testing

Docusaurus production build clean (`[SUCCESS]`, no broken-link block).

Device check ran against this branch's submodule commit — see the linked PR for the cameras. Road shields at `--es style assets --es zoom 11.5 --es tilt 50 --es lat 45.30 --es lon 5.75` repeat along the A43 / A41 / A480, upright.

## Breaking changes

`shield-placement` defaults to `billboard-line-repeat` instead of `point`. A style that never set it gets repeated camera-facing shields along a line instead of one flat shield at its midpoint, and camera-facing instead of ground-flat on a point or polygon. `shield-placement: point` restores the old default; `text-placement` is unchanged. Written up in [`docs/migration.md`](docs/migration.md).

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/65 — merge it first, then rebase this pointer bump onto the merged commit.