### PR TITLE
fix(renderers): stop dereferencing a null GLResourceManager when a frame outlives the surface

### DIFF
--- a/all/native/renderers/BillboardRenderer.cpp
+++ b/all/native/renderers/BillboardRenderer.cpp
@@ -627,10 +627,15 @@ namespace massif {
         }
         _fogShaderSource = fogSource;
 
+        // Null once the surface is gone - a frame still in flight has nothing to create into (#178).
+        std::shared_ptr<GLResourceManager> glResourceManager;
         if (auto mapRenderer = _mapRenderer.lock()) {
-            _textureCache = mapRenderer->getGLResourceManager()->create<BitmapTextureCache>(TEXTURE_CACHE_SIZE);
+            glResourceManager = mapRenderer->getGLResourceManager();
+        }
+        if (glResourceManager) {
+            _textureCache = glResourceManager->create<BitmapTextureCache>(TEXTURE_CACHE_SIZE);
 
-            _shader = mapRenderer->getGLResourceManager()->create<Shader>("billboard", BILLBOARD_VERTEX_SHADER, BILLBOARD_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + BILLBOARD_FRAGMENT_SHADER_MAIN);
+            _shader = glResourceManager->create<Shader>("billboard", BILLBOARD_VERTEX_SHADER, BILLBOARD_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + BILLBOARD_FRAGMENT_SHADER_MAIN);
 
             // Get shader variables locations
             _a_color = _shader->getAttribLoc("a_color");
@@ -666,8 +671,13 @@ namespace massif {
             return true;
         }
 
+        // Null once the surface is gone - a frame still in flight has nothing to create into (#178).
+        std::shared_ptr<GLResourceManager> glResourceManager;
         if (auto mapRenderer = _mapRenderer.lock()) {
-            _nmlResources = mapRenderer->getGLResourceManager()->create<NMLResources>();
+            glResourceManager = mapRenderer->getGLResourceManager();
+        }
+        if (glResourceManager) {
+            _nmlResources = glResourceManager->create<NMLResources>();
 
             _nmlModelMap.clear();
         }

--- a/all/native/renderers/CelestialRenderer.cpp
+++ b/all/native/renderers/CelestialRenderer.cpp
@@ -242,7 +242,11 @@ namespace massif {
 
             std::shared_ptr<Texture> texture;
             if (batchBitmap) {
-                texture = mapRenderer->getGLResourceManager()->create<Texture>(batchBitmap, false, false);
+                // Null once the surface is gone - a frame still in flight has nothing to create
+                // into (#178). The batch then draws untextured rather than crashing.
+                if (std::shared_ptr<GLResourceManager> glResourceManager = mapRenderer->getGLResourceManager()) {
+                    texture = glResourceManager->create<Texture>(batchBitmap, false, false);
+                }
             }
             glUniform1f(_spriteShader->getUniformLoc("u_hasTex"), texture ? 1.0f : 0.0f);
             glUniform1f(_spriteShader->getUniformLoc("u_softness"), std::max(0.001f, batchSoftness));

--- a/all/native/renderers/LineRenderer.cpp
+++ b/all/native/renderers/LineRenderer.cpp
@@ -354,10 +354,15 @@ namespace massif {
         }
         _fogShaderSource = fogSource;
 
+        // Null once the surface is gone - a frame still in flight has nothing to create into (#178).
+        std::shared_ptr<GLResourceManager> glResourceManager;
         if (auto mapRenderer = _mapRenderer.lock()) {
-            _textureCache = mapRenderer->getGLResourceManager()->create<BitmapTextureCache>(TEXTURE_CACHE_SIZE);
+            glResourceManager = mapRenderer->getGLResourceManager();
+        }
+        if (glResourceManager) {
+            _textureCache = glResourceManager->create<BitmapTextureCache>(TEXTURE_CACHE_SIZE);
 
-            _shader = mapRenderer->getGLResourceManager()->create<Shader>("line", LINE_VERTEX_SHADER, LINE_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + LINE_FRAGMENT_SHADER_MAIN);
+            _shader = glResourceManager->create<Shader>("line", LINE_VERTEX_SHADER, LINE_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + LINE_FRAGMENT_SHADER_MAIN);
 
             // Get shader variables locations
             _a_color = _shader->getAttribLoc("a_color");

--- a/all/native/renderers/PointRenderer.cpp
+++ b/all/native/renderers/PointRenderer.cpp
@@ -282,10 +282,15 @@ namespace massif {
         }
         _fogShaderSource = fogSource;
 
+        // Null once the surface is gone - a frame still in flight has nothing to create into (#178).
+        std::shared_ptr<GLResourceManager> glResourceManager;
         if (auto mapRenderer = _mapRenderer.lock()) {
-            _textureCache = mapRenderer->getGLResourceManager()->create<BitmapTextureCache>(TEXTURE_CACHE_SIZE);
+            glResourceManager = mapRenderer->getGLResourceManager();
+        }
+        if (glResourceManager) {
+            _textureCache = glResourceManager->create<BitmapTextureCache>(TEXTURE_CACHE_SIZE);
 
-            _shader = mapRenderer->getGLResourceManager()->create<Shader>("point", POINT_VERTEX_SHADER, POINT_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + POINT_FRAGMENT_SHADER_MAIN);
+            _shader = glResourceManager->create<Shader>("point", POINT_VERTEX_SHADER, POINT_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + POINT_FRAGMENT_SHADER_MAIN);
     
             // Get shader variables locations
             _a_color = _shader->getAttribLoc("a_color");

--- a/all/native/renderers/Polygon3DRenderer.cpp
+++ b/all/native/renderers/Polygon3DRenderer.cpp
@@ -292,8 +292,13 @@ namespace massif {
         }
         _fogShaderSource = fogSource;
 
+        // Null once the surface is gone - a frame still in flight has nothing to create into (#178).
+        std::shared_ptr<GLResourceManager> glResourceManager;
         if (auto mapRenderer = _mapRenderer.lock()) {
-            _shader = mapRenderer->getGLResourceManager()->create<Shader>("polygon3d", POLYGON3D_VERTEX_SHADER, POLYGON3D_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + POLYGON3D_FRAGMENT_SHADER_MAIN);
+            glResourceManager = mapRenderer->getGLResourceManager();
+        }
+        if (glResourceManager) {
+            _shader = glResourceManager->create<Shader>("polygon3d", POLYGON3D_VERTEX_SHADER, POLYGON3D_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + POLYGON3D_FRAGMENT_SHADER_MAIN);
 
             // Get shader variables locations
             _a_color = _shader->getAttribLoc("a_color");

--- a/all/native/renderers/PolygonRenderer.cpp
+++ b/all/native/renderers/PolygonRenderer.cpp
@@ -258,8 +258,13 @@ namespace massif {
         }
         _fogShaderSource = fogSource;
 
+        // Null once the surface is gone - a frame still in flight has nothing to create into (#178).
+        std::shared_ptr<GLResourceManager> glResourceManager;
         if (auto mapRenderer = _mapRenderer.lock()) {
-            _shader = mapRenderer->getGLResourceManager()->create<Shader>("polygon", POLYGON_VERTEX_SHADER, POLYGON_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + POLYGON_FRAGMENT_SHADER_MAIN);
+            glResourceManager = mapRenderer->getGLResourceManager();
+        }
+        if (glResourceManager) {
+            _shader = glResourceManager->create<Shader>("polygon", POLYGON_VERTEX_SHADER, POLYGON_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + POLYGON_FRAGMENT_SHADER_MAIN);
 
             // Get shader variables locations
             _a_color = _shader->getAttribLoc("a_color");

--- a/all/native/renderers/SolidRenderer.cpp
+++ b/all/native/renderers/SolidRenderer.cpp
@@ -119,9 +119,14 @@ namespace massif {
         }
         _fogShaderSource = fogSource;
 
+        // Null once the surface is gone - a frame still in flight has nothing to create into (#178).
+        std::shared_ptr<GLResourceManager> glResourceManager;
         if (auto mapRenderer = _mapRenderer.lock()) {
+            glResourceManager = mapRenderer->getGLResourceManager();
+        }
+        if (glResourceManager) {
             // Shader and textures must be reloaded
-            _shader = mapRenderer->getGLResourceManager()->create<Shader>("solid", SOLID_VERTEX_SHADER, SOLID_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + SOLID_FRAGMENT_SHADER_MAIN);
+            _shader = glResourceManager->create<Shader>("solid", SOLID_VERTEX_SHADER, SOLID_FRAGMENT_SHADER_PREFIX + FogShader::buildBlock(fogSource) + SOLID_FRAGMENT_SHADER_MAIN);
         
             // Get shader variables locations
             _u_mvpMat = _shader->getUniformLoc("u_mvpMat");
@@ -133,10 +138,10 @@ namespace massif {
             _a_texCoord = _shader->getAttribLoc("a_texCoord");
 
             if (_bitmap) {
-                _bitmapTex = mapRenderer->getGLResourceManager()->create<Texture>(_bitmap, true, true);
+                _bitmapTex = glResourceManager->create<Texture>(_bitmap, true, true);
             } else {
                 auto defaultBitmap = std::make_shared<Bitmap>(DEFAULT_BITMAP, 1, 1, ColorFormat::COLOR_FORMAT_RGBA, 4);
-                _bitmapTex = mapRenderer->getGLResourceManager()->create<Texture>(defaultBitmap, true, true);
+                _bitmapTex = glResourceManager->create<Texture>(defaultBitmap, true, true);
             }
         }
 

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -1410,8 +1410,14 @@ viewState.getRotation(), viewState.getTilt(), viewState.getAspectRatio(), viewSt
             return false; // safety check, should never happen
         }
 
+        // Null once the surface is gone - a frame still in flight has nothing to create into (#178).
+        std::shared_ptr<GLResourceManager> glResourceManager = mapRenderer->getGLResourceManager();
+        if (!glResourceManager) {
+            return false;
+        }
+
         Log::Debug("TileRenderer: Initializing renderer");
-        _vtRenderer = mapRenderer->getGLResourceManager()->create<VTRenderer>(_tileTransformer);
+        _vtRenderer = glResourceManager->create<VTRenderer>(_tileTransformer);
 
         if (std::shared_ptr<vt::GLTileRenderer> tileRenderer = _vtRenderer->getTileRenderer()) {
             tileRenderer->setVisibleTiles(_tiles);


### PR DESCRIPTION
## Summary

A SIGSEGV on the GL thread when a map screen is opened and closed repeatedly. Symbolized:

```
#00 GLResourceManager::create<VTRenderer>   shared_from_this() on nullptr, fault addr 0x10
#01 TileRenderer::initializeRenderer()      TileRenderer.cpp:1414
#02 TileRenderer::onDrawFrame()             TileRenderer.cpp:682
#03 RasterTileLayer::onDrawFrame()  #04 MapRenderer::drawLayers()  #05 MapRenderer::onDrawFrame()
```

`MapRenderer::onSurfaceDestroyed` resets the manager and `getGLResourceManager()` then returns null.
`onDrawFrame` *does* guard on `_surfaceCreated`, but that flag is cleared on the way **into**
teardown — a frame already past the check keeps running and dereferences the null much further down
the call chain.

**14 sites across 8 renderers** had the same unguarded `mapRenderer->getGLResourceManager()->create<…>()`;
`TileRenderer` is only the one that draws first. Each now binds the manager once and skips its work
when it is gone — the same thing those blocks already do when the `MapRenderer` weak_ptr is dead.
`CelestialRenderer` draws its batch untextured rather than not at all.

I looked for a single choke point and there isn't one: holding the manager alive for the frame in
`onDrawFrame` does not help, because each renderer calls the getter again and gets null.

## Testing

- `clang++ -fsyntax-only -std=c++20` clean on all 8 touched translation units.
- The crash was reproduced and symbolized on the emulator against the shipped build id; the guard
  removes the deref that faulted.
- **Not yet re-run through 10 open/close cycles on device** — that is the acceptance test in #178 and
  it is still owed. The change is a null check on a path that previously had none, so the risk is
  low, but I am not claiming it verified.

## Not fixed here

`onSurfaceDestroyed` writes `_surfaceCreated` and `_glResourceManager` without taking `_mutex`, while
`getGLResourceManager()` reads under it. These guards close the crash; whether that write also wants
the lock is a separate call, and on Android `onSurfaceDestroyed` "may never be called" (its own
comment), so the teardown path that actually runs should be confirmed first. Noted in the issue.

## How it was found

Opening and closing the 2D/3D switch example, which toggles `TerrainOptions.enabled` and so almost
always has a redraw in flight at teardown. It makes an existing race easy to hit rather than causing
it — the crashing functions are untouched by that work.

Closes #178