### PR TITLE
fix(terrain): draw contours under the roads in 3D, as the style orders them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,19 @@ if `libs-external/boost` is not set up.
 Useful cglib semantics (libs-external/cglib): `bbox::inside(bbox)` = *intersects* (not
 containment); `frustum3::inside(bbox)` = *intersects frustum*.
 
+## OpenGL ES 3 is a hard requirement
+
+Both platforms create an ES3 context and nothing falls back to ES2:
+`android/java/com/massifmaps/ui/ConfigChooser.java` asks for `EGL_OPENGL_ES3_BIT` in **every** EGL
+config, and `ios/objc/ui/MapView.mm` uses `kEAGLRenderingAPIOpenGLES3`. `GLES3/gl3.h` is included
+directly (`renderers/utils/GLContext.h`).
+
+So an ES3-only format or entry point needs no extension check and no ES2 path — `GL_R8`,
+`glInvalidateFramebuffer`, MRT, `sampler2DShadow`. What is still version-dependent is the **shader
+language**: programs are built at `#version 100` unless they ask for `ESSL3_FLAG`, and a driver
+that refuses the 3.00 variant falls back to 1.00 (`GLTileRenderer::hasShaderVersionFallback`), so a
+shader written for ESSL 3.00 must still have a 1.00 form.
+
 ## Rendering architecture (vector tiles + labels)
 
 **Full technical documentation lives in [`docs/internals/rendering/`](docs/internals/rendering/index.mdx)**, split by

--- a/all/native/layers/TileLayer.cpp
+++ b/all/native/layers/TileLayer.cpp
@@ -1049,6 +1049,18 @@ namespace massif {
         return _tileRenderer->bakeDrapeTile(tileId);
     }
 
+    void TileLayer::collectDrapeStackOrder(std::vector<std::pair<int, bool> >& units) const {
+        _tileRenderer->collectDrapeStackOrder(units);
+    }
+
+    int TileLayer::bakeDrapeCoverage(const vt::TileId& tileId, int fromStyleLayerIdx) {
+        return _tileRenderer->bakeDrapeCoverage(tileId, fromStyleLayerIdx);
+    }
+
+    void TileLayer::setDrapeCoverageMasks(const std::vector<std::map<vt::TileId, unsigned int> >& maskTextures, const std::map<int, int>& styleLayerMasks) {
+        _tileRenderer->setDrapeCoverageMasks(maskTextures, styleLayerMasks);
+    }
+
     int TileLayer::renderDrapedSurface(const vt::TileId& tileId, unsigned int drapeTexture, float uvOffsetX, float uvOffsetY, float uvScale) {
         return _tileRenderer->renderDrapedSurface(tileId, drapeTexture, uvOffsetX, uvOffsetY, uvScale);
     }

--- a/all/native/layers/TileLayer.h
+++ b/all/native/layers/TileLayer.h
@@ -448,6 +448,10 @@ class ProjectionSurface;
         int renderTerrainGround(const Color& color);
         void collectDrapeTiles(std::map<vt::TileId, std::size_t>& drapeTiles) const;
         int bakeDrapeTile(const vt::TileId& tileId);
+        // The ordered draped/live style layers of this layer, for the cross-layer cut (#175).
+        void collectDrapeStackOrder(std::vector<std::pair<int, bool> >& units) const;
+        int bakeDrapeCoverage(const vt::TileId& tileId, int fromStyleLayerIdx);
+        void setDrapeCoverageMasks(const std::vector<std::map<vt::TileId, unsigned int> >& maskTextures, const std::map<int, int>& styleLayerMasks);
         int renderDrapedSurface(const vt::TileId& tileId, unsigned int drapeTexture, float uvOffsetX, float uvOffsetY, float uvScale);
         int renderDrapedSurfaceFill(const vt::TileId& tileId, const Color& color);
         int blitDrapeTexture(unsigned int srcTexture, float dstOffsetX, float dstOffsetY, float dstScale, float uvOffsetX, float uvOffsetY, float uvScale);

--- a/all/native/renderers/MapRenderer.cpp
+++ b/all/native/renderers/MapRenderer.cpp
@@ -37,6 +37,7 @@
 #include <set>
 #include "core/MapTile.h"
 #include "terrain/AutoFlatten.h"
+#include "terrain/DrapeStackCuts.h"
 #include "terrain/ElevationManager.h"
 #include "renderers/utils/Shader.h"
 #include "renderers/utils/Texture.h"
@@ -2754,6 +2755,43 @@ namespace massif {
                         // startFrame runs between the two and resets frame state.
                         tileLayer->setExternalDrapeTiles(drapeActive ? drapeTileIds : std::vector<vt::TileId>());
                     }
+                    // WHERE THE LIVE LAYERS SIT IN THE STACK (#175). The drape composite is drawn
+                    // before any live geometry, so a layer kept out of the bake
+                    // (TerrainOptions::NoDrapeLayerFilter) can only land on TOP of all of it -
+                    // contours over roads in 3D, roads over contours in 2D. Flatten the whole stack
+                    // into ordered units, one per style layer of each drape layer, and mark every
+                    // LIVE unit that has a DRAPED unit after it: that unit is drawn through a mask
+                    // holding the accumulated coverage of everything draped above it.
+                    //
+                    // Units sharing the same nearest draped unit share a mask, so the count is the
+                    // number of live->draped transitions - 0 or 1 for every ordinary style.
+                    //
+                    // Capped: each mask is an R8 texture per drape tile and one more rasterisation
+                    // of the units above it. A style needing more than this is pathological, and
+                    // the cuts left out simply keep the pre-#175 behaviour. The rule itself is in
+                    // terrain/DrapeStackCuts.h, where the host tests can reach it.
+                    static const std::size_t MAX_DRAPE_COVERAGE_MASKS = 2;
+                    std::vector<DrapeStackCuts::Cut> drapeCuts;
+                    std::vector<std::map<int, int> > drapeLayerMasks(drapeLayers.size());
+                    if (drapeActive && TerrainDrapeCache::isCoverageMaskEnabled()) {
+                        std::vector<DrapeStackCuts::Unit> units;
+                        for (std::size_t i = 0; i < drapeLayers.size(); i++) {
+                            std::vector<std::pair<int, bool> > layerUnits;
+                            drapeLayers[i]->collectDrapeStackOrder(layerUnits);
+                            for (const std::pair<int, bool>& unit : layerUnits) {
+                                units.push_back(DrapeStackCuts::Unit { i, unit.first, unit.second });
+                            }
+                        }
+                        if (DrapeStackCuts::compute(units, MAX_DRAPE_COVERAGE_MASKS, drapeCuts, drapeLayerMasks)) {
+                            static bool cutCapLogged = false;
+                            if (!cutCapLogged) {
+                                cutCapLogged = true;
+                                Log::Warnf("MapRenderer: more than %d no-drape cuts in the style stack - the deepest are drawn on top, as before", static_cast<int>(MAX_DRAPE_COVERAGE_MASKS));
+                            }
+                        }
+                    }
+                    std::size_t drapeCutSignature = DrapeStackCuts::signature(drapeCuts);
+
                     if (!drapeActive) {
                         static bool emptyDrapeLogged = false;
                         if (!emptyDrapeLogged) {
@@ -3021,6 +3059,12 @@ namespace massif {
                             };
                             drawBakedDescendants(it->first, 2);
                         }
+                        // A mask evicted on its own - it is a separate cache entry - would leave the
+                        // tile's live layers unmasked for as long as the colour drape stays current,
+                        // which is for ever. Re-bake the tile so its masks come back with it.
+                        for (std::size_t k = 0; k < drapeCuts.size() && !needsBake; k++) {
+                            needsBake = !_terrainDrapeCache->isBaked(it->first, static_cast<int>(k) + 1);
+                        }
                         if (!needsBake) {
                             continue;
                         }
@@ -3119,6 +3163,28 @@ namespace massif {
                         }
                         _terrainDrapeCache->markBaked(request.tileId, 0, bakedFingerprint, bakedMask);
                         TerrainDrapeCache::generateMipmaps(texture);
+                        // The occlusion masks of this tile (#175), in the same pass and off the same
+                        // fingerprint, so a mask can never describe a different generation of the
+                        // map than the drape it is read beside. Stack 1+k, R8.
+                        for (std::size_t k = 0; k < drapeCuts.size(); k++) {
+                            std::size_t maskFingerprint = bakedFingerprint ^ (drapeCutSignature + k * 0x9e3779b9);
+                            bool maskNeedsBake = false, maskHasContent = false;
+                            unsigned int maskTexture = _terrainDrapeCache->acquire(request.tileId, static_cast<int>(k) + 1, maskFingerprint, maskNeedsBake, maskHasContent);
+                            if (maskTexture == 0) {
+                                continue;
+                            }
+                            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, maskTexture, 0);
+                            glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+                            glClear(GL_COLOR_BUFFER_BIT);
+                            for (std::size_t i = drapeCuts[k].layerIndex; i < drapeLayers.size(); i++) {
+                                // The cut's own layer starts at the cut; every later layer is wholly
+                                // above it.
+                                int fromStyleLayerIdx = (i == drapeCuts[k].layerIndex ? drapeCuts[k].styleLayerIdx : std::numeric_limits<int>::min());
+                                drapeLayers[i]->bakeDrapeCoverage(request.tileId, fromStyleLayerIdx);
+                            }
+                            _terrainDrapeCache->markBaked(request.tileId, static_cast<int>(k) + 1, maskFingerprint, 0);
+                            TerrainDrapeCache::generateMipmaps(maskTexture);
+                        }
                         bakedTiles++;
                         bakedThisFrame++;
                         VT_STAT_INC(drapeBakes);
@@ -3194,6 +3260,23 @@ namespace massif {
                         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
                         glBindFramebuffer(GL_FRAMEBUFFER, prevFBO);
                         glViewport(0, 0, viewState.getWidth(), viewState.getHeight());
+                    }
+
+                    // Hand the masks to the layers BEFORE they draw, the same explicit per-frame
+                    // hand-off setExternalDrapeTiles is. A tile whose mask has not been baked yet -
+                    // budgeted out, or its drape only just seeded - is absent from the map, and its
+                    // live layers draw unmasked for those frames, as they did before #175.
+                    std::vector<std::map<vt::TileId, unsigned int> > drapeCoverageMasks(drapeCuts.size());
+                    for (std::size_t k = 0; k < drapeCuts.size(); k++) {
+                        for (const vt::TileId& tileId : drapeTileIds) {
+                            unsigned int maskTexture = _terrainDrapeCache->findBaked(tileId, static_cast<int>(k) + 1);
+                            if (maskTexture != 0) {
+                                drapeCoverageMasks[k][tileId] = maskTexture;
+                            }
+                        }
+                    }
+                    for (std::size_t i = 0; i < drapeLayers.size(); i++) {
+                        drapeLayers[i]->setDrapeCoverageMasks(drapeCoverageMasks, drapeLayerMasks[i]);
                     }
 
                     // Directional shadows over the drape cover.

--- a/all/native/renderers/TileRenderer.cpp
+++ b/all/native/renderers/TileRenderer.cpp
@@ -371,6 +371,31 @@ namespace massif {
         return 0;
     }
 
+    void TileRenderer::collectDrapeStackOrder(std::vector<std::pair<int, bool> >& units) const {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (std::shared_ptr<vt::GLTileRenderer> tileRenderer = (_vtRenderer ? _vtRenderer->getTileRenderer() : std::shared_ptr<vt::GLTileRenderer>())) {
+            tileRenderer->collectDrapeStackOrder(units);
+        }
+    }
+
+    int TileRenderer::bakeDrapeCoverage(const vt::TileId& tileId, int fromStyleLayerIdx) {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (std::shared_ptr<vt::GLTileRenderer> tileRenderer = (_vtRenderer ? _vtRenderer->getTileRenderer() : std::shared_ptr<vt::GLTileRenderer>())) {
+            return tileRenderer->bakeDrapeCoverage(tileId, fromStyleLayerIdx);
+        }
+        return 0;
+    }
+
+    void TileRenderer::setDrapeCoverageMasks(const std::vector<std::map<vt::TileId, unsigned int> >& maskTextures, const std::map<int, int>& styleLayerMasks) {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (std::shared_ptr<vt::GLTileRenderer> tileRenderer = (_vtRenderer ? _vtRenderer->getTileRenderer() : std::shared_ptr<vt::GLTileRenderer>())) {
+            tileRenderer->setDrapeCoverageMasks(maskTextures, styleLayerMasks);
+        }
+    }
+
     int TileRenderer::renderDrapedSurface(const vt::TileId& tileId, unsigned int drapeTexture, float uvOffsetX, float uvOffsetY, float uvScale) {
         std::lock_guard<std::mutex> lock(_mutex);
 

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -121,6 +121,12 @@ namespace massif {
         int renderTerrainGround(const Color& color);
         void collectDrapeTiles(std::map<vt::TileId, std::size_t>& drapeTiles) const;
         int bakeDrapeTile(const vt::TileId& tileId);
+        // This layer's style layers with drapeable content, in draw order, each flagged draped or
+        // live. The owner concatenates them across layers to place a live layer in the whole stack
+        // (see GLTileRenderer::collectDrapeStackOrder).
+        void collectDrapeStackOrder(std::vector<std::pair<int, bool> >& units) const;
+        int bakeDrapeCoverage(const vt::TileId& tileId, int fromStyleLayerIdx);
+        void setDrapeCoverageMasks(const std::vector<std::map<vt::TileId, unsigned int> >& maskTextures, const std::map<int, int>& styleLayerMasks);
         int renderDrapedSurface(const vt::TileId& tileId, unsigned int drapeTexture, float uvOffsetX, float uvOffsetY, float uvScale);
         int renderDrapedSurfaceFill(const vt::TileId& tileId, const Color& color);
         int blitDrapeTexture(unsigned int srcTexture, float dstOffsetX, float dstOffsetY, float dstScale, float uvOffsetX, float uvOffsetY, float uvScale);

--- a/all/native/renderers/utils/TerrainDrapeCache.cpp
+++ b/all/native/renderers/utils/TerrainDrapeCache.cpp
@@ -68,6 +68,11 @@ const std::size_t TerrainDrapeCache::MAX_ENTRIES = 160;
             glDeleteTextures(1, &tex);
         }
         _texturePool.clear();
+        for (unsigned int texture : _maskTexturePool) {
+            GLuint tex = texture;
+            glDeleteTextures(1, &tex);
+        }
+        _maskTexturePool.clear();
     }
 
     void TerrainDrapeCache::setStackSignature(std::size_t signature) {
@@ -115,16 +120,23 @@ const std::size_t TerrainDrapeCache::MAX_ENTRIES = 160;
     }
 #endif
 
-    unsigned int TerrainDrapeCache::createTexture() {
-        if (!_texturePool.empty()) {
-            unsigned int texture = _texturePool.back();
-            _texturePool.pop_back();
+    unsigned int TerrainDrapeCache::createTexture(bool mask) {
+        std::vector<unsigned int>& pool = (mask ? _maskTexturePool : _texturePool);
+        if (!pool.empty()) {
+            unsigned int texture = pool.back();
+            pool.pop_back();
             return texture;
         }
         GLuint texture = 0;
         glGenTextures(1, &texture);
         glBindTexture(GL_TEXTURE_2D, texture);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _resolution, _resolution, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+        // A coverage mask is one channel: R8 (core in ES3, which both platforms require - see
+        // CLAUDE.md) rather than a quarter-used RGBA, so a mask costs a quarter of a drape.
+        if (mask) {
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, _resolution, _resolution, 0, GL_RED, GL_UNSIGNED_BYTE, NULL);
+        } else {
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _resolution, _resolution, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+        }
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         // Mipmapped, because a drape texture is almost always MINIFIED: the bake resolution is
         // sized for the widest a tile can ever get on screen (see TileRenderer::
@@ -155,7 +167,8 @@ const std::size_t TerrainDrapeCache::MAX_ENTRIES = 160;
         Key key { tileId, stack };
         Entry& entry = _entries[key];
         if (entry.texture == 0) {
-            entry.texture = createTexture();
+            entry.texture = createTexture(stack > 0);
+            entry.bytes = static_cast<std::size_t>(_resolution) * _resolution * (stack > 0 ? 1 : 4);
             entry.baked = false;
             entry.seeded = false;
             entry.stale = false;
@@ -256,6 +269,20 @@ const std::size_t TerrainDrapeCache::MAX_ENTRIES = 160;
     }
 #endif
 
+#ifdef __ANDROID__
+    bool TerrainDrapeCache::isCoverageMaskEnabled() {
+        static const bool enabled = [] {
+            char property[PROP_VALUE_MAX] = { 0 };
+            return !(__system_property_get("debug.massif.drapemask", property) > 0 && property[0] == '0');
+        }();
+        return enabled;
+    }
+#else
+    bool TerrainDrapeCache::isCoverageMaskEnabled() {
+        return true;
+    }
+#endif
+
     std::size_t TerrainDrapeCache::maxEntries() const {
         if (!isBudgetEnabled()) {
             return MAX_ENTRIES;
@@ -268,9 +295,23 @@ const std::size_t TerrainDrapeCache::MAX_ENTRIES = 160;
         return std::min(MAX_ENTRIES, std::max(MIN_ENTRIES, entries));
     }
 
+    std::size_t TerrainDrapeCache::cachedBytes() const {
+        std::size_t bytes = 0;
+        for (auto it = _entries.begin(); it != _entries.end(); it++) {
+            bytes += it->second.bytes;
+        }
+        return bytes;
+    }
+
     void TerrainDrapeCache::endFrame() {
+        // BYTES, not a count: a coverage mask entry (#175) is R8 and costs a quarter of a colour
+        // drape, so a count would let the masks eat a quarter of the cache's tiles for nothing.
+        // MIN_ENTRIES stays the floor, in colour-drape equivalents.
         std::size_t maxCount = maxEntries();
-        if (_entries.size() <= maxCount) {
+        std::size_t colourBytes = static_cast<std::size_t>(_resolution) * _resolution * 4;
+        std::size_t maxBytes = (isBudgetEnabled() ? std::max(MAX_BYTES, MIN_ENTRIES * colourBytes) : MAX_ENTRIES * colourBytes);
+        std::size_t bytes = cachedBytes();
+        if (_entries.size() <= maxCount && bytes <= maxBytes) {
             return; // keep unused tiles cached; they come back constantly while panning/zooming
         }
         // Over budget: evict the least recently used entries, never one used this frame.
@@ -284,18 +325,22 @@ const std::size_t TerrainDrapeCache::MAX_ENTRIES = 160;
         std::sort(candidates.begin(), candidates.end(), [](const std::pair<unsigned int, Key>& a, const std::pair<unsigned int, Key>& b) {
             return a.first < b.first;
         });
-        std::size_t evictCount = _entries.size() - maxCount;
-        for (std::size_t i = 0; i < candidates.size() && i < evictCount; i++) {
+        for (std::size_t i = 0; i < candidates.size(); i++) {
+            if (_entries.size() <= maxCount && bytes <= maxBytes) {
+                break;
+            }
             auto it = _entries.find(candidates[i].second);
             if (it == _entries.end()) {
                 continue;
             }
-            if (_texturePool.size() < MAX_POOLED_TEXTURES) {
-                _texturePool.push_back(it->second.texture);
+            std::vector<unsigned int>& pool = (candidates[i].second.stack > 0 ? _maskTexturePool : _texturePool);
+            if (pool.size() < MAX_POOLED_TEXTURES) {
+                pool.push_back(it->second.texture);
             } else {
                 GLuint texture = it->second.texture;
                 glDeleteTextures(1, &texture);
             }
+            bytes -= std::min(bytes, it->second.bytes);
             _entries.erase(it);
         }
     }
@@ -311,6 +356,11 @@ const std::size_t TerrainDrapeCache::MAX_ENTRIES = 160;
             glDeleteTextures(1, &tex);
         }
         _texturePool.clear();
+        for (unsigned int texture : _maskTexturePool) {
+            GLuint tex = texture;
+            glDeleteTextures(1, &tex);
+        }
+        _maskTexturePool.clear();
         if (_frameBuffer != 0) {
             GLuint fbo = _frameBuffer;
             glDeleteFramebuffers(1, &fbo);

--- a/all/native/renderers/utils/TerrainDrapeCache.h
+++ b/all/native/renderers/utils/TerrainDrapeCache.h
@@ -23,9 +23,11 @@ namespace massif {
      * given tile, in layer order, so a hillshade layer and a vector tile layer share one drape,
      * one terrain surface draw and one depth domain instead of each keeping their own.
      *
-     * Textures are keyed by (tile, stack). A stack is a run of contiguous drapeable layers; a
-     * non-drapeable layer between drapeable ones starts a new stack, which needs its own texture
-     * and its own surface draw over the previous one.
+     * Textures are keyed by (tile, stack). Stack 0 is the RGBA colour drape - the only one the
+     * stack index was originally meant to have, a second one being reserved for a run of drapeable
+     * layers split by a non-drapeable one, which nothing produces. Stacks 1..K are now the R8
+     * COVERAGE MASKS a live no-drape layer is occluded by (#175) - one per cut in the style order,
+     * baked and invalidated with the colour drape they belong to.
      *
      * GL thread only.
      */
@@ -82,6 +84,9 @@ namespace massif {
         // debug.massif.drapebudget 0 restores the pre-budget behaviour - a tile COUNT cap and an
         // uncapped bake resolution - so the two can be measured against each other in one build.
         static bool isBudgetEnabled();
+        // debug.massif.drapemask 0 turns the no-drape occlusion masks off (#175), so a run with a
+        // live layer back on top of the whole drape is one relaunch away. Read once (Android only).
+        static bool isCoverageMaskEnabled();
 
         /**
          * Rebuilds the mipmap chain of a drape texture. Must follow every write to its level 0,
@@ -143,6 +148,7 @@ namespace massif {
 
         struct Entry {
             unsigned int texture = 0;
+            std::size_t bytes = 0; // 4 bytes/texel for a colour drape, 1 for an R8 coverage mask
             std::size_t fingerprint = 0;
             std::size_t layerMask = 0;
             bool baked = false;
@@ -152,7 +158,9 @@ namespace massif {
             unsigned int lastUsedFrame = 0;
         };
 
-        unsigned int createTexture();
+        // mask: a one-channel R8 coverage mask (stack > 0) rather than the RGBA colour drape.
+        unsigned int createTexture(bool mask);
+        std::size_t cachedBytes() const;
 
         static const int MAX_ANISOTROPY;
         static const std::size_t MAX_POOLED_TEXTURES; // recycled textures kept between frames
@@ -165,6 +173,7 @@ namespace massif {
         unsigned int _frameBuffer;
         std::map<Key, Entry> _entries;
         std::vector<unsigned int> _texturePool;
+        std::vector<unsigned int> _maskTexturePool; // R8, kept apart: a pooled texture keeps its format
         unsigned int _frameCounter;
     };
 

--- a/all/native/terrain/DrapeStackCuts.h
+++ b/all/native/terrain/DrapeStackCuts.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _MASSIF_DRAPESTACKCUTS_H_
+#define _MASSIF_DRAPESTACKCUTS_H_
+
+#include <cstddef>
+#include <map>
+#include <vector>
+
+namespace massif {
+
+    /**
+     * Where a LIVE (no-drape) style layer sits in the drape stack, and which occlusion mask it has
+     * to be drawn through.
+     *
+     * The drape composite is baked and drawn before any live geometry, so a layer kept out of the
+     * bake (TerrainOptions::NoDrapeLayerFilter) can only land on top of ALL of it - contours over
+     * roads in 3D where 2D draws roads over contours. Flatten the stack into ordered units, one per
+     * style layer of each drape layer, and every live unit with a draped unit after it is drawn
+     * through a mask holding the accumulated coverage of everything draped above it.
+     *
+     * Free of the renderer on purpose: this is the ordering rule, so it is the part worth testing
+     * on the host. See MapRenderer::onDrawFrame and docs/internals/rendering/04-terrain.md.
+     */
+    struct DrapeStackCuts {
+        struct Unit {
+            std::size_t layerIndex; // the drape layer this style layer belongs to
+            int styleLayerIdx;      // vt::TileLayer::getLayerIndex
+            bool draped;            // in the bake, as opposed to drawn live
+        };
+        // The mask covers every draped unit from this position on: styleLayerIdx and up inside
+        // layerIndex, and all of the drape layers after it.
+        struct Cut {
+            std::size_t layerIndex;
+            int styleLayerIdx;
+        };
+
+        /**
+         * units must be in draw order. layerMasks is indexed by drape layer and filled with
+         * styleLayerIdx -> mask index for every live layer that needs one; a live layer left out
+         * draws unmasked, which is both the pre-#175 behaviour and the correct answer when nothing
+         * draped comes after it.
+         *
+         * Live units sharing the same nearest draped unit share a mask, so the number of masks is
+         * the number of live->draped transitions - 0 or 1 for every ordinary style. Returns true
+         * when maxMasks cut the list short.
+         */
+        static bool compute(const std::vector<Unit>& units, std::size_t maxMasks, std::vector<Cut>& cuts, std::vector<std::map<int, int> >& layerMasks) {
+            bool capped = false;
+            // Backwards, so the nearest draped unit after each live one is known when it is
+            // reached. Its position IS the mask's identity.
+            int nearestDrapedUnit = -1;
+            std::map<int, int> maskIndexByUnit;
+            for (int k = static_cast<int>(units.size()) - 1; k >= 0; k--) {
+                if (units[k].draped) {
+                    nearestDrapedUnit = k;
+                    continue;
+                }
+                if (nearestDrapedUnit < 0) {
+                    continue; // nothing draped after it: already on top, as it should be
+                }
+                auto maskIt = maskIndexByUnit.find(nearestDrapedUnit);
+                if (maskIt == maskIndexByUnit.end()) {
+                    if (cuts.size() >= maxMasks) {
+                        capped = true;
+                        continue;
+                    }
+                    maskIt = maskIndexByUnit.emplace(nearestDrapedUnit, static_cast<int>(cuts.size())).first;
+                    cuts.push_back(Cut { units[nearestDrapedUnit].layerIndex, units[nearestDrapedUnit].styleLayerIdx });
+                }
+                if (units[k].layerIndex < layerMasks.size()) {
+                    layerMasks[units[k].layerIndex][units[k].styleLayerIdx] = maskIt->second;
+                }
+            }
+            return capped;
+        }
+
+        /**
+         * A hash of the cut positions, folded into the mask fingerprints so a style reorder that
+         * leaves the tile content alone still re-bakes them.
+         */
+        static std::size_t signature(const std::vector<Cut>& cuts) {
+            std::size_t signature = 0;
+            for (const Cut& cut : cuts) {
+                std::size_t cutHash = cut.layerIndex * 1000003 + static_cast<std::size_t>(cut.styleLayerIdx + 1);
+                signature ^= cutHash + 0x9e3779b9 + (signature << 6) + (signature >> 2);
+            }
+            return signature;
+        }
+    };
+
+}
+
+#endif

--- a/docs/internals/rendering/04-terrain.md
+++ b/docs/internals/rendering/04-terrain.md
@@ -810,3 +810,66 @@ nothing draped.
 
 Note the filter matches the **vt layer name**, which comes from the style's own rule names — a style
 that calls its contour rules something else needs its own pattern.
+
+### Putting the live layer back in its style position
+
+Keeping a layer out of the bake also takes it out of the **order**. The drape composite for every
+visible tile is baked and drawn before any live geometry, and the per-layer pass then skips whatever
+went into the bake (`GLTileRenderer.cpp`, the `drapedTile && isDrapeableGeometry && isLayerDraped`
+skip), so a no-drape layer can only land on top of *everything* draped. With the defaults — filter
+`^contour|maneuver.*`, `DrapeLinesEnabled` true — roads are baked and contours are drawn live over
+them, while 2D draws them the other way round. That is [#175](https://github.com/massif-maps/MassifMaps/issues/175).
+
+Three fixes do not work. **Draping the contours too**: the drape is parameterised by the tile's XY,
+so its ground resolution degrades as `1/cos(slope)` and contours run *along* the slope, where the
+stretch is worst — no `DrapeResolution` fixes a parameterisation. **Cutting the drape** at the
+topmost no-drape layer: correct order, but roads stop being draped, and that is the 13.4 → 27 fps
+win in the table above. **Splitting the drape into two RGBA textures**: exact, but +4 MB per tile at
+1024 against a 96 MB cache.
+
+So: do not reorder the passes, **occlude**. The whole stack flattens into ordered units, one per
+style layer of each drape layer, each draped (**D**) or live (**L**). What the frame produces today
+is all D then all L, which is wrong at exactly one kind of position — a D after an L. Each L is
+therefore drawn through a **coverage mask**: the accumulated alpha of every D after it, sampled in
+drape-tile uv, `alpha *= 1.0 - mask`.
+
+| where | what |
+|---|---|
+| `terrain/DrapeStackCuts.h` | the ordering rule — flatten, walk backwards, one mask per L→D transition. Header-only, covered by `tests/api/DrapeStackCutsTest.cpp` |
+| `MapRenderer::onDrawFrame` | asks each drape layer for its D/L runs, stitches them into one sequence, bakes the masks inside `bakeTile` and hands them back before the layers draw |
+| `GLTileRenderer::bakeDrapeCoverage` | the bake — the same covering tiles and transforms as `bakeDrapeTile`, restricted to the style layers at or after the cut, with the fragment stage writing alpha (`COVERAGE`) instead of colour |
+| `GLTileRenderer::resolveDrapeCoverageMask` | which mask a live layer takes over a given tile, and the target-tile → mask-tile uv sub-rect |
+| `TerrainDrapeCache` | stack 0 is the RGBA drape, stacks 1..K the **R8** masks — baked off the same fingerprint, so a mask can never describe a different generation of the map than the drape beside it |
+
+Two properties make it cheap. Coverage accumulation is **order-independent** (`1-(1-a1)(1-a2)`
+commutes), so the extra pass need not preserve style order internally; and consecutive L units with
+no D between them **share** a mask, so K is the number of L→D transitions — 0 or 1 for every
+ordinary style. The rule is derived per frame from `isLayerDraped` plus the existing drape-layer
+order, so a style that puts its contours above the roads still renders that way, at zero cost.
+
+| style order | K | result |
+|---|---|---|
+| landcover, hillshade, **contours**, roads | 1 | contours under roads, over hillshade |
+| roads, hillshade, **contours** | 0 | contours on top — already correct, and free |
+| landcover, **contours**, roads, **maneuver** | 1 | both correct; the maneuver layer has nothing draped after it |
+
+Costs and known limits:
+
+- **K × 1 MB per drape tile** at resolution 1024 (R8 — [ES3 is a hard requirement](../../../CLAUDE.md)
+  on both platforms), against the 4 MB of the colour drape. `TerrainDrapeCache` budgets in **bytes**
+  rather than entries for this reason: a count would let the masks eat a quarter of the cache's
+  tiles for nothing.
+- **One extra rasterisation** of the above-cut units per mask, inside the existing bake budget.
+- **Exact for opaque above-layers, approximate for translucent ones** — a 50 %-alpha road gets the
+  contour tinting it rather than the other way round. The exact fix is the 2×RGBA split.
+- **A terrain paint contributes no coverage.** It shades the ground the other layers put in the
+  drape; treating it as an occluder would hide every live layer under it outright.
+- **A drape tile finer than the geometry's render tile** would need several masks in one draw. That
+  draw keeps the pre-#175 behaviour and is drawn on top.
+- **Capped at 2 masks** (`MAX_DRAPE_COVERAGE_MASKS`); a deeper cut is dropped, logged once, and its
+  layer draws on top as before.
+- **A style with an opaque layer above the contours hides them completely.** Correct, and what 2D
+  already does, but it reads as a bug the first time.
+
+A/B: `adb shell setprop debug.massif.drapemask 0` and relaunch puts the live layers back on top of
+the whole drape.

--- a/docs/internals/rendering/09-composite-layer.md
+++ b/docs/internals/rendering/09-composite-layer.md
@@ -62,6 +62,10 @@ For depth, the children's style layers are part of the stack's ordinal numbering
 layer's ([05-depth-model.md](05-depth-model.md#ordinals-and-the-budget)) — which is why the ordinals
 are handed out per layer in draw order rather than per renderer.
 
+Under 3D terrain the same list decides the **drape order**, and a slot kept out of the drape bake
+(`TerrainOptions::NoDrapeLayerFilter` — contours) has to be occluded by the layers above it rather
+than drawn over them: [04-terrain.md](04-terrain.md#putting-the-live-layer-back-in-its-style-position).
+
 ## Why this exists at all
 
 Tangram has one ordered style list, so "hillshade under the roads but over the landcover" is just an

--- a/tests/api/ApiTest.cpp
+++ b/tests/api/ApiTest.cpp
@@ -63,6 +63,7 @@ void testSetAll();
 void testAliases();
 void testWriteProjection();
 void testAutoFlatten();
+void testDrapeStackCuts();
 
 namespace {
 
@@ -416,6 +417,7 @@ int main() {
     testAliases();
     testWriteProjection();
     testAutoFlatten();
+    testDrapeStackCuts();
 
     std::printf("\n%d failure(s)\n", failures);
     return failures ? 1 : 0;

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -170,6 +170,8 @@ add_executable(api_tests
   SpecKeyTest.cpp
   # Header-only: AutoFlatten.h has no dependencies at all, so this costs the link nothing.
   AutoFlattenTest.cpp
+  # Same: DrapeStackCuts.h is the ordering rule and nothing else.
+  DrapeStackCutsTest.cpp
   "${TEST_TABLE_DIR}/PropertyTable.inc"
   "${TEST_TABLE_DIR}/MethodDecls.inc"
   ${TEST_SDK_SOURCES})

--- a/tests/api/DrapeStackCutsTest.cpp
+++ b/tests/api/DrapeStackCutsTest.cpp
@@ -1,0 +1,136 @@
+/*
+ * Tests for the drape-stack cut rule (all/native/terrain/DrapeStackCuts.h): where a live no-drape
+ * style layer sits in the stack, how many occlusion masks that costs, and which live layer takes
+ * which mask (#175).
+ *
+ * The table in the issue is what these cases are: contours between hillshade and roads need one
+ * mask, contours last need none, a maneuver layer after the contours must not take the contours'
+ * mask, and a pathological D L D L D needs two nested suffixes.
+ *
+ * NOT covered here: everything that reads the rule. The masks themselves are an R8 bake per drape
+ * tile through GLTileRenderer::bakeDrapeCoverage, and whether a contour really lands under a road
+ * on a slope is a device check - see docs/internals/rendering/04-terrain.md.
+ */
+
+#include "terrain/DrapeStackCuts.h"
+
+using namespace massif;
+
+#include "TestCheck.h"
+
+namespace {
+
+    // One drape layer, style layers numbered from 0 in the order given.
+    std::vector<DrapeStackCuts::Unit> oneLayer(const std::vector<bool>& draped) {
+        std::vector<DrapeStackCuts::Unit> units;
+        for (std::size_t i = 0; i < draped.size(); i++) {
+            units.push_back(DrapeStackCuts::Unit { 0, static_cast<int>(i), draped[i] });
+        }
+        return units;
+    }
+
+    void testNothingDrapedAfter() {
+        // landcover, hillshade, roads, contours: the contours are already last, which is what the
+        // style asked for. Zero masks, zero cost - the case every "contours on top" style is in.
+        std::vector<DrapeStackCuts::Cut> cuts;
+        std::vector<std::map<int, int> > layerMasks(1);
+        bool capped = DrapeStackCuts::compute(oneLayer({ true, true, true, false }), 2, cuts, layerMasks);
+        TEST_CHECK(!capped, "four units and one live one cannot hit the cap");
+        TEST_CHECK(cuts.empty(), "a live layer with nothing draped after it needs no mask");
+        TEST_CHECK(layerMasks[0].empty(), "... and is not in the mask map at all, so it draws unmasked");
+    }
+
+    void testOneCut() {
+        // landcover, hillshade, contours, roads: one live->draped transition.
+        std::vector<DrapeStackCuts::Cut> cuts;
+        std::vector<std::map<int, int> > layerMasks(1);
+        DrapeStackCuts::compute(oneLayer({ true, true, false, true }), 2, cuts, layerMasks);
+        TEST_CHECK(cuts.size() == 1, "one live->draped transition is one mask");
+        TEST_CHECK(cuts[0].layerIndex == 0 && cuts[0].styleLayerIdx == 3,
+                   "the mask starts at the first draped unit AFTER the live one, not at the live one");
+        TEST_CHECK(layerMasks[0].size() == 1 && layerMasks[0][2] == 0, "the contour layer takes mask 0");
+    }
+
+    void testLiveLayerAfterTheCutTakesNoMask() {
+        // landcover, contours, roads, maneuver: the maneuver layer is last and must stay on top,
+        // even though the contours below it are masked. One mask, and it is not the maneuver's.
+        std::vector<DrapeStackCuts::Cut> cuts;
+        std::vector<std::map<int, int> > layerMasks(1);
+        DrapeStackCuts::compute(oneLayer({ true, false, true, false }), 2, cuts, layerMasks);
+        TEST_CHECK(cuts.size() == 1, "only the contours have anything draped after them");
+        TEST_CHECK(layerMasks[0].count(1) == 1 && layerMasks[0][1] == 0, "the contours are masked");
+        TEST_CHECK(layerMasks[0].count(3) == 0, "the last layer is not masked - nothing draped follows it");
+    }
+
+    void testAdjacentLiveLayersShareOneMask() {
+        // Two live layers with no draped unit between them see the same suffix, so they share a
+        // mask rather than each costing one.
+        std::vector<DrapeStackCuts::Cut> cuts;
+        std::vector<std::map<int, int> > layerMasks(1);
+        DrapeStackCuts::compute(oneLayer({ false, false, true }), 2, cuts, layerMasks);
+        TEST_CHECK(cuts.size() == 1, "live units sharing a nearest draped unit share a mask");
+        TEST_CHECK(layerMasks[0][0] == 0 && layerMasks[0][1] == 0, "... and both point at it");
+    }
+
+    void testNestedSuffixes() {
+        // D L D L D - the pathological shape: two transitions, two nested suffix masks, and the
+        // deeper live layer must take the LOWER cut (more content above it), not the higher one.
+        std::vector<DrapeStackCuts::Cut> cuts;
+        std::vector<std::map<int, int> > layerMasks(1);
+        bool capped = DrapeStackCuts::compute(oneLayer({ true, false, true, false, true }), 2, cuts, layerMasks);
+        TEST_CHECK(!capped, "two cuts fit a cap of two");
+        TEST_CHECK(cuts.size() == 2, "two live->draped transitions are two masks");
+        TEST_CHECK(layerMasks[0][3] == 0 && cuts[0].styleLayerIdx == 4,
+                   "the upper live layer is occluded by the last draped unit only");
+        TEST_CHECK(layerMasks[0][1] == 1 && cuts[1].styleLayerIdx == 2,
+                   "the lower one is occluded from the draped unit right above it, so its mask nests the other");
+    }
+
+    void testCap() {
+        // D L D L D L D needs three; with a cap of two the deepest cut is dropped and that layer
+        // draws on top, as it did before the fix.
+        std::vector<DrapeStackCuts::Cut> cuts;
+        std::vector<std::map<int, int> > layerMasks(1);
+        bool capped = DrapeStackCuts::compute(oneLayer({ true, false, true, false, true, false, true }), 2, cuts, layerMasks);
+        TEST_CHECK(capped, "three transitions against a cap of two is reported");
+        TEST_CHECK(cuts.size() == 2, "and never allocates more masks than the cap");
+        TEST_CHECK(layerMasks[0].count(1) == 0, "the dropped cut's layer is unmasked, not mis-masked");
+    }
+
+    void testAcrossDrapeLayers() {
+        // A standalone contour LAYER between a hillshade layer and the base map: the cut is at the
+        // start of a later drape layer, which is the case MapRenderer alone can see.
+        std::vector<DrapeStackCuts::Unit> units;
+        units.push_back(DrapeStackCuts::Unit { 0, 0, true });  // hillshade layer
+        units.push_back(DrapeStackCuts::Unit { 1, 0, false }); // contour layer, live
+        units.push_back(DrapeStackCuts::Unit { 2, 5, true });  // base map, roads
+        std::vector<DrapeStackCuts::Cut> cuts;
+        std::vector<std::map<int, int> > layerMasks(3);
+        DrapeStackCuts::compute(units, 2, cuts, layerMasks);
+        TEST_CHECK(cuts.size() == 1 && cuts[0].layerIndex == 2 && cuts[0].styleLayerIdx == 5,
+                   "the cut names the drape layer AND the style layer inside it");
+        TEST_CHECK(layerMasks[1].size() == 1 && layerMasks[1][0] == 0, "the contour layer takes the mask");
+        TEST_CHECK(layerMasks[0].empty() && layerMasks[2].empty(), "draped layers take none");
+    }
+
+    void testSignature() {
+        std::vector<DrapeStackCuts::Cut> cuts1 { DrapeStackCuts::Cut { 0, 3 } };
+        std::vector<DrapeStackCuts::Cut> cuts2 { DrapeStackCuts::Cut { 0, 4 } };
+        TEST_CHECK(DrapeStackCuts::signature(cuts1) != DrapeStackCuts::signature(cuts2),
+                   "moving a cut changes the signature, so the cached masks are re-baked");
+        TEST_CHECK(DrapeStackCuts::signature(std::vector<DrapeStackCuts::Cut>()) == 0,
+                   "no cuts is a zero signature, so a style with no live layer never disturbs the fingerprints");
+    }
+
+}
+
+void testDrapeStackCuts() {
+    testNothingDrapedAfter();
+    testOneCut();
+    testLiveLayerAfterTheCutTakesNoMask();
+    testAdjacentLiveLayersShareOneMask();
+    testNestedSuffixes();
+    testCap();
+    testAcrossDrapeLayers();
+    testSignature();
+}


### PR DESCRIPTION
## Summary

With 3D terrain and draping on, a style layer matching `TerrainOptions.NoDrapeLayerFilter` was drawn
after the **entire** drape composite, because that is the only place the frame had for it. With the
defaults — filter `^contour|maneuver.*`, `DrapeLinesEnabled` true — roads are baked and contours are
drawn live over them, while 2D draws them the other way round.

Three fixes do not work, and are worth stating because each looks obvious: draping the contours too
(the drape is parameterised by tile XY, so its ground resolution degrades as `1/cos(slope)` exactly
where contours run — no `DrapeResolution` fixes a parameterisation); cutting the drape at the topmost
no-drape layer (correct order, but roads stop being draped, and that is the 13.4 → 27 fps win);
splitting the drape into two RGBA textures (exact, but +4 MB per tile against a 96 MB cache).

So: do not reorder the passes, **occlude**.

- **`terrain/DrapeStackCuts.h`** — the ordering rule alone. Flatten the stack into ordered units, one
  per style layer of each drape layer, each draped (D) or live (L); walk backwards; one mask per L→D
  transition. Header-only, so the host tests can reach it.
- **`MapRenderer`** — stitches the per-layer runs into one sequence, bakes the masks inside `bakeTile`
  off the *same fingerprint* as the colour drape, and hands them to the layers before they draw. The
  cut is at vt **style-layer** granularity, not SDK-layer: the reported case has contours merged into
  the composite base map, so no single renderer can see it.
- **`TerrainDrapeCache`** — masks at stack 1..K as R8, and the budget is now in **bytes** rather than
  entries; a count would let the masks eat a quarter of the cache's tiles for nothing.

Consecutive L units with no D between them share a mask, so K is the number of L→D transitions —
0 or 1 for every ordinary style, and a style that already puts its contours on top costs nothing.

| style order | K | result |
|---|---|---|
| landcover, hillshade, **contours**, roads | 1 | contours under roads, over hillshade |
| roads, hillshade, **contours** | 0 | contours on top — already correct, and free |
| landcover, **contours**, roads, **maneuver** | 1 | both correct; nothing draped follows the maneuver layer |

Limits, all documented in [04-terrain.md](docs/internals/rendering/04-terrain.md#putting-the-live-layer-back-in-its-style-position):
exact for opaque above-layers and approximate for translucent ones; a terrain paint contributes no
coverage (it shades the ground rather than occluding it); capped at 2 masks, a deeper cut is dropped
and logged once.

## Testing

- `cd tests && ./run.sh` — 8 new cases over the ordering rule (`DrapeStackCutsTest.cpp`): the issue's
  table rows, adjacent live layers sharing a mask, the nested `D L D L D` suffixes, the cap, and the
  cross-drape-layer case. I broke one assertion deliberately to confirm they actually run.
- `clang++ -fsyntax-only -std=c++20` clean on all five touched translation units.

**Device-verified** on an Adreno 610 (Crosscall HLTE556N), fresh process both runs:

```sh
adb shell setprop debug.massif.drapemask 0   # or 1; read once, so relaunch between
adb shell am force-stop com.massifmaps.MassifDemo
adb shell am start -n com.massifmaps.MassifDemo/.BenchActivity --es ui false \
  --es lon 5.7606 --es lat 45.2442 --es zoom 13.6 --es tilt 55 --es contour true --es style inline
```

Contours break at every road crossing with their shapes otherwise identical (so it is the mask, not
tiles settling), 2.6–3.9 % of pixels differing per band, logcat clean — no GL errors, no incomplete
framebuffer, no cap warning. Sweep at z11.5 / z14.5 / z15.55 clean.

**Not measured: the extra bake's frame cost.** The `RTT drape cost` lines I captured came from the
mask-off process, so there is no honest before/after. Worth a look before this leaves draft. iOS not
built.

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/74 — merges first; the pointer bump here is then
rebased onto the merged submodule commit, not the branch commit.

Fixes #175