### PR TITLE
feat(terrain): judge tile detail by the ground's real height, and bound grazing-angle coarsening

### DIFF
--- a/all/modules/components/Options.i
+++ b/all/modules/components/Options.i
@@ -74,6 +74,7 @@
 %attribute(massif::Options, int, TileThreadPoolSize, getTileThreadPoolSize, setTileThreadPoolSize)
 %attribute(massif::Options, int, TileDrawSize, getTileDrawSize, setTileDrawSize)
 %attribute(massif::Options, float, TileLODFactor, getTileLODFactor, setTileLODFactor)
+%attribute(massif::Options, float, TileLODForeshorteningLimit, getTileLODForeshorteningLimit, setTileLODForeshorteningLimit)
 %attribute(massif::Options, float, DPI, getDPI, setDPI)
 %attribute(massif::Options, float, DrawDistance, getDrawDistance, setDrawDistance)
 %std_exceptions(massif::Options::setBaseProjection)

--- a/all/native/components/Options.cpp
+++ b/all/native/components/Options.cpp
@@ -28,6 +28,7 @@ namespace massif {
         _doubleClickMaxDuration(DEFAULT_DOUBLE_CLICK_MAX_DURATION),
         _tileDrawSize(256),
         _tileLODFactor(1.0f),
+        _tileLODForeshorteningLimit(0.0f),
         _dpi(160.0f),
         _drawDistance(16),
         _fovY(70),
@@ -268,6 +269,23 @@ namespace massif {
             _tileLODFactor = clamped;
         }
         notifyOptionChanged("TileLODFactor");
+    }
+
+    float Options::getTileLODForeshorteningLimit() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _tileLODForeshorteningLimit;
+    }
+
+    void Options::setTileLODForeshorteningLimit(float levels) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            float clamped = std::max(0.0f, levels);
+            if (_tileLODForeshorteningLimit == clamped) {
+                return;
+            }
+            _tileLODForeshorteningLimit = clamped;
+        }
+        notifyOptionChanged("TileLODForeshorteningLimit");
     }
     
     float Options::getDPI() const {

--- a/all/native/components/Options.h
+++ b/all/native/components/Options.h
@@ -310,6 +310,25 @@ namespace massif {
          * @param factor The new tile LOD factor. The default is 1.
          */
         void setTileLODFactor(float factor);
+
+        /**
+         * Returns how many zoom levels a tile may lose to foreshortening.
+         * @return The limit in zoom levels, or 0 when there is no limit. The default is 0.
+         */
+        float getTileLODForeshorteningLimit() const;
+        /**
+         * Sets how many zoom levels a tile may be coarsened by the grazing angle alone.
+         * The LOD rule (see setTileLODFactor) compares a tile's projected screen AREA, which falls
+         * both with the distance and with the cosine of the angle the view ray makes with the
+         * ground. The second term is what keeps a mountain 10 km out coarse while ground at the same
+         * distance under a steeper angle is refined: at a low tilt every tile in the frame sits at
+         * 79-89 degrees of incidence and loses 1.2 to 3 levels to it.
+         * This bounds that second term only, so the distance term is untouched and genuinely far
+         * ground stays coarse. Lower values refine more of the tilted view and cost tiles roughly
+         * 2x per level; 0 leaves the area rule as tangram wrote it.
+         * @param levels The limit in zoom levels, or 0 for no limit. The default is 0.
+         */
+        void setTileLODForeshorteningLimit(float levels);
     
         /**
          * Returns the dots per inch value.
@@ -802,6 +821,7 @@ namespace massif {
     
         int _tileDrawSize;
         float _tileLODFactor;
+        float _tileLODForeshorteningLimit;
     
         float _dpi;
     

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -654,13 +654,16 @@ namespace massif {
             }
         }
 
-        // Screen-centre elevation for the whole cull, like tangram's View::getTileScreenArea - it
-        // moves with the camera, not with the tile (docs/internals/rendering/02-tiles.md, the LOD rule).
+        // Elevation the LOD projects tile corners at. Per tile where the DEM is decoded, screen-centre
+        // elevation elsewhere - tangram's View::getTileScreenArea uses the screen centre for every tile
+        // (docs/internals/rendering/02-tiles.md, the LOD rule).
         _lodElevation = 0;
+        _lodElevationManager.reset();
         if (auto options = getOptions()) {
             if (auto terrainOptions = options->getTerrainOptions()) {
                 if (terrainOptions->isEnabled()) {
                     if (auto elevationManager = terrainOptions->getElevationManager()) {
+                        _lodElevationManager = elevationManager;
                         const cglib::vec3<double>& focusPos = cullState->getViewState().getFocusPos();
                         _lodElevation = elevationManager->getDisplayHeight(focusPos(0), focusPos(1), ElevationManager::LoadMode::CACHED_ONLY);
                     }
@@ -740,6 +743,16 @@ namespace massif {
         // projected area and is always subdivided.
         const cglib::mat4x4<double>& mvpMat = viewState.getModelviewProjectionMat();
         cglib::mat4x4<double> tileMat = tileTransformer->calculateTileMatrix(vtTileId, 1.0f);
+        // The height THIS tile sits at, not the height under the screen centre that tangram uses for
+        // every tile - at a low tilt the focus can be a kilometre above the near ground. The band
+        // midpoint, not its top: see docs/internals/rendering/02-tiles.md, the LOD rule.
+        double lodElevation = _lodElevation;
+        if (_lodElevationManager) {
+            double minZ = 0, maxZ = 0;
+            if (_lodElevationManager->getMinMaxDisplayHeightCached(MapTile(tile.getX() & tileMask, tile.getY(), tile.getZoom(), 0), minZ, maxZ)) {
+                lodElevation = (minZ + maxZ) * 0.5;
+            }
+        }
         double screenArea = std::numeric_limits<double>::infinity();
         {
             static const cglib::vec3<double> CORNERS[4] = {
@@ -750,7 +763,7 @@ namespace massif {
             bool projected = true;
             for (int i = 0; i < 4; i++) {
                 cglib::vec3<double> worldPos = cglib::transform_point(CORNERS[i], tileMat);
-                worldPos(2) += _lodElevation; // see calculateVisibleTiles
+                worldPos(2) += lodElevation;
                 cglib::vec4<double> clipPos = cglib::transform(cglib::vec4<double>(worldPos(0), worldPos(1), worldPos(2), 1.0), mvpMat);
                 if (!(clipPos(3) > 0)) {
                     projected = false;

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -672,6 +672,7 @@ namespace massif {
         }
 
         _lodMaxTileArea = 0;
+        _lodMinCosTheta = 0;
         if (auto options = getOptions()) {
             const ViewState& viewState = cullState->getViewState();
             double tileSizePixels = options->getTileDrawSize() * viewState.getDPI() / Const::UNSCALED_DPI;
@@ -681,6 +682,10 @@ namespace massif {
             // A source whose tiles are bigger than the nominal size carries a zoom bias; the same
             // bias applies to the area it is allowed to cover (tangram: maxArea * exp2(2*zoomBias)).
             _lodMaxTileArea = maxEdge * maxEdge * std::pow(4.0, -getZoomLevelBias());
+            // Floor on cos(incidence): the area falls with the distance AND with the grazing angle,
+            // and only the second term is bounded here (docs/internals/rendering/02-tiles.md).
+            float limit = options->getTileLODForeshorteningLimit();
+            _lodMinCosTheta = limit > 0 ? std::pow(2.0, -2.0 * limit) : 0.0;
         }
 
         // Recursively calculate visible tiles
@@ -779,6 +784,14 @@ namespace massif {
                     area += p(0) * q(1) - q(0) * p(1);
                 }
                 screenArea = std::abs(area) * 0.5;
+                if (_lodMinCosTheta > 0) {
+                    cglib::vec3<double> toTile = tileCenter + cglib::vec3<double>(0, 0, lodElevation) - viewState.getCameraPos();
+                    double dist = cglib::length(toTile);
+                    double cosTheta = dist > 0 ? std::abs(toTile(2)) / dist : 1.0;
+                    if (cosTheta > 0 && cosTheta < _lodMinCosTheta) {
+                        screenArea *= _lodMinCosTheta / cosTheta; // the area this tile would have at the limit
+                    }
+                }
             }
         }
         bool subDivide = !(_lodMaxTileArea > 0) || screenArea >= _lodMaxTileArea;

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -25,6 +25,7 @@
 namespace massif {
     class CancelableTask;
     class CullState;
+    class ElevationManager;
     class GLResourceManager;
     class ProjectionSurface;
     class TerrainOptions;
@@ -525,7 +526,8 @@ namespace massif {
         int _terrainMinTileZoom = 0; // terrain mode: the coarsest tile zoom the LOD rule may pick
         double _maxVisibleDistance = 0; // internal units; 0 = as far as the camera can see
         double _lodMaxTileArea = 0; // screen pixels squared; the tangram LOD threshold, 0 = no area test
-        double _lodElevation = 0; // world z the LOD projects tile corners at (the terrain under the focus)
+        double _lodElevation = 0; // world z the LOD projects a tile at when the DEM has no data for it (the terrain under the focus)
+        std::shared_ptr<ElevationManager> _lodElevationManager; // held for one cull pass, per-tile terrain height for the LOD
         bool _terrainOverzoomTargets = false; // terrain mode: target tiles may exceed the data source max zoom (overzoom-fed)
 
         std::vector<MapTile> _visibleTiles;

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -526,6 +526,7 @@ namespace massif {
         int _terrainMinTileZoom = 0; // terrain mode: the coarsest tile zoom the LOD rule may pick
         double _maxVisibleDistance = 0; // internal units; 0 = as far as the camera can see
         double _lodMaxTileArea = 0; // screen pixels squared; the tangram LOD threshold, 0 = no area test
+        double _lodMinCosTheta = 0; // cos of the most grazing incidence the LOD charges for, 0 = no limit
         double _lodElevation = 0; // world z the LOD projects a tile at when the DEM has no data for it (the terrain under the focus)
         std::shared_ptr<ElevationManager> _lodElevationManager; // held for one cull pass, per-tile terrain height for the LOD
         bool _terrainOverzoomTargets = false; // terrain mode: target tiles may exceed the data source max zoom (overzoom-fed)

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -569,7 +569,11 @@ namespace massif {
         getMinMaxDisplayHeight(tile, minZ, maxZ, true);
     }
 
-    void ElevationManager::getMinMaxDisplayHeight(const MapTile& tile, double& minZ, double& maxZ, bool exact) const {
+    bool ElevationManager::getMinMaxDisplayHeightCached(const MapTile& tile, double& minZ, double& maxZ) const {
+        return getMinMaxDisplayHeight(tile, minZ, maxZ, true);
+    }
+
+    bool ElevationManager::getMinMaxDisplayHeight(const MapTile& tile, double& minZ, double& maxZ, bool exact) const {
         // Fall back to the maximum elevation actually observed so far (starting flat) instead
         // of a large conservative constant: a many-kilometers default bound would pull far
         // tiles into the view frustum, causing them to fetch elevation data, which changes
@@ -597,10 +601,11 @@ namespace massif {
         if (exact && haveData) {
             minZ = minMeters * exaggeration * scale;
             maxZ = maxMeters * exaggeration * scale;
-            return;
+            return true;
         }
         minZ = std::min(0.0, minMeters * exaggeration * scale);
         maxZ = std::max(0.0, maxMeters * exaggeration * scale);
+        return haveData;
     }
 
     unsigned int ElevationManager::getDataVersion() const {

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -188,6 +188,12 @@ namespace massif {
          * shadow box, not culling. Falls back to the clamped range when the tile has no data.
          */
         void getMinMaxDisplayHeightExact(const MapTile& tile, double& minZ, double& maxZ) const;
+        /**
+         * getMinMaxDisplayHeightExact, plus whether the range came from decoded data: false when
+         * the tile has no cached grid, for a caller that would rather keep its own estimate than
+         * use the conservative global one. Never loads.
+         */
+        bool getMinMaxDisplayHeightCached(const MapTile& tile, double& minZ, double& maxZ) const;
         virtual unsigned int getVersion() const override;
 
         /**
@@ -227,7 +233,7 @@ namespace massif {
         std::shared_ptr<ElevationTileGrid> lookupTileGrid(const MapTile& dataTile, LoadMode mode) const;
         std::shared_ptr<ElevationTileGrid> getGridForInternalPos(double internalX, double internalY, LoadMode mode) const;
         std::shared_ptr<ElevationTileGrid> loadTileGrid(const MapTile& mapTile) const;
-        void getMinMaxDisplayHeight(const MapTile& tile, double& minZ, double& maxZ, bool exact) const;
+        bool getMinMaxDisplayHeight(const MapTile& tile, double& minZ, double& maxZ, bool exact) const;
         void runPrefetchWorker() const;
 
         const std::shared_ptr<TileDataSource> _dataSource;

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1753,5 +1753,7 @@ Gain on the visible set, static at 45.1852/5.7220 z15.71 t29: `z10=3 z11=1 z12=4
 
 **It does not fix the grazing far field**, which is what prompted the work. At that camera the
 accepted areas are 13k-83k px² against a 212k threshold — the elevation term moves the areas 2-4x
-and still trips no level. Method and the rule change that would fix it are in
+and still trips no level. The cause is the flat footprint quad, not the rule: maplibre's
+`calculateTileZoom` reduces to the same `−log2(d) + ½·log2(cos θ)` as the area test at its default
+fov. Method and the fix that would work (per-corner DEM heights) are in
 [02-tiles.md](rendering/02-tiles.md#the-lod-height-is-per-tile-not-per-frame).

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1724,3 +1724,34 @@ drape tile, and the extrusions are a small part of the geometry.
 The model and the two dead ends - a per-fragment depth test on the label pass, and a
 `GL_DEPTH_COMPONENT24` texture sampled from the vertex stage - are in
 [the labels page](rendering/06-labels.mdx#per-label-occlusion-by-3d-content).
+
+## 22. Per-tile LOD height (2026-08-20)
+
+Crosscall (Adreno 610), `-PprofileRender`, Grenoble looking north into the Chartreuse
+`--es lat 45.218503 --es lon 5.734582 --es zoom 15.37 --es tilt 29 --es rotation -7.46
+--es contour true --es hs true --es anim pan --es animLatDelta 0.03`, three interleaved pairs of
+prebuilt APKs, `bench/absum.py` medians over 63-64 windows.
+
+`TileLayer::calculateVisibleTilesRecursive` projected every tile at the elevation under the screen
+centre (tangram's rule). Here the focus sits at **1389 m** and the near valley at ~250 m, so the
+near field was projected a kilometre too high.
+
+| tile height for the area test | fps | frame ms | tiles/frame |
+|---|---|---|---|
+| screen centre (before) | 25.7 | 29.7 | 42.0 |
+| elevation band **top** | 21.8 | 33.8 | 57.0 |
+| elevation band **midpoint** (shipped) | 25.8 | 29.5 | 38.8 |
+
+The band top is the maplibre-shaped choice (the AABB point nearest the camera) and costs **15% of
+the frame** for +37% tiles: projecting a whole quad at its highest corner refines the far field for
+one peak. The midpoint redistributes instead — slopes refine, the near valley coarsens — and is
+free. One `ElevationManager::getMinMaxDisplayHeightCached` per visited quadtree node (one mutex +
+LRU read, `CACHED_ONLY`, never loads) does not show at this scale.
+
+Gain on the visible set, static at 45.1852/5.7220 z15.71 t29: `z10=3 z11=1 z12=4 z14=3 z15=7` →
+`z10=3 z12=4 z13=2 z14=4 z15=6`.
+
+**It does not fix the grazing far field**, which is what prompted the work. At that camera the
+accepted areas are 13k-83k px² against a 212k threshold — the elevation term moves the areas 2-4x
+and still trips no level. Method and the rule change that would fix it are in
+[02-tiles.md](rendering/02-tiles.md#the-lod-height-is-per-tile-not-per-frame).

--- a/docs/internals/performance-log.md
+++ b/docs/internals/performance-log.md
@@ -1757,3 +1757,37 @@ and still trips no level. The cause is the flat footprint quad, not the rule: ma
 `calculateTileZoom` reduces to the same `−log2(d) + ½·log2(cos θ)` as the area test at its default
 fov. Method and the fix that would work (per-corner DEM heights) are in
 [02-tiles.md](rendering/02-tiles.md#the-lod-height-is-per-tile-not-per-frame).
+
+## 23. Bounding the LOD's foreshortening term (2026-08-20)
+
+Same rig and camera as entry 22, plus a static probe logging `(zoom, area, cos θ, distance)` per
+accepted tile. `Options::TileLODFactor` 0.5 (the demo's value), threshold 212 337 px².
+
+The probe's first result is the useful one: at tilt 29 **every** accepted tile is at 79°–89°
+incidence, losing 1.2–3.0 levels to foreshortening — not just the horizon band. And beyond ~15 km
+the tiles are distance-limited: they would need `cos θ > 1` to refine, so no bound on the grazing
+term can reach them.
+
+`Options::TileLODForeshorteningLimit` (default 0 = off = tangram's rule), static camera at
+45.1852/5.7220 z15.71 t29:
+
+| limit | visible set | n |
+|---|---|---|
+| 0 | `z10=3 z12=4 z13=2 z14=4 z15=6` | 19 |
+| 1.25 | `z10=2 z12=4 z13=2 z14=2 z15=9` | 19 |
+| 1.0 | `z11=2 z12=3 z13=6 z14=2 z15=9` | 22 |
+| 0.75 | saturated, same as 1.0 | 22 |
+
+Cost at limit 1.0, panning north at 45.2185/5.7346 z15.37 t29, 3 interleaved pairs, 63 windows:
+
+| | fps | frame ms | tiles/frame |
+|---|---|---|---|
+| off | 26.7 | 29.1 | 40.0 |
+| limit 1.0 | 24.6 | 30.1 | 50.4 |
+
+**+26% tiles for −8% fps.** Off by default, so it costs nothing until an app opts in.
+
+**Method note — do not size an LOD change from a spreadsheet.** Applying the clamp to each accepted
+tile's measured area predicted 19 → 40 tiles, **7× the real cost**. The recursion boosts a parent
+and its children by the same factor, so a tile that splits produces children that stop one level
+down rather than cascading; the per-tile model has no way to see that. Build it and count.

--- a/docs/internals/rendering/02-tiles.md
+++ b/docs/internals/rendering/02-tiles.md
@@ -139,6 +139,43 @@ At **tilt 90** none of this applies: the areas there (408k–464k px²) are abov
 level is the `targetTileZoom` cap, `floor(cameraZoom)`, for every tile. Tangram short-circuits the
 same case explicitly (`if (m_pitch == 0) return FLT_MAX`).
 
+### Bounding what the grazing angle may cost
+
+The area rule folds two independent things into one number. Write it as a level:
+
+```
+level = const − log2(distance) + ½·log2(cos θ)      θ = incidence of the view ray on the ground
+```
+
+The first term is what LOD is *for*. The second is foreshortening, and at a low tilt it dominates
+everything: measured per accepted tile on the Crosscall at 45.1852/5.7220 z15.71 t29, **every tile in
+the frame sits at 79°–89° of incidence** and loses **1.2 to 3.0 levels** to it — the near ones as much
+as the horizon. That is why a mountain 10 km out stays coarse while ground at the same distance
+under a steeper angle is refined, and why panning closer to it does so little: you are buying back
+one level per halving of distance against a 2-level foreshortening debt.
+
+`Options::TileLODForeshorteningLimit` bounds the second term only, as a floor on `cos θ`
+(`limit` levels ⇒ `cos θ ≥ 2^(−2·limit)`). The distance term is untouched, so genuinely far ground
+stays coarse — and it *must*, because beyond ~15 km those tiles would need `cos θ > 1` to refine at
+all. `0` (the default) is the area rule exactly as tangram wrote it.
+
+Measured at that camera, `TileLODFactor` 0.5 (the demo's value), threshold 212 337 px²:
+
+| limit | visible set | n |
+|---|---|---|
+| 0 (off) | `z10=3 z12=4 z13=2 z14=4 z15=6` | 19 |
+| 1.25 | `z10=2 z12=4 z13=2 z14=2 z15=9` | 19 |
+| **1.0** | `z11=2 z12=3 z13=6 z14=2 z15=9` | 22 |
+| 0.75 | same as 1.0 (saturated) | 22 |
+
+At 1.0 the 46–66 km `z10` patches are gone, `z13` triples, and the ladder is continuous `z11`…`z15`
+instead of jumping `z12`→`z10`. Cost while panning (3 interleaved pairs, 63 windows):
+**40.0 → 50.4 tiles/frame, 26.7 → 24.6 fps** — +26% tiles for −8% frame rate.
+
+Do not size this from a spreadsheet. Simulating the clamp per accepted tile predicted 19 → 40 tiles
+at limit 1.0, **7× the real cost**: boosting a parent boosts its children by the same factor, so a
+tile that splits produces children that stop one level down instead of cascading.
+
 ### The coarsening floor times the view distance
 
 `TerrainOptions::MaxTileZoomCoarsening` floors how coarse a far tile may get (default: 3 levels

--- a/docs/internals/rendering/02-tiles.md
+++ b/docs/internals/rendering/02-tiles.md
@@ -111,14 +111,29 @@ The midpoint redistributes rather than adds: slopes refine, the near valley coar
 effect on the visible set at 45.1852/5.7220 z15.71 t29, a coarse mid-field patch splitting:
 `z10=3 z11=1 z12=4 z14=3 z15=7` → `z10=3 z12=4 z13=2 z14=4 z15=6`.
 
-**What this does not fix.** At that camera the accepted tiles' areas run 13k–83k px² against a
-212k px² threshold — 3 to 16× under it — so the elevation term moves areas without moving levels.
-The deep massif is coarse because a grazing tile's projected area collapses with the foreshortening,
-not because of its height, and the area rule counts that foreshortening on top of the distance. The
-symptom is a tile that stays coarse after you pan closer to it than a tile that was already fine.
-The lever for that is the rule itself — maplibre's `calculateTileZoom` is a distance ratio plus an
-explicit `maxZoomLevelsOnScreen` budget, and loses roughly one level per doubling of distance where
-the area rule loses two. Not adopted; see [11-tangram-diff.md](11-tangram-diff.md).
+**What this does not fix: the flat footprint.** At that camera the accepted tiles' areas run
+13k–83k px² against a 212k px² threshold — 3 to 16× under it — so the elevation term moves areas
+without moving levels. The symptom is a mountain that stays coarse after you pan closer to it than a
+tile that was already fine, while flat ground at the same distance behaves.
+
+The cause is not the rule. Both candidate rules decompose identically:
+
+```
+level = const − log2(distance) + (p/2)·log2(cos θ)     θ = incidence angle of the view ray on the ground
+```
+
+with `p = 1` for the area rule, and `p = 2·((maxZoomLevelsOnScreen − 1) / log2(cos(H − fov)/cos H) − 1)`
+for maplibre's `calculateTileZoom` — which is **1.000** at its defaults (`maxZoomLevelsOnScreen`
+9.314, `maxMercatorHorizonAngle` 89.25°, fov 36.87°). Same rule. Swapping to it buys nothing here;
+it only becomes gentler than ours above fov ~37° (p 0.83 at fov 50) and harsher below.
+
+What is wrong is the **input**: the four corners are projected as a flat footprint quad, so a
+mountain face standing toward the camera is given the incidence angle of flat ground in the same
+place. At 85° flat incidence a 30° slope facing the camera really presents cos 55° / cos 85° ≈ 6.6×
+the area — **1.4 levels**. Projecting each corner at its own DEM height instead of all four at one
+height would recover that, and only where the ground is actually tilted toward the viewer. Not done
+yet. The blunt alternative, `Options::TileLODFactor` 0.71, buys the same level everywhere and costs
+2× the tiles.
 
 At **tilt 90** none of this applies: the areas there (408k–464k px²) are above the threshold, so the
 level is the `targetTileZoom` cap, `floor(cameraZoom)`, for every tile. Tangram short-circuits the

--- a/docs/internals/rendering/02-tiles.md
+++ b/docs/internals/rendering/02-tiles.md
@@ -56,12 +56,14 @@ Three terrain-specific details, each of which was a bug once:
 
 - **The LOD area is taken at surface level, not from the elevation-expanded bbox.** Otherwise
   subdivision decisions change as elevation streams in, and the visible tile set (and with it tile
-  and DEM fetching) churns forever. "Surface level" is the elevation **at the screen centre**
-  (`_lodElevation`), tangram's choice too (`View::getTileScreenArea`, "use elevation at center of
-  screen"): one value for the whole cull, so it moves with the camera and not with the tile.
-  Measuring a mountain tile as if it lay at sea level puts it further away and makes it smaller, so
-  it stays coarse exactly where the terrain is high and steep — blurred hillshade, a blunt depth
-  occluder that ridges leak through, and a wide LOD spread that tears at tile borders.
+  and DEM fetching) churns forever. Measuring a mountain tile as if it lay at sea level puts it
+  further away and makes it smaller, so it stays coarse exactly where the terrain is high and steep
+  — blurred hillshade, a blunt depth occluder that ridges leak through, and a wide LOD spread that
+  tears at tile borders. "Surface level" is the **midpoint of the tile's own elevation band**
+  (`ElevationManager::getMinMaxDisplayHeightCached`, never loads), falling back to the elevation at
+  the screen centre (`_lodElevation`) where the DEM is not decoded yet. See
+  [the per-tile height](#the-lod-height-is-per-tile-not-per-frame) below for why this differs from
+  both references.
 - **Target tiles may exceed the data source's max zoom** in terrain mode
   (`_terrainOverzoomTargets`, fed by the existing overzoom machinery). A z12 DEM-derived hillshade
   under a z15 camera otherwise renders surfaces many times coarser than the base map's, and those
@@ -80,6 +82,47 @@ Three terrain-specific details, each of which was a bug once:
   [05-depth.md](05-depth-model.md)) — so it is an explicit trade, not the default. A style may pin an absolute
   distance in metres with `terrain-max-visible-distance`. Pair a short one with fog
   ([08-lighting-sky-fog.md](08-lighting-sky-fog.md)) or the ground simply ends.
+
+### The LOD height is per-tile, not per-frame
+
+Both references use **one** height for every tile in a frame. Tangram takes the terrain depth under
+the screen centre (`View::getTileScreenArea`, "use elevation at center of screen"). Maplibre's
+`coveringTiles` uses each tile's real min/max elevation AABB — but only for the **frustum test**:
+its LOD distance is `Aabb.distanceX`/`distanceY`, purely horizontal, and the vertical term
+(`distanceToTileZ`) is the camera-to-center distance, the same for every tile
+(`src/geo/projection/covering_tiles.ts`). Neither refines by per-tile height.
+
+One height per frame is wrong whenever the screen centre is not at the height of the tile being
+judged, and at a low tilt that is most of the frame. Measured on the Crosscall at
+45.2185/5.7346 z15.37 t29 looking north into the Chartreuse, the focus sits at **1389 m** while the
+near valley is at ~250 m: every near tile was projected a kilometre too high.
+
+The tile's own band midpoint is used instead — the midpoint, not the ceiling, because projecting the
+whole quad at the band's top refines a valley tile for one high corner. Measured at the same camera,
+3 interleaved pairs, `--es contour true --es hs true`, panning north:
+
+| tile height | fps (median of 63 windows) | tiles/frame |
+|---|---|---|
+| screen centre (tangram) | 25.7 | 42.0 |
+| band top | 21.8 | 57.0 |
+| band midpoint | 25.8 | 38.8 |
+
+The midpoint redistributes rather than adds: slopes refine, the near valley coarsens. Measured
+effect on the visible set at 45.1852/5.7220 z15.71 t29, a coarse mid-field patch splitting:
+`z10=3 z11=1 z12=4 z14=3 z15=7` → `z10=3 z12=4 z13=2 z14=4 z15=6`.
+
+**What this does not fix.** At that camera the accepted tiles' areas run 13k–83k px² against a
+212k px² threshold — 3 to 16× under it — so the elevation term moves areas without moving levels.
+The deep massif is coarse because a grazing tile's projected area collapses with the foreshortening,
+not because of its height, and the area rule counts that foreshortening on top of the distance. The
+symptom is a tile that stays coarse after you pan closer to it than a tile that was already fine.
+The lever for that is the rule itself — maplibre's `calculateTileZoom` is a distance ratio plus an
+explicit `maxZoomLevelsOnScreen` budget, and loses roughly one level per doubling of distance where
+the area rule loses two. Not adopted; see [11-tangram-diff.md](11-tangram-diff.md).
+
+At **tilt 90** none of this applies: the areas there (408k–464k px²) are above the threshold, so the
+level is the `targetTileZoom` cap, `floor(cameraZoom)`, for every tile. Tangram short-circuits the
+same case explicitly (`if (m_pitch == 0) return FLT_MAX`).
 
 ### The coarsening floor times the view distance
 

--- a/docs/internals/rendering/11-tangram-diff.md
+++ b/docs/internals/rendering/11-tangram-diff.md
@@ -94,9 +94,11 @@ elevation band midpoint instead, falling back to their value where the DEM is no
 Maplibre is not a precedent for this either — its `coveringTiles` uses the per-tile elevation AABB
 for the **frustum test** only, and its LOD distance is horizontal (`Aabb.distanceX`/`distanceY`).
 
-Cost, gain and the case it does **not** fix (the grazing far field, where the area rule counts the
-foreshortening on top of the distance and maplibre's distance-ratio rule would not) are in
-[02-tiles.md](02-tiles.md#the-lod-height-is-per-tile-not-per-frame).
+Cost, gain and the case it does **not** fix (a mountain face given the incidence angle of flat
+ground, because the area is taken on the tile's flat footprint) are in
+[02-tiles.md](02-tiles.md#the-lod-height-is-per-tile-not-per-frame). Note there that maplibre's
+`calculateTileZoom` reduces to the *same* rule as tangram's area test at its default fov, so it is
+not an alternative worth porting for that case.
 
 ### The zoom is calibrated on the focus, not on the terrain
 

--- a/docs/internals/rendering/11-tangram-diff.md
+++ b/docs/internals/rendering/11-tangram-diff.md
@@ -34,7 +34,8 @@ and *still different*, the latter with the reason it is not simply copied.
 | line antialias | none — hard-edged quads (`core/shaders/polyline.fs`) | ramp over one device pixel (`uAntialiasScale`) | **different — we antialias** |
 | content subdivision | none at all | area fills to two surface cells; lines cut at the lattice | **different — see below** |
 | elevation texture | source raster bound directly, ancestors via uv sub-rects, edges extrapolated in-shader (`res/scenes/elevation.yaml`) | per-tile CPU re-encode with a 1-texel border from up to 8 neighbours | **different — see below** |
-| tile LOD | subdivide while screen area > `(2·pixelScale·256)²` (`core/src/tile/tileManager.cpp:214`) | distance rule, ~one zoom level finer | **different — measured not to matter** |
+| tile LOD | subdivide while screen area > `(2·pixelScale·256)²` (`core/src/tile/tileManager.cpp:214`) | same rule, `Options::TileLODFactor` scaling it | ported whole |
+| LOD tile height | terrain depth at the screen centre, one value per frame (`View::getTileScreenArea`) | each tile's own elevation band midpoint | **different — see below** |
 | tile decode threads | 2 (`SceneOptions::numTileWorkers`) | 1 (`Options::setTileThreadPoolSize`) | **different — measured not to matter** |
 | terrain depth read-back | worker thread, shared context, half res, never waited on | worker thread, **unshared** context, submit-interval limited | ported with a difference |
 | terrain shadows | none | cascaded shadow maps (currently off on the shared ground) | **we are ahead** ([08](08-lighting-sky-fog.md)) |
@@ -81,6 +82,21 @@ the name cannot win or lose a slot independently — "icon placed, name dropped"
 no equivalent because CartoCSS centres every line within the block already, so alignment only moves
 the block and one glyph run covers all sides. See
 [06-labels.mdx](06-labels.mdx#anchored-shields-the-name-takes-a-free-side-fork-specific).
+
+### The LOD height is per-tile
+
+Their `getTileScreenArea` projects every tile at the terrain depth under the screen centre. That is
+right for their camera, whose zoom is *defined* by that same depth (see the next section), and wrong
+for ours, which lets the focus keep its own height: at a low tilt the focus can sit a kilometre above
+the near ground, and every near tile is then projected a kilometre too high. We use the tile's own
+elevation band midpoint instead, falling back to their value where the DEM is not decoded yet.
+
+Maplibre is not a precedent for this either — its `coveringTiles` uses the per-tile elevation AABB
+for the **frustum test** only, and its LOD distance is horizontal (`Aabb.distanceX`/`distanceY`).
+
+Cost, gain and the case it does **not** fix (the grazing far field, where the area rule counts the
+foreshortening on top of the distance and maplibre's distance-ratio rule would not) are in
+[02-tiles.md](02-tiles.md#the-lod-height-is-per-tile-not-per-frame).
 
 ### The zoom is calibrated on the focus, not on the terrain
 

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoConfig.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoConfig.java
@@ -178,6 +178,11 @@ public final class DemoConfig {
      *  (fewer tiles, fewer far labels); 0 refines everything to the camera zoom.
      *  '--es lodFactor 2'. */
     public static float TILE_LOD_FACTOR = 0.5f;
+    /** Zoom levels a tile may lose to the grazing angle alone, 0 = no limit (the tangram rule).
+     *  Bounds only the foreshortening half of the LOD area test, never the distance half, so far
+     *  ground stays coarse while a tilted mid-field is refined. Costs ~2x the tiles per level.
+     *  '--es lodGrazing 1.25'. */
+    public static float TILE_LOD_GRAZING = 0f;
     /** Metres beyond which the inline style's street labels are not placed (0 = no limit). Only
      *  the inline style uses it; it is the 'text-max-distance' CartoCSS property.
      *  '--es labelMaxDistance 2000'. */
@@ -1051,6 +1056,7 @@ public final class DemoConfig {
         // terrain
         TILE_THREAD_POOL_SIZE = DemoCfg.cfgInt("tilePool", TILE_THREAD_POOL_SIZE);
         TILE_LOD_FACTOR = DemoCfg.cfgFloat("lodFactor", TILE_LOD_FACTOR);
+        TILE_LOD_GRAZING = DemoCfg.cfgFloat("lodGrazing", TILE_LOD_GRAZING);
         LABEL_MAX_DISTANCE = DemoCfg.cfgFloat("labelMaxDistance", LABEL_MAX_DISTANCE);
         TERRAIN_ENABLED = DemoCfg.cfgBool("terrain", TERRAIN_ENABLED);
         TERRAIN_CAMERA_CLEARANCE = DemoCfg.cfgFloat("clearance", TERRAIN_CAMERA_CLEARANCE);

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoLive.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoLive.java
@@ -33,7 +33,7 @@ public final class DemoLive extends BroadcastReceiver {
     };
     private static final String[] TERRAIN_KEYS = {
         "terrain", "drape", "drapeLines", "drapeResolution", "meshResolution", "exaggeration",
-        "viewDistance", "viewDistanceMeters", "coarsening", "stitch", "textOcclusion"
+        "viewDistance", "viewDistanceMeters", "coarsening", "stitch", "textOcclusion", "lodFactor", "lodGrazing"
     };
     private static final String[] LIGHT_KEYS = {
         "daycycle", "sunHour", "sunAzimuth", "sunAltitude", "shadow", "shadowSoftness",

--- a/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoMap.java
+++ b/scripts/android-dev/app/src/main/java/com/massifmaps/MassifDemo/demo/DemoMap.java
@@ -1330,6 +1330,8 @@ public class DemoMap {
 
     /** Creates the TerrainOptions on first call, then pushes every terrain value onto it. */
     public void applyTerrainOptions() {
+        mapView.getOptions().setTileLODFactor(DemoConfig.TILE_LOD_FACTOR);
+        mapView.getOptions().setTileLODForeshorteningLimit(DemoConfig.TILE_LOD_GRAZING);
         if (terrainOptions == null) {
             terrainOptions = new TerrainOptions(demSource(), elevationDecoder());
             mapView.getOptions().setTerrainOptions(terrainOptions);


### PR DESCRIPTION
Two changes to how `TileLayer::calculateVisibleTilesRecursive` picks a tile's zoom, both driven by
per-tile probe data taken on the Crosscall (Adreno 610) at the cameras below.

## 1. The LOD height is the tile's own, not the screen centre's

Tangram projects every tile at the terrain depth under the screen centre
(`View::getTileScreenArea`). That is right for their camera, whose zoom is *defined* by that same
depth. Ours lets the focus keep its own height, so at a low tilt the focus sits far above the near
ground — measured **1389 m against a ~250 m valley** — and every near tile was projected a kilometre
too high.

Each tile is now projected at the **midpoint of its own elevation band**
(`ElevationManager::getMinMaxDisplayHeightCached`, `CACHED_ONLY`, never loads, never blocks),
falling back to the screen-centre height where the DEM is not decoded yet.

The midpoint, **not the band top**: the top is the maplibre-shaped choice (the AABB point nearest
the camera) and costs 15% of the frame for +37% tiles, because a whole quad projected at its highest
corner refines the far field for one peak.

| tile height for the area test | fps | frame ms | tiles/frame |
|---|---|---|---|
| screen centre (before) | 25.7 | 29.7 | 42.0 |
| elevation band top | 21.8 | 33.8 | 57.0 |
| elevation band midpoint (this PR) | 25.8 | 29.5 | 38.8 |

Cost-neutral — it redistributes rather than adds: slopes refine, the near valley coarsens.

## 2. `Options::TileLODForeshorteningLimit`

The area test folds two independent things into one number:

```
level = const − log2(distance) + ½·log2(cos θ)      θ = incidence of the view ray on the ground
```

The probe's headline result: at tilt 29, **every** accepted tile is at 79°–89° incidence and loses
**1.2–3.0 levels** to the second term — the near ones as much as the horizon. That is why a mountain
10 km out stays coarse while ground at the same distance under a steeper angle is refined, and why
panning closer barely helps: one level per halving of distance against a 2-level debt.

The new option floors `cos θ` at `2^(−2·limit)`, bounding that term **only**. The distance term is
untouched, so genuinely far ground stays coarse — and must: beyond ~15 km those tiles would need
`cos θ > 1` to refine at all. `0` is the default and is tangram's rule unchanged, so nothing moves
until an app opts in.

Static camera 45.1852/5.7220 z15.71 t29, `TileLODFactor` 0.5, threshold 212 337 px²:

| limit | visible set | n |
|---|---|---|
| 0 (off) | `z10=3 z12=4 z13=2 z14=4 z15=6` | 19 |
| 1.25 | `z10=2 z12=4 z13=2 z14=2 z15=9` | 19 |
| **1.0** | `z11=2 z12=3 z13=6 z14=2 z15=9` | 22 |
| 0.75 | saturated, same as 1.0 | 22 |

At 1.0 the 46–66 km `z10` patches go, `z13` triples, and the ladder is continuous `z11`…`z15`
instead of jumping `z12`→`z10`. Cost while panning, 3 interleaved pairs of 63 windows:
**40.0 → 50.4 tiles/frame, 26.7 → 24.6 fps** (+26% tiles, −8% fps).

## Two dead ends worth recording

- **Per-corner DEM heights** (tilting the quad to the real surface) made it *worse* — `z12`×4
  collapsed to ×1. For a grazing tile `A ∝ h/(D²+h²)^{3/2}` with `h` the camera height above the
  ground, and `∂A/∂h = 0` at `h = D/√2`; far tiles are in the `A ≈ h/D³` regime, so raising the
  ground toward camera height *reduces* its projected area. No height model can refine the far field.
- **Maplibre's `calculateTileZoom` is not an alternative**: `p = 2·((maxZoomLevelsOnScreen − 1) /
  log2(cos(H − fov)/cos H) − 1)` evaluates to **1.000** at its defaults — algebraically the same
  rule as tangram's area test. Porting it would change nothing.

Both are written up in [02-tiles.md](docs/internals/rendering/02-tiles.md) so the next reader does
not pay for them again.

## Testing

- `clang++ -fsyntax-only -std=c++20 -DTARGET_OS_ANDROID` clean on `TileLayer.cpp`,
  `ElevationManager.cpp`, `Options.cpp`.
- `all/modules/components/Options.i` gained one attribute; wrappers regenerated with
  `swigpp-java.py --profile "standard+valhalla+geocoding+routing+packagemanager"`.
- `cd website && npm run build` clean, no broken-links block.
- Device numbers above are perf and tile-set counts. **A visual check is still required** — they say
  the tile set changed and what it cost, not that the map looks right. The demo knobs are live now:

```sh
adb shell am start -n com.massifmaps.MassifDemo/.MainActivity --es ui false \
  --es contour true --es hs true --es lodGrazing 1.0 \
  --es lat 45.185165 --es lon 5.722047 --es zoom 15.71 --es tilt 29 --es rotation -7.46
```

  `--es lodGrazing 0` is the off arm; both apply live via `DemoLive`, no relaunch. Watch for LOD
  seams at tile borders and for churn while the DEM streams in (a tile with no cached grid keeps the
  old screen-centre height, which is what guards that).

Docs: [02-tiles.md](docs/internals/rendering/02-tiles.md),
[11-tangram-diff.md](docs/internals/rendering/11-tangram-diff.md),
[performance-log.md](docs/internals/performance-log.md) entries 22 and 23.
