### PR TITLE
feat(website): redraw the brand mark as a two-peak massif

### DIFF
--- a/website/static/img/favicon.svg
+++ b/website/static/img/favicon.svg
@@ -1,11 +1,7 @@
-<svg width="32" height="32" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#036FE2"/>
-      <stop offset="1" stop-color="#00C4B3"/>
-    </linearGradient>
-  </defs>
-  <rect width="40" height="40" rx="9" fill="url(#g)"/>
-  <path d="M6 29 L15 15 L21 23 L27 12 L34 29 Z" fill="#ffffff"/>
-  <circle cx="27" cy="12" r="2.6" fill="#FF4F4F"/>
+<svg width="32" height="23" viewBox="0 5.5 40 29" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Massif Maps">
+  <title>Massif Maps</title>
+  <path d="M11.5 17 L2.5 32 L12.5 32 Z" fill="#00C4B3"/>
+  <path d="M11.5 17 L12.5 32 L20 32 Z" fill="#009184"/>
+  <path d="M23.5 8 L10.5 32 L24.5 32 Z" fill="#2C8BF0"/>
+  <path d="M23.5 8 L24.5 32 L37.5 32 Z" fill="#0A4FA8"/>
 </svg>

--- a/website/static/img/logo.svg
+++ b/website/static/img/logo.svg
@@ -1,11 +1,7 @@
-<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#036FE2"/>
-      <stop offset="1" stop-color="#00C4B3"/>
-    </linearGradient>
-  </defs>
-  <rect width="40" height="40" rx="9" fill="url(#g)"/>
-  <path d="M6 29 L15 15 L21 23 L27 12 L34 29 Z" fill="#ffffff" fill-opacity="0.95"/>
-  <circle cx="27" cy="12" r="2.4" fill="#FF4F4F"/>
+<svg width="44" height="32" viewBox="0 5.5 40 29" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Massif Maps">
+  <title>Massif Maps</title>
+  <path d="M11.5 17 L2.5 32 L12.5 32 Z" fill="#00C4B3"/>
+  <path d="M11.5 17 L12.5 32 L20 32 Z" fill="#009184"/>
+  <path d="M23.5 8 L10.5 32 L24.5 32 Z" fill="#2C8BF0"/>
+  <path d="M23.5 8 L24.5 32 L37.5 32 Z" fill="#0A4FA8"/>
 </svg>

--- a/website/static/img/social-card.svg
+++ b/website/static/img/social-card.svg
@@ -1,11 +1,13 @@
-<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Massif Maps placeholder">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#036FE2"/><stop offset="1" stop-color="#00C4B3"/>
-    </linearGradient>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <path d="M0 630 L240 289 L480 441 L720 214 L960 403 L1200 264 L1200 630 Z" fill="#ffffff" opacity="0.14"/>
-  <text x="600" y="296" font-family="system-ui,Segoe UI,Roboto,sans-serif" font-size="70" font-weight="800" fill="#ffffff" text-anchor="middle">&#128506;&#65039;  Massif Maps</text>
-  <text x="600" y="378" font-family="system-ui,Segoe UI,Roboto,sans-serif" font-size="26" fill="#eaf3ff" text-anchor="middle">Maps, terrain &amp; routing for Android and iOS</text>
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Massif Maps — maps, terrain and routing for Android and iOS">
+  <title>Massif Maps</title>
+  <rect width="1200" height="630" fill="#0A1729"/>
+  <path d="M0 630 L200 498 L360 566 L560 468 L760 546 L960 452 L1200 518 L1200 630 Z" fill="#0E2138"/>
+  <g transform="translate(206 215) scale(5)">
+    <path d="M11.5 17 L2.5 32 L12.5 32 Z" fill="#00C4B3"/>
+    <path d="M11.5 17 L12.5 32 L20 32 Z" fill="#009184"/>
+    <path d="M23.5 8 L10.5 32 L24.5 32 Z" fill="#2C8BF0"/>
+    <path d="M23.5 8 L24.5 32 L37.5 32 Z" fill="#0A4FA8"/>
+  </g>
+  <text x="458" y="326" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="82" font-weight="700" fill="#ffffff">Massif Maps</text>
+  <text x="462" y="382" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="30" fill="#8FA9C6">Maps, terrain &amp; routing for Android and iOS</text>
 </svg>


### PR DESCRIPTION
## Summary

- New logo: flat low-poly massif, two peaks, each split into a lit and a shadow face (teal foothill, blue summit). No gradient, no rounded-square container — the mark reads on any background instead of only inside its own card.
- `logo.svg` / `favicon.svg` drop the square padding (`viewBox 0 5.5 40 29`) so the mark fills the 32px navbar height rather than floating inside it.
- `social-card.svg` rebuilt around the mark: navy field, ridge silhouette, centred lockup, no emoji in the title.

## Testing

No C++ and no `all/modules/*.i` touched, so the syntax gate and SWIG regen do not apply.

Rendered both SVGs directly, and checked the navbar in the Docusaurus dev server (dark theme) — the mark fills the navbar height. Not checked: light theme navbar, which uses the same file.

## Known gaps

- The social card is still SVG. Most link scrapers (X, Slack, LinkedIn) do not render SVG previews, so the card never actually shows — same as before this PR, not a regression. A PNG needs a rasteriser that is not installed here.
- The Android demo (`scripts/android-dev`) still ships the stock Android Studio launcher icon, and the iOS demo has no AppIcon set at all. Both left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)