### PR TITLE
feat(api): let a PMTiles source be built from JSON, like every other tile source

### DIFF
--- a/all/modules/datasources/PMTilesTileDataSource.i
+++ b/all/modules/datasources/PMTilesTileDataSource.i
@@ -23,6 +23,7 @@
 
 !polymorphic_shared_ptr(massif::PMTilesTileDataSource, datasources.PMTilesTileDataSource)
 
+!spec(massif::PMTilesTileDataSource, source, pmtiles, default(minZoom, 0), default(maxZoom, 24))
 %std_io_exceptions(massif::PMTilesTileDataSource::PMTilesTileDataSource)
 
 %feature("director") massif::PMTilesTileDataSource;

--- a/android/java/com/massifmaps/api/ApiNames.java
+++ b/android/java/com/massifmaps/api/ApiNames.java
@@ -1077,6 +1077,7 @@ public final class ApiNames {
     public static final String TYPE_SOURCE_MULTI = "multi";
     public static final String TYPE_SOURCE_ORDERED = "ordered";
     public static final String TYPE_SOURCE_PERSISTENT_CACHE = "persistent-cache";
+    public static final String TYPE_SOURCE_PMTILES = "pmtiles";
     public static final String TYPE_STYLE_MBVT = "mbvt";
     public static final String TYPE_STYLESET_CARTOCSS = "cartocss";
     public static final String TYPE_STYLESET_PROJECT = "project";

--- a/bindings/typescript/massif.d.ts
+++ b/bindings/typescript/massif.d.ts
@@ -7617,7 +7617,18 @@ export interface SourceSpec_persistent_cache {
   source?: SourceSpec | string;
 }
 
-export type SourceSpec = SourceSpec_assets | SourceSpec_combined | SourceSpec_geojson | SourceSpec_http | SourceSpec_local | SourceSpec_maptiler | SourceSpec_mbtiles | SourceSpec_memory_cache | SourceSpec_merged_mbvt | SourceSpec_multi | SourceSpec_ordered | SourceSpec_persistent_cache;
+export interface SourceSpec_pmtiles {
+  type: "pmtiles";
+  /** Gets the current maximum overzoom level for this datasource. Over it the datasource will not be "drawn" */
+  maxOverzoomLevel?: number;
+  maxZoom?: number;
+  /** Returns a copy of the data source meta data map. The changes you make to this map are NOT reflected in the actual meta data of the source. The map is attached to every tile this source loads, and consumers read their settings from it - "dem_encoding" ("mapbox" or "terrarium") selects the elevation decoder, for instance. A wrapper source with no map of its own answers with its wrapped source's. */
+  metaData?: Record<string, Json>;
+  minZoom?: number;
+  path?: string;
+}
+
+export type SourceSpec = SourceSpec_assets | SourceSpec_combined | SourceSpec_geojson | SourceSpec_http | SourceSpec_local | SourceSpec_maptiler | SourceSpec_mbtiles | SourceSpec_memory_cache | SourceSpec_merged_mbvt | SourceSpec_multi | SourceSpec_ordered | SourceSpec_persistent_cache | SourceSpec_pmtiles;
 
 export interface StyleSpec_mbvt {
   type: "mbvt";

--- a/docs/api/massif-api.json
+++ b/docs/api/massif-api.json
@@ -11460,6 +11460,60 @@
             ]
           ]
         ]
+      ],
+      [
+        "pmtiles",
+        "massif__PMTilesTileDataSource",
+        [
+          [
+            0,
+            [
+              [
+                "VALUE",
+                "minZoom",
+                "static_cast<int>(intAt(spec, \"minZoom\", 0))",
+                null
+              ],
+              [
+                "VALUE",
+                "maxZoom",
+                "static_cast<int>(intAt(spec, \"maxZoom\", 24))",
+                null
+              ],
+              [
+                "VALUE",
+                "path",
+                "stringAt(spec, \"path\", \"\")",
+                null
+              ]
+            ],
+            [
+              "path"
+            ],
+            [
+              "minZoom",
+              "maxZoom",
+              "path"
+            ]
+          ],
+          [
+            1,
+            [
+              [
+                "VALUE",
+                "path",
+                "stringAt(spec, \"path\", \"\")",
+                null
+              ]
+            ],
+            [
+              "path"
+            ],
+            [
+              "path"
+            ]
+          ]
+        ]
       ]
     ],
     "style": [
@@ -11653,6 +11707,7 @@
     "massif::MultiTileDataSource": "source",
     "massif::MultiValhallaOfflineRoutingService": "routing",
     "massif::OrderedTileDataSource": "source",
+    "massif::PMTilesTileDataSource": "source",
     "massif::PersistentCacheTileDataSource": "source",
     "massif::Point": "element",
     "massif::PointGeometry": "geometry",
@@ -13140,6 +13195,54 @@
           },
           {
             "key": "databasePath",
+            "type": "STRING",
+            "cppType": "std::string",
+            "childKind": null,
+            "childClass": null,
+            "required": true
+          }
+        ]
+      ]
+    },
+    {
+      "cppClass": "massif::PMTilesTileDataSource",
+      "kind": "source",
+      "type": "pmtiles",
+      "aliases": {},
+      "defaults": {
+        "minZoom": "0",
+        "maxZoom": "24"
+      },
+      "constructors": [
+        [
+          {
+            "key": "minZoom",
+            "type": "INT",
+            "cppType": "int",
+            "childKind": null,
+            "childClass": null,
+            "required": false
+          },
+          {
+            "key": "maxZoom",
+            "type": "INT",
+            "cppType": "int",
+            "childKind": null,
+            "childClass": null,
+            "required": false
+          },
+          {
+            "key": "path",
+            "type": "STRING",
+            "cppType": "std::string",
+            "childKind": null,
+            "childClass": null,
+            "required": true
+          }
+        ],
+        [
+          {
+            "key": "path",
             "type": "STRING",
             "cppType": "std::string",
             "childKind": null,

--- a/docs/features/pmtiles.md
+++ b/docs/features/pmtiles.md
@@ -43,6 +43,22 @@ let layer = MSFVectorTileLayer(dataSource: source, decoder: decoder)
 mapView.getLayers()?.add(layer)
 ```
 
+## From JSON
+
+`pmtiles` is a `source` spec type of the [facade API](/docs/internals/api-facade), so a
+NativeScript / React Native / C ABI caller builds one from JSON, with no native construction and
+no `adopt` step:
+
+```json
+{"type":"vector",
+ "source":{"type":"pmtiles","path":"/sdcard/maps/basemap.pmtiles"},
+ "style":{"type":"mbvt","project":{"type":"project",
+          "assets":{"type":"dir","path":"/sdcard/massif_style"},"name":"osm"}}}
+```
+
+`minZoom` / `maxZoom` are accepted like every other source, but `getMinZoom()`/`getMaxZoom()` read
+the archive header either way, so leaving them out is the normal case.
+
 ## Metadata & extent
 
 ```kotlin

--- a/docs/internals/api-facade.md
+++ b/docs/internals/api-facade.md
@@ -602,7 +602,7 @@ inline spec of that kind, and it is checked against the class the caller is abou
 
 | kind | types |
 |---|---|
-| `source` | `http` `assets` `mbtiles` `maptiler` `memory-cache` `persistent-cache` `ordered` `combined` `merged-mbvt` `multi` `geojson` `local` |
+| `source` | `http` `assets` `mbtiles` `pmtiles` `maptiler` `memory-cache` `persistent-cache` `ordered` `combined` `merged-mbvt` `multi` `geojson` `local` |
 | `data` | `url` — bytes from `file://`, `assets://` or `http(s)://` |
 | `assets` | `dir` (a directory), `bundle` (the app's own bundled assets), `zip` (a `data` archive) |
 | `geometry` | `geojson` — a JSON string or the document inline, optional target `projection` — plus `point` (`pos`), `line` (`poses`) and `polygon` (`poses`, optional `holes`, or `rings`) |
@@ -669,7 +669,7 @@ One line per class in its `.i` says what to call it and how to spell the awkward
   defaults and `scheme` does not — and passing `scheme` now reaches the 4-argument one, which no
   hand-written factory ever exposed. Same for `HillshadeRasterTileLayer`'s `elevationDecoder`.
 
-Fifty-one classes over thirteen kinds build this way, and everything left hand-written in
+Fifty-two classes over thirteen kinds build this way, and everything left hand-written in
 `SpecFactories.cpp` is genuinely adaptive rather than boilerplate:
 
 | still hand-written | why the signature cannot say it |

--- a/ios/objc/api/MassifApiNames.h
+++ b/ios/objc/api/MassifApiNames.h
@@ -1084,6 +1084,7 @@ FOUNDATION_EXPORT MassifSpecType const MassifSpecTypeSourceMergedMbvt;
 FOUNDATION_EXPORT MassifSpecType const MassifSpecTypeSourceMulti;
 FOUNDATION_EXPORT MassifSpecType const MassifSpecTypeSourceOrdered;
 FOUNDATION_EXPORT MassifSpecType const MassifSpecTypeSourcePersistentCache;
+FOUNDATION_EXPORT MassifSpecType const MassifSpecTypeSourcePmtiles;
 FOUNDATION_EXPORT MassifSpecType const MassifSpecTypeStyleMbvt;
 FOUNDATION_EXPORT MassifSpecType const MassifSpecTypeStylesetCartocss;
 FOUNDATION_EXPORT MassifSpecType const MassifSpecTypeStylesetProject;

--- a/ios/objc/api/MassifApiNames.m
+++ b/ios/objc/api/MassifApiNames.m
@@ -595,6 +595,7 @@ MassifSpecType const MassifSpecTypeSourceMergedMbvt = @"merged-mbvt";
 MassifSpecType const MassifSpecTypeSourceMulti = @"multi";
 MassifSpecType const MassifSpecTypeSourceOrdered = @"ordered";
 MassifSpecType const MassifSpecTypeSourcePersistentCache = @"persistent-cache";
+MassifSpecType const MassifSpecTypeSourcePmtiles = @"pmtiles";
 MassifSpecType const MassifSpecTypeStyleMbvt = @"mbvt";
 MassifSpecType const MassifSpecTypeStylesetCartocss = @"cartocss";
 MassifSpecType const MassifSpecTypeStylesetProject = @"project";

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,7 +36,10 @@ than a choice:
   the generator on the way.
 
 Spec factories (`create`) are in the same position: they reference the constructors of every source
-type, so they are device-verified rather than covered here.
+type, so they are device-verified rather than covered here. What is covered is the **schema** those
+factories are generated from (`SpecSchemaTest.cpp`): a second, schema-only generator run over the
+archive sources, read as JSON, so a class whose `!spec` is missing or whose constructors stopped
+resolving fails here rather than in an integration two repos away.
 
 ## The style XML round-trip — outside this suite
 

--- a/tests/api/ApiTest.cpp
+++ b/tests/api/ApiTest.cpp
@@ -59,6 +59,7 @@ void testFogOptions();
 void testSkyOptions();
 void testFogSkyPaths();
 void testNestedSpecIndexedKey();
+void testSourceSpecSchema();
 void testBagBatch();
 void testSetAll();
 void testAliases();
@@ -415,6 +416,7 @@ int main() {
     testSkyOptions();
     testFogSkyPaths();
     testNestedSpecIndexedKey();
+    testSourceSpecSchema();
     testBagBatch();
     testSetAll();
     testAliases();

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -160,6 +160,30 @@ add_custom_command(
   COMMENT "Generating the reduced API property table for tests"
   VERBATIM)
 
+# A SECOND, schema-only run over the archive sources. Their classes cannot be linked here - PMTiles
+# needs zlib, brotli and zstd - but the schema is JSON, so SpecSchemaTest reads it without any of
+# that. Separate outdir: these .inc files are deliberately not compiled.
+set(TEST_SCHEMA_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated/schema")
+set(TEST_SCHEMA_MODULES
+  "${SDK_BASE_DIR}/all/modules/datasources/PMTilesTileDataSource.i"
+  "${SDK_BASE_DIR}/all/modules/datasources/MBTilesTileDataSource.i"
+  "${SDK_BASE_DIR}/all/modules/datasources/TileDataSource.i"
+)
+list(JOIN TEST_SCHEMA_MODULES "," TEST_SCHEMA_MODULE_LIST)
+
+add_custom_command(
+  OUTPUT "${TEST_SCHEMA_DIR}/massif-api.json"
+  COMMAND "${TEST_PYTHON}" "${SDK_BASE_DIR}/scripts/gen-api-tables.py"
+          "--modules" "${TEST_SCHEMA_MODULE_LIST}"
+          "--defines" "_MASSIF_OFFLINE_SUPPORT"
+          "--cppdir" "${SDK_BASE_DIR}/all/native"
+          "--outdir" "${TEST_SCHEMA_DIR}"
+          "--schema" "${TEST_SCHEMA_DIR}/massif-api.json"
+  DEPENDS ${TEST_SCHEMA_MODULES} "${SDK_BASE_DIR}/scripts/gen-api-tables.py"
+  WORKING_DIRECTORY "${SDK_BASE_DIR}/scripts"
+  COMMENT "Generating the source spec schema for tests"
+  VERBATIM)
+
 add_executable(api_tests
   ApiTest.cpp
   EventTest.cpp
@@ -174,6 +198,8 @@ add_executable(api_tests
   BagTest.cpp
   FogSkyTest.cpp
   SpecKeyTest.cpp
+  # Reads the two schemas below, links nothing of its own.
+  SpecSchemaTest.cpp
   # Header-only: AutoFlatten.h has no dependencies at all, so this costs the link nothing.
   AutoFlattenTest.cpp
   # Same: DrapeStackCuts.h is the ordering rule and nothing else.
@@ -182,11 +208,15 @@ add_executable(api_tests
   FlattenSwitchTest.cpp
   "${TEST_TABLE_DIR}/PropertyTable.inc"
   "${TEST_TABLE_DIR}/MethodDecls.inc"
+  "${TEST_SCHEMA_DIR}/massif-api.json"
   ${TEST_SDK_SOURCES})
 
 set_source_files_properties("${TEST_TABLE_DIR}/PropertyTable.inc" PROPERTIES HEADER_FILE_ONLY TRUE)
+set_source_files_properties("${TEST_SCHEMA_DIR}/massif-api.json" PROPERTIES HEADER_FILE_ONLY TRUE)
 
-target_compile_definitions(api_tests PRIVATE ${TEST_DEFINES})
+target_compile_definitions(api_tests PRIVATE ${TEST_DEFINES}
+  "TEST_SCHEMA_PATH=\"${TEST_SCHEMA_DIR}/massif-api.json\""
+  "SDK_SCHEMA_PATH=\"${SDK_BASE_DIR}/docs/api/massif-api.json\"")
 
 target_include_directories(api_tests PRIVATE
   "${SDK_BASE_DIR}/all/native"

--- a/tests/api/SpecSchemaTest.cpp
+++ b/tests/api/SpecSchemaTest.cpp
@@ -1,0 +1,86 @@
+/*
+ * A source class reaches the facade only through its !spec declaration - without one there is no
+ * `{"type":…}` factory at all, whatever the SDK class can do. PMTiles had none, so a binding could
+ * only build one natively and adopt it.
+ *
+ * The factory itself is device-verified (see ../README.md), and PMTilesTileDataSource cannot even
+ * be linked here - it needs zlib, brotli and zstd. What IS checkable on the host is the schema the
+ * generator derives from the .i and the constructors, which is what a binding reads.
+ */
+
+#include "core/Variant.h"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+using namespace massif;
+
+#include "TestCheck.h"
+
+namespace {
+
+    Variant readSchema(const std::string& path) {
+        std::ifstream file(path, std::ios::binary);
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        return Variant::FromString(buffer.str());
+    }
+
+    Variant findSpec(const Variant& schema, const std::string& kind, const std::string& type) {
+        Variant specs = schema.getObjectElement("specs");
+        for (int i = 0; i < specs.getArraySize(); i++) {
+            Variant spec = specs.getArrayElement(i);
+            if (spec.getObjectElement("kind").getString() == kind &&
+                spec.getObjectElement("type").getString() == type) {
+                return spec;
+            }
+        }
+        return Variant();
+    }
+
+    // The keys a caller must pass for this overload - a declared default makes one optional.
+    int requiredArgs(const Variant& constructor, std::string& lastKey) {
+        int count = 0;
+        for (int i = 0; i < constructor.getArraySize(); i++) {
+            Variant arg = constructor.getArrayElement(i);
+            if (arg.getObjectElement("required").getBool()) {
+                count++;
+                lastKey = arg.getObjectElement("key").getString();
+            }
+        }
+        return count;
+    }
+
+}
+
+void testSourceSpecSchema() {
+    Variant schema = readSchema(TEST_SCHEMA_PATH);
+
+    Variant pmtiles = findSpec(schema, "source", "pmtiles");
+    TEST_CHECK(pmtiles.getObjectElement("cppClass").getString() == "massif::PMTilesTileDataSource",
+               "PMTilesTileDataSource declares a `pmtiles` source spec");
+    TEST_CHECK(pmtiles.getObjectElement("defaults").getObjectElement("minZoom").getString() == "0" &&
+               pmtiles.getObjectElement("defaults").getObjectElement("maxZoom").getString() == "24",
+               "the zoom bounds are declared defaults, as on mbtiles");
+
+    // Both overloads are readable, and the path-only spec has to satisfy one of them - that is what
+    // makes `{"type":"pmtiles","path":"x"}` a complete spec rather than a missing-argument error.
+    Variant constructors = pmtiles.getObjectElement("constructors");
+    TEST_CHECK(constructors.getArraySize() == 2, "both PMTiles constructors are in the table");
+    bool pathOnly = false;
+    for (int i = 0; i < constructors.getArraySize(); i++) {
+        std::string key;
+        if (requiredArgs(constructors.getArrayElement(i), key) == 1 && key == "path") {
+            pathOnly = true;
+        }
+    }
+    TEST_CHECK(pathOnly, "a path alone builds a pmtiles source");
+
+    // The committed schema is what an integration generates its typings from, so a spec that only
+    // exists in the .i is still invisible to it.
+    Variant committed = readSchema(SDK_SCHEMA_PATH);
+    TEST_CHECK(findSpec(committed, "source", "pmtiles").getObjectElement("cppClass").getString() ==
+               "massif::PMTilesTileDataSource",
+               "docs/api/massif-api.json carries it too (scripts/gen-api-bindings.sh)");
+}


### PR DESCRIPTION
## Summary

- `PMTilesTileDataSource` had no `!spec` line, so the generated spec table listed **twelve** source
  types and not `pmtiles`. A NativeScript / React Native / C-ABI caller could not build one from
  JSON at all — it had to construct the source natively and `adopt` it. One declaration fixes that:
  `{"type":"pmtiles","path":"…"}` now builds.
- Declared with the `mbtiles` defaults (`minZoom` 0, `maxZoom` 24) so a path-only spec still
  resolves a constructor. Which overload wins costs nothing here — `getMinZoom()`/`getMaxZoom()`
  read the archive header whichever one ran.
- Regenerated artefacts (`scripts/gen-api-bindings.sh`): `docs/api/massif-api.json`,
  `bindings/typescript/massif.d.ts`, `ApiNames.java` (`TYPE_SOURCE_PMTILES`),
  `MassifApiNames.{h,m}` (`MassifSpecTypeSourcePmtiles`). `massif_api_names.{h,c}` unchanged.
- Docs: a **From JSON** section in `docs/features/pmtiles.md`, `pmtiles` added to the `source` kind
  table in `docs/internals/api-facade.md`.

## Testing

- `cd tests && ./run.sh` → 2/2 pass. New `tests/api/SpecSchemaTest.cpp`: PMTiles needs zlib, brotli
  and zstd and cannot be linked on the host, so CMake does a second **schema-only** generator run
  over the archive `.i` files and the test reads the JSON — spec present, defaults 0/24, both
  constructors, a path alone satisfies one, and the committed schema carries it too.
- Negative-checked: with the `!spec` line removed, 4 of those checks FAIL. Not a tautology.
- No C++ behaviour change, nothing to check on device. `swigpp-java.py` was **not** re-run and does
  not need to be: `!spec` lines are dropped by the preprocessor
  (`scripts/swigpp-java.py:331`), so the generated wrappers are byte-identical.

## Not breaking

No `.i` signature changed — a spec type is added to the facade, nothing is renamed or removed.