### PR TITLE
fix(layers): stop a style whose #contour block only styles lines from crashing the map

### DIFF
--- a/docs/features/composite-layer-reference.md
+++ b/docs/features/composite-layer-reference.md
@@ -105,6 +105,12 @@ per frame — they regenerate tiles):
 | `contour-min-visible-zoom` | `setMinVisibleZoom` |
 | `contour-simplify-tolerance` | `setSimplifyTolerance` |
 
+All of them are optional: a `#contour` block that only styles the lines (no `contour-*`
+property) leaves the source on its own defaults. Ordinary styling rules in the block are
+ignored when the config is read, filters included — a converted MapBox style writes
+`[$type] = 'line'` on every line rule, and that filter reads a feature the config pass does
+not have.
+
 Contours render past the DEM's max zoom via the child layer's `MaxOverzoomLevel` (from the
 source) — no need to download the DEM at the target zoom. Set
 `contourSource.setMaxOverzoomLevel(n)`.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,3 +8,4 @@ set(SDK_BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 enable_testing()
 add_subdirectory(api)
+add_subdirectory(style)

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,13 +8,21 @@ a host-native binary over the parts that can be linked without the renderer, plu
 cd tests && ./run.sh
 ```
 
-Needs `cmake`, `python3` and a host compiler. Nothing Android or iOS.
+Needs `cmake`, `python3` and a host compiler. Nothing Android or iOS. `libs-external` has to be
+checked out with its nested submodules (`git submodule update --init --recursive libs-external`) —
+`rapidjson` and `utf8` are both on the link — and `libs-external/boost` symlinked as in
+[`BUILDING.md`](../BUILDING.md).
 
 ## What is covered, and what is not
 
 `api/` covers the facade's [property table, handle table and registry](../docs/internals/api-facade.md):
 generated-table lookups, the base-class chain, handle generations and the stale-handle rule,
 `set`/`get` per value type, and dotted path resolution.
+
+`style/` covers the mapnikvt style MODEL without the renderer: what `resolveLayerConfig` reads out
+of a style layer that also carries ordinary line/text rules, which is what a converted MapBox style
+produces. Only the TUs the model needs are linked — the symbolizer implementations pull vt's tile
+builders in, so a case that needs one belongs behind a device check instead.
 
 It does **not** cover anything that needs a real map. Two things make that a hard boundary rather
 than a choice:
@@ -33,8 +41,8 @@ type, so they are device-verified rather than covered here.
 ## The style XML round-trip — outside this suite
 
 Whether the Mapnik XML parser can read back everything `css2xml` writes is checked by `css2xml`
-itself, not here: linking `mapnikvt` drags `vt`, freetype and harfbuzz in, which is exactly the
-weight this suite avoids.
+itself, not here: the parser needs the symbolizers, and those drag `vt`, freetype and harfbuzz in —
+the weight `style/` stays under by linking the style model alone.
 
 ```sh
 cmake -S libs-massif/cartocss/util -B build/css2xml && cmake --build build/css2xml --target css2xml
@@ -53,3 +61,6 @@ parser, generator or expression grammar**, and add the construct to
 line and the binary exits non-zero, which is all `ctest` needs. If a new case needs another class,
 add its `.i` to `TEST_MODULES` in `api/CMakeLists.txt` and its `.cpp` to `TEST_SDK_SOURCES` — if
 that turns into a long list, the class probably belongs behind a device check instead.
+
+`style/StyleTest.cpp` is the same `main` for the style side; a new case is a function there plus
+its `.cpp` in `style/CMakeLists.txt`. Keep `STYLE_SOURCES` short for the same reason.

--- a/tests/style/CMakeLists.txt
+++ b/tests/style/CMakeLists.txt
@@ -1,0 +1,44 @@
+# mapnikvt without the renderer. Only the TUs the style MODEL needs are listed: the symbolizer
+# implementations pull vt's tile builders in, and with them freetype and harfbuzz, which is the
+# weight ../README.md keeps out of this suite. Symbolizer.cpp itself is the property binding only.
+set(STYLE_SOURCES
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/LayerConfigResolver.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/Symbolizer.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/Map.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/Style.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/Rule.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/Expression.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/ExpressionContext.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/ExpressionUtils.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/Predicate.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/PredicateUtils.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/TransformUtils.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/Value.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/Feature.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/ParserUtils.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/ParseTables.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/CSSColorParser.cpp"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/StringUtils.cpp"
+)
+
+add_executable(style_tests
+  StyleTest.cpp
+  LayerConfigTest.cpp
+  ${STYLE_SOURCES})
+
+target_include_directories(style_tests PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  # TestCheck.h is the whole framework and lives with the api tests.
+  "${CMAKE_CURRENT_SOURCE_DIR}/../api"
+  "${SDK_BASE_DIR}/libs-massif/mapnikvt/src"
+  # vt headers only - no vt object is linked.
+  "${SDK_BASE_DIR}/libs-massif/vt/src"
+  "${SDK_BASE_DIR}/libs-external/cglib"
+  "${SDK_BASE_DIR}/libs-external/stdext"
+  # stdext/unistring.h, reached from StringUtils.cpp.
+  "${SDK_BASE_DIR}/libs-external/utf8/source"
+  "${SDK_BASE_DIR}/libs-external/boost"
+  "${SDK_BASE_DIR}/libs-external/picojson"
+  "${SDK_BASE_DIR}/libs-external/tinyformat")
+
+add_test(NAME style COMMAND style_tests)

--- a/tests/style/LayerConfigTest.cpp
+++ b/tests/style/LayerConfigTest.cpp
@@ -1,0 +1,116 @@
+/*
+ * resolveLayerConfig over a style layer that carries ORDINARY styling rules, which is what a
+ * converted MapBox style produces for '#contour' / '#hillshade' (see tools/style-cli). The
+ * resolver runs with no tile and no feature, so a feature filter on such a rule has nothing to
+ * read - evaluating it used to dereference a null FeatureData.
+ */
+
+#include "TestCheck.h"
+
+#include "mapnikvt/LayerConfigResolver.h"
+#include "mapnikvt/ContourConfigSymbolizer.h"
+#include "mapnikvt/ExpressionContext.h"
+#include "mapnikvt/Filter.h"
+#include "mapnikvt/Layer.h"
+#include "mapnikvt/Map.h"
+#include "mapnikvt/Predicate.h"
+#include "mapnikvt/Rule.h"
+#include "mapnikvt/Style.h"
+#include "mapnikvt/Symbolizer.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace massif::mvt;
+
+namespace {
+    class NullLogger : public Logger {
+    public:
+        void write(Severity, const std::string&) override { }
+    };
+
+    // Stands in for a line/text symbolizer: those pull the vt tile builders in, and all this
+    // suite needs is a symbolizer that is NOT a LayerConfigSymbolizer.
+    class TestGeometrySymbolizer : public Symbolizer {
+    public:
+        explicit TestGeometrySymbolizer(std::shared_ptr<Logger> logger) : Symbolizer(std::move(logger)) { }
+
+        FeatureProcessor createFeatureProcessor(const ExpressionContext&, const SymbolizerContext&) const override {
+            return FeatureProcessor();
+        }
+    };
+
+    // '[mapnik::geometry_type] = 2', i.e. what '[$type] = "line"' converts to.
+    std::shared_ptr<const Filter> geometryTypeFilter() {
+        Predicate pred = std::make_shared<ComparisonPredicate>(ComparisonPredicate::Op::EQ,
+            Expression(std::make_shared<VariableExpression>(std::string("mapnik::geometry_type"))),
+            Expression(Value(static_cast<long long>(2))));
+        return std::make_shared<Filter>(Filter::Type::FILTER, std::optional<Predicate>(pred));
+    }
+
+    std::shared_ptr<Style> makeStyle(const std::string& name, std::vector<std::shared_ptr<const Rule>> rules) {
+        return std::make_shared<Style>(name, 1.0f, "", std::optional<massif::vt::CompOp>(), Style::FilterMode::ALL, "", std::move(rules));
+    }
+
+    void addLayer(Map& map, const std::shared_ptr<Style>& style) {
+        map.addStyle(style);
+        map.addLayer(std::make_shared<Layer>(style->getName(), std::vector<std::string> { style->getName() }));
+    }
+}
+
+void testLayerConfig() {
+    auto logger = std::make_shared<NullLogger>();
+
+    // A '#contour' layer holding only line rules: no config symbolizer, so no config - and the
+    // feature filter must not be evaluated on the way there.
+    {
+        Map map { Map::Settings() };
+        auto rule = std::make_shared<Rule>("line", 0, 24, geometryTypeFilter(),
+            std::vector<std::shared_ptr<const Symbolizer>> { std::make_shared<TestGeometrySymbolizer>(logger) });
+        addLayer(map, makeStyle("contour", { rule }));
+
+        ResolvedLayerConfig config = resolveLayerConfig(map, "contour", 12.0f, nullptr);
+        TEST_CHECK(!config.visible, "a styling-only layer resolves to no config");
+        TEST_CHECK(config.values.empty(), "a styling-only layer resolves no values");
+    }
+
+    // The same layer with a config rule beside the line rules: the config still resolves.
+    {
+        Map map { Map::Settings() };
+        auto lineRule = std::make_shared<Rule>("line", 0, 24, geometryTypeFilter(),
+            std::vector<std::shared_ptr<const Symbolizer>> { std::make_shared<TestGeometrySymbolizer>(logger) });
+        auto configSymbolizer = std::make_shared<ContourConfigSymbolizer>(logger);
+        configSymbolizer->getProperty("base-interval")->setExpression(Expression(Value(50.0)));
+        auto configRule = std::make_shared<Rule>("config", 0, 24, std::shared_ptr<const Filter>(),
+            std::vector<std::shared_ptr<const Symbolizer>> { configSymbolizer });
+        addLayer(map, makeStyle("contour", { lineRule, configRule }));
+
+        ResolvedLayerConfig config = resolveLayerConfig(map, "contour", 12.0f, nullptr);
+        TEST_CHECK(config.visible, "a config rule beside styling rules is still found");
+        auto it = config.values.find("base-interval");
+        TEST_CHECK(it != config.values.end() && ValueConverter<float>::convert(it->second) == 50.0f,
+                   "the config rule's value is resolved");
+    }
+
+    // The zoom range ignores styling rules the same way.
+    {
+        Map map { Map::Settings() };
+        auto rule = std::make_shared<Rule>("line", 5, 15, geometryTypeFilter(),
+            std::vector<std::shared_ptr<const Symbolizer>> { std::make_shared<TestGeometrySymbolizer>(logger) });
+        addLayer(map, makeStyle("contour", { rule }));
+
+        std::pair<int, int> range = resolveLayerZoomRange(map, "contour");
+        TEST_CHECK(range.first == 0 && range.second == 24, "a styling-only layer is zoom-unconstrained");
+    }
+
+    // A mapnik:: variable with no feature under it is undefined, not a crash - the same
+    // expression reached from anywhere else out of a tile.
+    {
+        ExpressionContext exprContext;
+        TEST_CHECK(std::holds_alternative<std::monostate>(exprContext.getVariable("mapnik::geometry_type")),
+                   "mapnik::geometry_type is null without a feature");
+        TEST_CHECK(std::holds_alternative<std::monostate>(exprContext.getVariable("mapnik::feature_id")),
+                   "mapnik::feature_id is null without a feature");
+    }
+}

--- a/tests/style/StyleTest.cpp
+++ b/tests/style/StyleTest.cpp
@@ -1,0 +1,16 @@
+/*
+ * The style-side host tests: mapnikvt without the renderer. See ../README.md.
+ */
+
+#include "TestCheck.h"
+
+int failures = 0;
+
+void testLayerConfig();
+
+int main() {
+    testLayerConfig();
+
+    std::printf("\n%d failure(s)\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- A style converted from MapBox (`massif-style mapbox2css …`) gives `#contour` ordinary line rules
  and no `contour-*` config property. Reading the slot's config evaluated those rules' `[$type]`
  filter with no feature under it, so `CompositeVectorTileLayer::addVectorDataSource("contour", …)`
  segfaulted the moment the slot was added — every launch with such a style.
- Bumps `libs-massif` onto the resolver fix (see below). Such a layer now resolves to an empty
  config and keeps the data source's defaults.
- Adds `tests/style`, a second host test target over the mapnikvt style model. It links the
  resolver, `Symbolizer` and the expression machinery **without** `vt`, freetype or harfbuzz, so
  `./run.sh` stays under a second.
- Documents that `contour-*` properties are optional and that styling rules are ignored by the
  config pass.

## Testing

`cd tests && ./run.sh` — both targets pass; with the submodule fix stashed the new one reports
`***Exception: SegFault`, i.e. it reproduces the reported crash on the host.

**Still needs a device/emulator check** — the crash was reported from the demo bench and only the
host repro is proven here:

```sh
node tools/style-cli/dist/cli.js mapbox2css topo-v4.json /tmp/topo-style --contour-schema div
adb push /tmp/topo-style/. /sdcard/alpimaps_mbtiles/osm/
adb shell am start -n com.massifmaps.MassifDemo/.BenchActivity --es style dir --es ui false
```

Expected: no `Fatal signal 11` on the `demo-build` thread, and the contour lines drawn by the
converted style's own rules.

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/76 — merge it first, then rebase this branch's
pointer bump onto the merged commit.