### PR TITLE
fix(api): give a reopened screen its own camera again, instead of the closed one's

### DIFF
--- a/android/java/com/massifmaps/api/MassifMap.java
+++ b/android/java/com/massifmaps/api/MassifMap.java
@@ -426,6 +426,9 @@ public final class MassifMap implements AutoCloseable {
         elements = null;
         if (options.id != null) {
             MassifApi.unregisterObject(KIND, options.id);
+            // The view is adopted under the SAME id and has to go with it: left registered, the
+            // next attach reuses it and the camera drives the CLOSED screen's map view.
+            MassifApi.unregisterObject(VIEW_KIND, options.id);
         }
     }
 

--- a/docs/internals/api-facade.md
+++ b/docs/internals/api-facade.md
@@ -715,6 +715,13 @@ map.addLayer("base", Spec.of("vector").set("source", "osm"));
 map.onClick(e -> map.camera().animate(2).moveTo(e.position(), 14));
 ```
 
+**`attach` registers TWO ids, and `close` drops both.** The `Options` goes in under `map:<id>` and
+the `BaseMapView` under `view:<id>` — the view is what carries the camera. They are released
+together on `close`/`-detach`, and the failure mode when one is left behind is silent: the next
+`attach` under the same id finds the stale view handle and reuses it, so the new screen's layers
+build correctly while `camera().moveTo` drives the CLOSED screen's map view and the visible map
+never leaves its default camera.
+
 ### The sugar's own value types
 
 `Position`, `Bounds`, `ScreenPoint`, `ScreenRect` (`MSFPosition` … on iOS) are **hand-written and

--- a/ios/objc/api/MSFMassifMap.mm
+++ b/ios/objc/api/MSFMassifMap.mm
@@ -487,6 +487,9 @@ static void MSFInstallUiDispatcher(void) {
     _elements = nil;
     if (_options.objectId) {
         [MSFMassifApi unregisterObject:kMapKind objectId:_options.objectId];
+        // The view is adopted under the SAME id and has to go with it: left registered, the next
+        // attach reuses it and the camera drives the CLOSED screen's map view.
+        [MSFMassifApi unregisterObject:kViewKind objectId:_options.objectId];
     }
 }
 


### PR DESCRIPTION
## Summary

- `MassifMap.attach` registers **two** ids - the `Options` under `map:<id>` and the `BaseMapView`,
  which is what carries the camera, under `view:<id>` - and `close()` released only the first.
- Reopening a screen under the same id then found the stale view handle and reused it. The new map's
  layers built correctly, so the map looked alive, while `camera().moveTo` drove the **closed**
  screen's map view: the visible map sat at its default camera (the whole world) and
  `camera().zoom()` read back the value that had been asked for, which is what made this read as a
  camera-clamp bug rather than a registry one.
- Same bug and same fix in the Objective-C sugar layer (`-detach`).

## Testing

- Emulator, 3D terrain example: open, back out, open again. Before, the second open renders the whole
  world at zoom 0 while the log reads `camera ... zoom=11.50`; after, it renders the Matterhorn view
  it was asked for. Opening a *different* example in between always worked - a different id, so no
  stale handle - which is what isolated it.

```sh
adb shell am start -n com.massifmaps.MassifDemo/.ExampleActivity --es example terrain-3d
adb shell input keyevent 4
adb shell am start -n com.massifmaps.MassifDemo/.ExampleActivity --es example terrain-3d
```

- `cd tests && ./run.sh` passes; it cannot reach either binding.
- **The Objective-C side is unbuilt** - the fix mirrors the Java one line for line, but no iOS build
  was run here.