### PR TITLE
fix(terrain): apply elevation as it arrives, instead of waiting for the next gesture

### DIFF
--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -2141,6 +2141,20 @@ namespace massif {
             if (auto terrainOptions = _options->getTerrainOptions()) {
                 if (terrainOptions->isEnabled()) {
                     terrainMode = true;
+                    // Elevation arrives on a loading thread and every consumer reads it from
+                    // inside a frame, so the tiles that land after the last one are never
+                    // applied: the map sits on a half-displaced mesh until the next gesture.
+                    if (std::shared_ptr<ElevationManager> elevationManager = terrainOptions->getElevationManager()) {
+                        if (_redrawElevationManager.lock() != elevationManager) {
+                            std::weak_ptr<MapRenderer> mapRendererWeak = shared_from_this();
+                            elevationManager->setDataChangedListener([mapRendererWeak]() {
+                                if (auto mapRenderer = mapRendererWeak.lock()) {
+                                    mapRenderer->requestRedraw();
+                                }
+                            });
+                            _redrawElevationManager = elevationManager;
+                        }
+                    }
                     bool depthWriteAssigned = false;
                     int terrainRenderOrder = 0;
                     for (const std::shared_ptr<Layer>& layer : layers) {

--- a/all/native/renderers/MapRenderer.h
+++ b/all/native/renderers/MapRenderer.h
@@ -39,6 +39,7 @@ namespace massif {
     class CameraZoomEvent;
     class Bitmap;
     class BillboardDrawData;
+    class ElevationManager;
     class Layer;
     class Layers;
     class MapRendererListener;
@@ -289,6 +290,7 @@ namespace massif {
         std::string _postProcessShaderName;
         std::optional<std::chrono::steady_clock::time_point> _postProcessStartTime;
         std::unique_ptr<TerrainRenderer> _terrainRenderer;
+        std::weak_ptr<ElevationManager> _redrawElevationManager; // the one whose loads ask for a frame
         std::vector<vt::TileId> _groundCoverTileIds; // last frame's shared ground cover (shadow refresh trigger)
         std::unique_ptr<TerrainDrapeCache> _terrainDrapeCache;
         std::unique_ptr<TerrainShadowMap> _terrainShadowMap; // shared cross-layer drape target

--- a/all/native/terrain/ElevationManager.cpp
+++ b/all/native/terrain/ElevationManager.cpp
@@ -346,8 +346,30 @@ namespace massif {
             }
             _pendingLoads.erase(tileId);
         }
+        if (grid) {
+            notifyDataChanged();
+        }
         promise.set_value(grid);
         return grid;
+    }
+
+    void ElevationManager::setDataChangedListener(const std::function<void()>& listener) {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        _dataChangedListener = listener;
+    }
+
+    void ElevationManager::notifyDataChanged() const {
+        std::function<void()> listener;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            listener = _dataChangedListener;
+        }
+        // Outside the lock: the listener asks the renderer for a frame, and that frame reads
+        // this manager back.
+        if (listener) {
+            listener();
+        }
     }
 
     MapTile ElevationManager::getDataTile(const MapTile& mapTile) const {
@@ -654,6 +676,7 @@ namespace massif {
         }
         _dataVersion++;
         bumpGlobalVersion();
+        notifyDataChanged();
     }
 
     void ElevationManager::bumpGlobalVersion() {

--- a/all/native/terrain/ElevationManager.h
+++ b/all/native/terrain/ElevationManager.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <deque>
+#include <functional>
 #include <future>
 #include <utility>
 #include <map>
@@ -205,6 +206,14 @@ namespace massif {
         bool getChangedTiles(unsigned int sinceVersion, std::vector<MapTile>& tiles) const;
 
         /**
+         * Called on a tile-loading thread whenever decoded elevation data changed. Nothing polls
+         * for it: the consumers all read the version from inside a frame, so without a redraw
+         * request the map goes idle on whatever mesh the last frame happened to have and only
+         * catches up on the next gesture.
+         */
+        void setDataChangedListener(const std::function<void()>& listener);
+
+        /**
          * Resolves the effective elevation decoder: the data source "encoding" setting takes precedence,
          * then the preferred decoder, then the MapBox decoder as the default.
          */
@@ -227,6 +236,7 @@ namespace massif {
 
         void tilesChanged();
         void bumpGlobalVersion();
+        void notifyDataChanged() const;
         double wrapInternalX(double internalX) const;
         MapTile clampTileZoom(const MapTile& mapTile) const;
         MapTile clampDataTileZoom(const MapTile& dataTile) const;
@@ -266,6 +276,7 @@ namespace massif {
         mutable cache::timed_lru_cache<long long, std::shared_ptr<ElevationTileGrid> > _gridCache;
         bool _gridCacheCapacityFixed = false; // set through setCacheCapacity: the app's number wins over the grid-count rule
         mutable std::map<long long, std::shared_future<std::shared_ptr<ElevationTileGrid> > > _pendingLoads; // single-flight de-duplication of concurrent loads
+        std::function<void()> _dataChangedListener; // called outside _mutex, see setDataChangedListener
         mutable std::mutex _mutex;
 
         // Background prefetch worker: loads elevation tiles requested by the render thread

--- a/docs/internals/rendering/04-terrain.md
+++ b/docs/internals/rendering/04-terrain.md
@@ -28,6 +28,15 @@ startup** on a Crosscall. The cache now grows on the first decoded grid to hold 
 loads equalled distinct tiles (128 still re-decoded ~20%). `TerrainOptions::setElevationCacheCapacity`
 still wins over the rule, for an app that cannot spend the memory.
 
+**A decoded tile asks for a frame.** Every consumer reads the elevation version from *inside* a
+frame (`TileRenderer::onDrawFrame` compares it and invalidates the surfaces it covers), so a tile
+that lands after the last drawn frame is never applied: the map goes idle on a half-displaced mesh —
+cracks at LOD rings, flat far ground — and only catches up on the next gesture, which is why "pan a
+pixel and it fixes itself" was the symptom. `ElevationManager::setDataChangedListener` closes that:
+`MapRenderer` hooks it on the terrain path and every decoded grid requests a redraw. Measured on the
+3D-terrain example, cold: frames stopped at elevation version 43 while loading ran on to 159; with
+the listener the last frame follows the last decoded tile by 146 ms and has consumed it.
+
 `setSurfaceResolution` caps the elevation level to what the mesh can express (roughly one texel per
 half surface cell), which costs about two zoom levels of detail. That cap is right for geometry and
 wrong for per-fragment shading, which is why the terrain paint can opt out of it


### PR DESCRIPTION
## Summary

- A decoded DEM tile now asks the renderer for a frame. `ElevationManager` gained a data-changed
  listener, called outside its lock on every decoded grid and on `tilesChanged`; `MapRenderer` hooks
  it on the terrain path and calls `requestRedraw`.
- Every elevation consumer reads the version from *inside* a frame
  (`TileRenderer::onDrawFrame` compares it and invalidates the surfaces it covers), so tiles landing
  after the last drawn frame were never applied. The map went idle on a half-displaced mesh - cracks
  at LOD rings, flat far ground - and only caught up on the next gesture. "Pan a pixel and it fixes
  itself" was the symptom.
- Stitching was **not** the cause, despite looking like it: the coarsening map is correct at open and
  is not rebuilt by the pan that heals the frame.

## Testing

- `clang++ -fsyntax-only -std=c++20` clean on `ElevationManager.cpp` and `MapRenderer.cpp`.
- `cd tests && ./run.sh` passes. It covers neither path - `ElevationManager` pulls the data source and
  the decoders, which is over the suite's link budget.
- Emulator, cold caches, 3D terrain example. Probe on the version counters, before: last drawn frame
  at elevation version 43, loading ran on to 159 - 116 tiles decoded with no frame after them. After:
  the last frame follows the last decoded tile by 146 ms and has consumed it.

To reproduce, watch the terrain at open and then nudge it a few pixels:

```sh
adb shell am force-stop com.massifmaps.MassifDemo
adb shell pm clear com.massifmaps.MassifDemo
adb shell am start -n com.massifmaps.MassifDemo/.ExampleActivity \
    --es example terrain-3d --es tilt 33 --es ui false
# wait ~30 s, screenshot, then:
adb shell input swipe 540 1200 545 1205 400
```

Before, white wedges at the LOD rings around Chamois / Bec di Nona heal on the swipe; after, the open
frame already matches the panned one. **A device check is still wanted** - this was measured on the
emulator, and the artifact is intermittent (it depends on which tiles are still in flight when the
frames stop), so the version-counter probe is the reliable signal, not the screenshot.