### PR TITLE
fix(ui): keep onMapStable firing after a pinch, for the rest of the session

### DIFF
--- a/all/native/renderers/components/KineticEventHandler.cpp
+++ b/all/native/renderers/components/KineticEventHandler.cpp
@@ -39,6 +39,11 @@ namespace massif {
         std::optional<CameraZoomEvent> cameraZoomEvent;
         {
             std::lock_guard<std::mutex> lock(_mutex);
+            // An option switched off mid-flight would otherwise leave its flag set forever, as
+            // calculate*() below only ever clears it from inside the enabled branch.
+            _pan = _pan && _options.isKineticPan();
+            _rotation = _rotation && _options.isKineticRotation();
+            _zoom = _zoom && _options.isKineticZoom();
             cameraPanEvent = calculatePan(viewState, deltaSeconds);
             cameraRotationEvent = calculateRotation(viewState, deltaSeconds);
             cameraZoomEvent = calculateZoom(viewState, deltaSeconds);
@@ -79,6 +84,11 @@ namespace massif {
     }
     
     void KineticEventHandler::startPan() {
+        // Only calculatePan() clears the flag, and it is a no-op when the option is off: setting it
+        // here anyway would latch isPanning() true for good and kill onMapStable.
+        if (!_options.isKineticPan()) {
+            return;
+        }
         {
             std::lock_guard<std::mutex> lock(_mutex);
             _pan = true;
@@ -124,6 +134,9 @@ namespace massif {
     }
     
     void KineticEventHandler::startRotation() {
+        if (!_options.isKineticRotation()) {
+            return; // see startPan
+        }
         {
             std::lock_guard<std::mutex> lock(_mutex);
             _rotation = true;
@@ -163,6 +176,9 @@ namespace massif {
     }
     
     void KineticEventHandler::startZoom() {
+        if (!_options.isKineticZoom()) {
+            return; // see startPan
+        }
         {
             std::lock_guard<std::mutex> lock(_mutex);
             _zoom = true;

--- a/all/native/ui/TouchHandler.cpp
+++ b/all/native/ui/TouchHandler.cpp
@@ -81,12 +81,46 @@ namespace massif {
             std::lock_guard<std::mutex> lock(_onTouchListenersMutex);
             onTouchListeners = _onTouchListeners;
         }
+        bool consumed = false;
         for (std::size_t i = onTouchListeners.size(); i-- > 0; ) {
             if (onTouchListeners[i]->onTouchEvent(action, screenPos1, screenPos2)) {
-                return;
+                consumed = true;
+                break;
             }
         }
 
+        if (!consumed) {
+            handleTouchEvent(action, screenPos1, screenPos2);
+        }
+
+        // The pointer count and the event checks run whether or not a listener took the gesture.
+        // A consumed UP used to skip them, leaving _pointersDown stuck and onMapStable dead for good.
+        {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            switch (action) {
+            // Assigned, not incremented: a gesture start resyncs the count, so an UP the platform
+            // never delivered costs one gesture instead of every onMapStable that follows.
+            case ACTION_POINTER_1_DOWN:
+                _pointersDown = 1;
+                break;
+            case ACTION_POINTER_2_DOWN:
+                _pointersDown = 2;
+                break;
+            case ACTION_POINTER_1_UP:
+            case ACTION_POINTER_2_UP:
+                _pointersDown = std::max(0, _pointersDown - 1);
+                break;
+            case ACTION_CANCEL:
+                _pointersDown = 0;
+                break;
+            }
+        }
+
+        checkCameraEvents();
+        checkMapStable();
+    }
+
+    void TouchHandler::handleTouchEvent(int action, const ScreenPos& screenPos1, const ScreenPos& screenPos2) {
         std::unique_lock<std::recursive_mutex> lock(_mutex);
         ViewState viewState = _mapRenderer->getViewState();
         switch (action) {
@@ -171,7 +205,6 @@ namespace massif {
             break;
     
         case ACTION_CANCEL:
-            _pointersDown = 0;
             _clickHandlerWorker->cancel();
             _gestureMode = SINGLE_POINTER_CLICK_GUESS;
             break;
@@ -251,17 +284,6 @@ namespace massif {
             break;
         }
 
-        if (action == ACTION_POINTER_1_DOWN || action == ACTION_POINTER_2_DOWN) {
-            _pointersDown = std::min(2, _pointersDown + 1);
-        } else if (action == ACTION_POINTER_1_UP || action == ACTION_POINTER_2_UP) {
-            _pointersDown = std::max(0, _pointersDown - 1);
-        }
-
-        lock.unlock();
-
-        // Call event handlers
-        checkCameraEvents();
-        checkMapStable();
     }
 
     void TouchHandler::onWheelEvent(int delta, const ScreenPos& screenPos) {

--- a/all/native/ui/TouchHandler.h
+++ b/all/native/ui/TouchHandler.h
@@ -101,6 +101,8 @@ namespace massif {
             std::weak_ptr<TouchHandler> _touchHandler;
         };
         
+        void handleTouchEvent(int action, const ScreenPos& screenPos1, const ScreenPos& screenPos2);
+
         void checkCameraEvents();
         void checkMapStable();
 

--- a/android/java/com/massifmaps/ui/MapView.java
+++ b/android/java/com/massifmaps/ui/MapView.java
@@ -58,6 +58,7 @@ public class MapView extends GLSurfaceView implements GLSurfaceView.Renderer, Ma
     
     private int pointer1Id = INVALID_POINTER_ID;
     private int pointer2Id = INVALID_POINTER_ID;
+    private boolean gestureAccepted;
     
     /**
      * Creates a new MapView object from a context object.
@@ -190,9 +191,14 @@ public class MapView extends GLSurfaceView implements GLSurfaceView.Renderer, Ma
             return false;
         }
 
-        boolean clickable = isClickable() || isLongClickable();
-        if (!isEnabled() || !clickable) {
-            return clickable;
+        // Latched for the whole gesture, not re-tested per event: a host framework that flips
+        // clickable or enabled mid-touch (adding or removing a gesture observer) would otherwise
+        // deliver the DOWN and drop the UP, and the native pointer count never comes back down.
+        if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
+            gestureAccepted = isEnabled() && (isClickable() || isLongClickable());
+        }
+        if (!gestureAccepted) {
+            return isClickable() || isLongClickable();
         }
 
         try {
@@ -280,6 +286,13 @@ public class MapView extends GLSurfaceView implements GLSurfaceView.Renderer, Ma
         }
         catch (IllegalArgumentException e) {
             com.massifmaps.utils.Log.error("MapView.onTouchEvent: " + e);
+            // The event never reached native, so its pointer was never released there. Cancel
+            // instead, or the native pointer count stays up and onMapStable never fires again.
+            pointer1Id = INVALID_POINTER_ID;
+            pointer2Id = INVALID_POINTER_ID;
+            baseMapView.onInputEvent(NATIVE_ACTION_CANCEL,
+                    NATIVE_NO_COORDINATE, NATIVE_NO_COORDINATE,
+                    NATIVE_NO_COORDINATE, NATIVE_NO_COORDINATE);
         }
         return true;
     }

--- a/android/java/com/massifmaps/ui/TextureMapView.java
+++ b/android/java/com/massifmaps/ui/TextureMapView.java
@@ -54,6 +54,7 @@ public class TextureMapView extends GLTextureView implements GLSurfaceView.Rende
 
     private int pointer1Id = INVALID_POINTER_ID;
     private int pointer2Id = INVALID_POINTER_ID;
+    private boolean gestureAccepted;
 
     /**
      * Creates a new MapView object from a context object.
@@ -169,9 +170,12 @@ public class TextureMapView extends GLTextureView implements GLSurfaceView.Rende
             return false;
         }
 
-        boolean clickable = isClickable() || isLongClickable();
-        if (!isEnabled() || !clickable) {
-            return clickable;
+        // Latched for the whole gesture - see MapView.onTouchEvent.
+        if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
+            gestureAccepted = isEnabled() && (isClickable() || isLongClickable());
+        }
+        if (!gestureAccepted) {
+            return isClickable() || isLongClickable();
         }
 
         try {
@@ -259,6 +263,13 @@ public class TextureMapView extends GLTextureView implements GLSurfaceView.Rende
         }
         catch (IllegalArgumentException e) {
             com.massifmaps.utils.Log.error("MapView.onTouchEvent: " + e);
+            // The event never reached native, so its pointer was never released there. Cancel
+            // instead, or the native pointer count stays up and onMapStable never fires again.
+            pointer1Id = INVALID_POINTER_ID;
+            pointer2Id = INVALID_POINTER_ID;
+            baseMapView.onInputEvent(NATIVE_ACTION_CANCEL,
+                    NATIVE_NO_COORDINATE, NATIVE_NO_COORDINATE,
+                    NATIVE_NO_COORDINATE, NATIVE_NO_COORDINATE);
         }
         return true;
     }

--- a/docs/guides/map-view.mdx
+++ b/docs/guides/map-view.mdx
@@ -51,7 +51,9 @@ There are listeners for user interaction related events, rendering events and ma
 An app can implement a custom `MapEventListener` to receive notifications about various events, such as:
 
 * Map is being moved or zoomed (`onMapMoved`)
-* Map has reached 'stable state', all tiles and data has been loaded displayed (`onMapStable`)
+* Map has come to rest — animations finished, fingers lifted (`onMapStable`). This is about the
+  camera, not the data: tiles may still be loading. See [Map events](/docs/internals/map-events)
+  for what it does and does not guarantee.
 * Map has been clicked (`onMapClicked`)
 
 Create a new class called **MyMapEventListener** which implements MapEventListner interface.

--- a/docs/internals/index.mdx
+++ b/docs/internals/index.mdx
@@ -20,6 +20,7 @@ read without the rest**.
 | the render path (frame, tiles, terrain, depth, labels, lighting…) | [Render pipeline](/docs/internals/rendering/) |
 | binary size, build time, ccache/ninja, what a profile costs | [Binary size & build time](/docs/internals/build-and-size) |
 | PMTiles archive internals | [PMTiles data source](/docs/internals/pmtiles-datasource) |
+| camera and touch events — which thread, and when each fires | [Map events](/docs/internals/map-events) |
 | the facade API — the C ABI, the generated property table, specs, events, calls | [Facade API](/docs/internals/api-facade) |
 | giving the facade's strings autocompletion, per language | [API autocompletion](/docs/internals/api-autocompletion) |
 | what was measured, when, and which ideas failed | [Performance lab notebook](/docs/internals/performance-log) |

--- a/docs/internals/map-events.md
+++ b/docs/internals/map-events.md
@@ -1,0 +1,102 @@
+---
+title: Map events
+description: "How onMapMoved, onMapInteraction, onMapIdle and onMapStable are raised, which thread each comes from, and the state that decides whether they fire at all."
+sidebar_position: 5
+---
+
+# Map events
+
+Scope: the camera and touch events an app receives through `MapEventListener` (and their facade
+mirrors `map.moved`, `map.interaction`, `map.idle`, `map.stable`). Not the click/selection path,
+and not the render loop itself — that is [the frame](rendering/01-frame.md).
+
+## The four events
+
+| Event | Raised from | Means |
+|---|---|---|
+| `onMapMoved` | `TouchHandler::checkCameraEvents`, and `MapRendererListener::onMapChanged` for everything else | the camera changed, whatever the source |
+| `onMapInteraction` | the touch pipeline only, with pan/zoom/rotate/tilt flags | the **user** changed the camera |
+| `onMapIdle` | `MapRenderer::onDrawFrame`, when a frame ended with no redraw pending | the renderer has nothing more to draw |
+| `onMapStable` | `TouchHandler::checkMapStable` | idle **and** no fingers down **and** no kinetic animation running |
+
+`onMapMoved` and `onMapInteraction` are not disjoint: a gesture raises both, back to back, and
+`onMapChanged` suppresses its own `onMapMoved` when camera events are already pending so it is not
+sent twice.
+
+**`onMapStable` is about the camera, not the data.** Tiles may still be loading when it fires; it
+does not wait for them. `onMapIdle` does not either — it only means this frame was the last one
+requested.
+
+## Threads
+
+`onMapIdle` comes from the GL thread. `onMapStable` comes from the GL thread when it follows an
+idle, and from the touch thread when it follows a finger lift. `onMapMoved` comes from whichever
+thread changed the camera. **Do not mutate map state from any of them** — `MapEventListener.h` says
+so, and it is a deadlock, not a race.
+
+## What decides whether onMapStable fires
+
+`checkMapStable` is **polled**, from two call sites only — `TouchHandler::onTouchEvent` and
+`MapRendererListener::onMapIdle` — and reads three pieces of state:
+
+- `_idling`, set by `onMapIdle` and cleared by `onMapChanged`;
+- the three `KineticEventHandler` flags (`isPanning`, `isRotating`, `isZooming`);
+- `_pointersDown`.
+
+Two consequences an app has to know about: it fires for a **tap that moved nothing** (the map is at
+rest, so the condition holds), and it can fire **repeatedly** while at rest, once per idle, whenever
+something else keeps requesting redraws — a label fade, a tile arrival.
+
+### Why it used to stop firing for good
+
+Every one of the three inputs was reachable in a state nothing recovered from
+([#162](https://github.com/massif-maps/MassifMaps/issues/162)). The failure was always the same
+shape: `onMapStable` silently never fires again until the app is restarted.
+
+- **Latched kinetic flags.** `startPan/startRotation/startZoom` set their flag unconditionally, but
+  only `calculatePan/Rotation/Zoom` cleared it — and those return early when the matching
+  `Options::isKinetic*` is off. With kinetic zoom or rotation disabled, the pinch-release path
+  (which starts both) latched the flag forever. The starts are now guarded, and `calculate` clears
+  a flag whose option was switched off mid-flight.
+- **A dropped UP.** `_pointersDown` was incremented and decremented per delivered event, and only
+  `ACTION_CANCEL` reset it, so any UP the platform never delivered stuck it above zero permanently.
+  It is now **assigned** on DOWN (1 for the first pointer, 2 for the second), which makes every
+  gesture start a resync point.
+- **A consumed touch event.** `onTouchEvent` returned early when an `OnTouchListener` claimed the
+  gesture, skipping the pointer accounting *and* both event checks. The listener chain now decides
+  who handles the gesture, not whether the handler's own bookkeeping runs.
+
+Two platform-side holes fed the second one, both fixed in `MapView.java` / `TextureMapView.java`:
+the `isClickable() || isLongClickable()` test ran per event rather than per gesture, so a host
+framework toggling it mid-touch delivered the DOWN and dropped the UP; and the `catch
+(IllegalArgumentException)` around the dispatch swallowed the UP without telling native, which now
+gets an `ACTION_CANCEL` instead.
+
+Ruled out along the way, so nobody re-investigates them: the min-zoom and terrain-clearance clamps
+do not stall kinetic (`_zoomDelta *= factor` runs whether or not the camera actually moved), and the
+frame loop always draws at least one more frame after the last change (`_redrawExtraFrames`), so the
+terminal kinetic frame's own `onMapIdle` sees the flags already cleared.
+
+## Compared to maplibre / mapbox
+
+They ship one phased camera stream, not two parallel ones: `movestart` / `move` / `moveend` (plus
+per-axis variants) in MapLibre GL JS, each carrying `originalEvent` — present for a gesture, absent
+for a programmatic move — and `onCameraMoveStarted(int reason)` / `onCameraMove` / `onCameraIdle`
+with `REASON_GESTURE` / `REASON_API_ANIMATION` / `REASON_DEVELOPER_ANIMATION` on Mapbox and Google
+Maps for Android.
+
+We have no `movestart`, and `onMapStable` is our de-facto `moveend`. `onMapInteraction` carries the
+information that belongs on the move event itself.
+
+## Known gaps
+
+- **No reason on the event.** Bindings reconstruct "was this the user" by watching touches
+  themselves — the NativeScript plugin subclasses the map view on both platforms to keep a
+  `userAction` flag. [#163](https://github.com/massif-maps/MassifMaps/issues/163).
+- **`onMapStable` is polled, not edge-triggered**, hence the tap-fires-stable and repeated-stable
+  behaviour above. Same issue.
+- **No `movestart`.**
+- **No native debounce.** Apps that refresh data on stable throttle it themselves. The facade's
+  subscription options (`mm_on`'s `opts_json`) already carry `delivery` and `coalesce` and are
+  designed to take new keys without a signature change, so a `debounce` belongs there rather than on
+  `Options`.


### PR DESCRIPTION
## Summary

`onMapStable` could stop firing permanently — reported after a pinch zoom-out, silent until the app restarted. All three inputs `checkMapStable` polls were reachable in a state nothing recovered from:

- **Latched kinetic flags.** `startPan/startRotation/startZoom` set their flag unconditionally, but only `calculate*` cleared it, and those return early when the matching `Options::isKinetic*` is off. A pinch release starts *both* rotation and zoom, so one disabled option latched the flag forever. The starts are now guarded, and `calculate` clears a flag whose option was switched off mid-flight.
- **A dropped UP.** `_pointersDown` was incremented per delivered event and reset only by `ACTION_CANCEL`, so any UP the platform never delivered stuck it above zero. It is now **assigned** on DOWN (1 for the first pointer, 2 for the second), making every gesture start a resync point.
- **A consumed touch event.** `onTouchEvent` returned early when an `OnTouchListener` claimed the gesture, skipping the pointer accounting *and* both event checks. The listener chain now decides who handles the gesture, not whether the handler's own bookkeeping runs.

Two platform-side holes fed the second one, both in `MapView.java` / `TextureMapView.java`: the `isClickable() || isLongClickable()` test ran per event rather than per gesture, so a host framework toggling it mid-touch delivered the DOWN and dropped the UP; and the `catch (IllegalArgumentException)` swallowed the UP without telling native, which now gets an `ACTION_CANCEL`.

New page `docs/internals/map-events.md` documents the model, the threads, and what was **ruled out** so nobody re-investigates: the zoom clamps do not stall kinetic, and the frame loop always draws a trailing frame, so the terminal kinetic frame's own `onMapIdle` already sees the flags cleared.

## Testing

- `cd tests && ./run.sh` — green. These classes are not in the host test link (they pull `MapRenderer` and `Options`), so this adds no test of its own; the behaviour change is covered by the edge-trigger tests in the stacked PR.
- `clang++ -fsyntax-only -std=c++20` clean on `TouchHandler.cpp` and `KineticEventHandler.cpp`.
- `cd website && npm run build` — `[SUCCESS]`, no broken-links block.

**Not verified on a device, and the Java changes are not compile-checked here.** To reproduce the original bug on a build without this fix: pinch zoom-out on `.BenchActivity` with `setKineticZoom(false)` or `setKineticRotation(false)`, and watch `onMapStable` never fire again. A reviewer with a device should confirm stable still fires after a pinch, after a fling, and after a two-finger release where one finger lifts well before the other.

Fixes #162