### PR TITLE
ci: unbreak the style-tools workflow and build it against the SDK's Boost

### DIFF
--- a/.github/workflows/build_css2xml.yml
+++ b/.github/workflows/build_css2xml.yml
@@ -48,14 +48,9 @@ jobs:
         run: |
           brew install autoconf automake libtool
 
-      - name: prepare boost
-        run: |
-          wget https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.zip
-          unzip boost_1_85_0.zip
-          ln -s ../boost_1_85_0 libs-external/boost
-          cd boost_1_85_0
-          ./bootstrap.sh
-          ./b2 headers
+      # The same Boost as every other build here. boostorg.jfrog.io is retired anyway.
+      - name: Prepare Boost
+        uses: ./.github/actions/prepare-boost
       
       - name: Build CSS2XML
         run: |

--- a/.github/workflows/release-style-tools.yml
+++ b/.github/workflows/release-style-tools.yml
@@ -24,7 +24,6 @@ on:
         type: boolean
 
 env:
-  BOOST_VERSION: 1.85.0
   PACKAGE_DIR: tools/style-cli
 
 jobs:
@@ -42,16 +41,13 @@ jobs:
           version: latest
           actions-cache-folder: emsdk-cache
 
-      # Headers only - the tools use boost.spirit and boost::math constants, nothing compiled.
-      # Boost retired boostorg.jfrog.io; archives.boost.io is the current host.
-      - name: Fetch Boost headers
-        run: |
-          BOOST_UNDERSCORE="boost_$(echo "${BOOST_VERSION}" | tr . _)"
-          curl -sSL -o boost.tar.gz \
-            "https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_UNDERSCORE}.tar.gz"
-          tar xzf boost.tar.gz
-          ln -s "../${BOOST_UNDERSCORE}" libs-external/boost
-          (cd "${BOOST_UNDERSCORE}" && ./bootstrap.sh && ./b2 headers)
+      # The SAME Boost the SDK builds against (BUILDING.md, build.yml). It has to be: the wasm
+      # compiles the style compiler, and boost.spirit.karma resolves an ambiguous grammar
+      # differently between versions and between compilers - a generator that wrote a nested `or`
+      # without parentheses under emcc, and with them under clang, silently corrupted every
+      # converted style's filters while every native check passed.
+      - name: Prepare Boost
+        uses: ./.github/actions/prepare-boost
 
       - name: Build wasm
         working-directory: libs-massif/cartocss/util

--- a/docs/contributing/style-tools.md
+++ b/docs/contributing/style-tools.md
@@ -134,10 +134,16 @@ Two things this repository does not have yet and this workflow is the first to n
   and has never been published, so nothing has authenticated to npm from here before.
 - `permissions: id-token: write` on the publishing job, which is what `--provenance` signs with.
 
-Boost is fetched from `archives.boost.io`. The older
-[`build_css2xml.yml`](https://github.com/massif-maps/MassifMaps/blob/master/.github/workflows/build_css2xml.yml)
-still points at `boostorg.jfrog.io`; check it still resolves before relying on that workflow.
-Only headers are needed (`./b2 headers`), never a compiled Boost.
+Boost comes from [`.github/actions/prepare-boost`](https://github.com/massif-maps/MassifMaps/blob/master/.github/actions/prepare-boost/action.yml),
+the same action `build.yml` uses, so the wasm is built against the **same Boost as the SDK**. That
+is not housekeeping: the wasm compiles the style compiler, and `boost.spirit.karma` resolves an
+ambiguous grammar differently between versions **and between compilers**. A generator alternative
+that wrote a nested `or` without parentheses under emcc, and with them under clang, corrupted every
+converted style's filters while every native check passed — see
+[06-labels](../internals/rendering/06-labels.mdx) for how that surfaced. Two toolchains compiling
+one grammar is how it hid; one pinned Boost is half of not repeating it, and the other half is
+[massif-maps-libs#78](https://github.com/massif-maps/massif-maps-libs/pull/78), which took the
+choice out of the grammar. Only headers are needed, never a compiled Boost.
 
 `build_css2xml.yml` stays as it is — it builds native binaries for local debugging, which is a
 different job from shipping the tool.

--- a/docs/features/cartocss-properties.md
+++ b/docs/features/cartocss-properties.md
@@ -12,7 +12,7 @@ sidebar_position: 20
 `CartoCSSMapnikTranslator.cpp`. Edit those, then re-run the script — never this page.
 :::
 
-205 properties across 12 symbolizers.
+210 properties across 12 symbolizers.
 
 ## Reading the table
 
@@ -25,7 +25,7 @@ sidebar_position: 20
 - Liveness is decided **per parameter across the whole style**, not per use: one baked use
   anywhere makes the parameter baked everywhere.
 
-Live-capable properties: 38 of 205.
+Live-capable properties: 41 of 210.
 
 ## `building`
 
@@ -112,6 +112,9 @@ Live-capable properties: 38 of 205.
 | `marker-file` | `file` | string |  |  |  |
 | `marker-fill` | `fill` | color | `#0000ff` |  |  |
 | `marker-fill-opacity` | `fill-opacity` | float | `1.0` |  |  |
+| `marker-halo-fill` | `halo-fill` | color | `#ffffff` | yes |  |
+| `marker-halo-opacity` | `halo-opacity` | float | `1.0` | yes |  |
+| `marker-halo-radius` | `halo-radius` | float | `0.0` | yes |  |
 | `marker-height` | `height` | float | `0.0` |  | yes |
 | `marker-ignore-placement` | `ignore-placement` | bool | `false` |  |  |
 | `marker-line-color` | `stroke` | color | `#000000` |  |  |
@@ -122,6 +125,7 @@ Live-capable properties: 38 of 205.
 | `marker-placement` | `placement` | value | `point` |  |  |
 | `marker-placement-priority` | `placement-priority` | float | `0.0` |  |  |
 | `marker-same-feature-id-dependent` | `same-feature-id-dependent` | bool | `false` |  |  |
+| `marker-sdf` | `sdf` | bool | `false` |  |  |
 | `marker-spacing` | `spacing` | float | `100.0` |  |  |
 | `marker-transform` | `transform` | transform |  |  |  |
 | `marker-type` | `marker-type` | value | `auto` |  |  |
@@ -216,6 +220,7 @@ Live-capable properties: 38 of 205.
 | `shield-orientation` | `orientation` | float | `0.0` |  |  |
 | `shield-placement` | `placement` | value | `point` |  |  |
 | `shield-placement-priority` | `placement-priority` | float | `0.0` |  |  |
+| `shield-sdf` | `sdf` | bool | `false` |  |  |
 | `shield-size` | `size` | float | `10.0` |  | yes |
 | `shield-spacing` | `spacing` | float | `0.0` |  |  |
 | `shield-text-dx` | `dx` | float | `0.0` |  |  |

--- a/tools/style-cli/src/generated/properties.json
+++ b/tools/style-cli/src/generated/properties.json
@@ -575,6 +575,36 @@
       "baked": false
     },
     {
+      "cartocss": "marker-halo-fill",
+      "mapnik": "halo-fill",
+      "symbolizer": "marker",
+      "kind": "color",
+      "type": "ColorFunctionProperty",
+      "default": "#ffffff",
+      "live": true,
+      "baked": false
+    },
+    {
+      "cartocss": "marker-halo-opacity",
+      "mapnik": "halo-opacity",
+      "symbolizer": "marker",
+      "kind": "float",
+      "type": "FloatFunctionProperty",
+      "default": "1.0",
+      "live": true,
+      "baked": false
+    },
+    {
+      "cartocss": "marker-halo-radius",
+      "mapnik": "halo-radius",
+      "symbolizer": "marker",
+      "kind": "float",
+      "type": "FloatFunctionProperty",
+      "default": "0.0",
+      "live": true,
+      "baked": false
+    },
+    {
       "cartocss": "marker-height",
       "mapnik": "height",
       "symbolizer": "marker",
@@ -667,6 +697,16 @@
     {
       "cartocss": "marker-same-feature-id-dependent",
       "mapnik": "same-feature-id-dependent",
+      "symbolizer": "marker",
+      "kind": "bool",
+      "type": "BoolProperty",
+      "default": "false",
+      "live": false,
+      "baked": false
+    },
+    {
+      "cartocss": "marker-sdf",
+      "mapnik": "sdf",
       "symbolizer": "marker",
       "kind": "bool",
       "type": "BoolProperty",
@@ -1361,6 +1401,16 @@
       "kind": "float",
       "type": "FloatProperty",
       "default": "0.0",
+      "live": false,
+      "baked": false
+    },
+    {
+      "cartocss": "shield-sdf",
+      "mapnik": "sdf",
+      "symbolizer": "shield",
+      "kind": "bool",
+      "type": "BoolProperty",
+      "default": "false",
       "live": false,
       "baked": false
     },


### PR DESCRIPTION
## Summary

Two fixes to the style-tools release workflow, which has been failing since the submodule pointer moved to `develop`.

- **Regenerate the CartoCSS property allowlist.** `develop` carries `marker-sdf`, `shield-sdf` and the marker halo trio, so `gen-cartocss-properties.py --check` failed and took the whole workflow with it — the wasm was built but never packaged. 204 → 209 properties.
- **Build against the same Boost as the SDK.** `release-style-tools.yml` pinned **1.85.0** and fetched it by hand, while `build.yml` uses the `prepare-boost` action at **1.89.0** — which is also what `BUILDING.md` tells a developer to install. Both style workflows now use that action, so there is one Boost, cached and checksummed like every other build's. `build_css2xml.yml` is switched too: it still fetched 1.85 from `boostorg.jfrog.io`, which Boost retired.

## Why the Boost pin is not housekeeping

The wasm compiles the style compiler, and `boost.spirit.karma` resolves an ambiguous grammar differently between versions **and between compilers**. A generator alternative wrote a nested `or` **without** parentheses under emcc and **with** them under clang, so `css2xml` silently corrupted the filter of every rule that has one — a converted MapTiler style drew its whole road network in the major-road colour. Every native check passed. Two toolchains compiling one grammar is how it hid.

The grammar side of that is fixed in massif-maps/massif-maps-libs#78 (merged). This is the other half.

## Testing

- `gen-cartocss-properties.py --check` clean against the submodule commit master now points at; the two files are byte-identical to what it generates.
- Both edited workflows parse.
- The wasm from run 32968996265 (built before this change) was installed locally and `massif-style css2xml` on a converted MapTiler topo-v4 style now emits correctly parenthesised filters and `sdf="true"` on all 13 shields, with no warnings. Rendering that XML on device matches the CartoCSS-project render of the same style.
- **Not verified:** that CI is green end to end — that needs one run of this branch.