### PR TITLE
fix(styles): load a style with deeply nested expressions instead of hanging on it

### DIFF
--- a/tests/style/CMakeLists.txt
+++ b/tests/style/CMakeLists.txt
@@ -19,11 +19,17 @@ set(STYLE_SOURCES
   "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/ParseTables.cpp"
   "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/CSSColorParser.cpp"
   "${SDK_BASE_DIR}/libs-massif/mapnikvt/src/mapnikvt/StringUtils.cpp"
+  # The CartoCSS parser, for the nesting-depth guard. Its own tree types only - the compiler and
+  # the mapnik translator are not reached from a parse.
+  "${SDK_BASE_DIR}/libs-massif/cartocss/src/cartocss/CartoCSSParser.cpp"
+  "${SDK_BASE_DIR}/libs-massif/cartocss/src/cartocss/Expression.cpp"
+  "${SDK_BASE_DIR}/libs-massif/cartocss/src/cartocss/Predicate.cpp"
 )
 
 add_executable(style_tests
   StyleTest.cpp
   LayerConfigTest.cpp
+  CartoCSSParseTest.cpp
   ${STYLE_SOURCES})
 
 target_include_directories(style_tests PRIVATE
@@ -31,6 +37,7 @@ target_include_directories(style_tests PRIVATE
   # TestCheck.h is the whole framework and lives with the api tests.
   "${CMAKE_CURRENT_SOURCE_DIR}/../api"
   "${SDK_BASE_DIR}/libs-massif/mapnikvt/src"
+  "${SDK_BASE_DIR}/libs-massif/cartocss/src"
   # vt headers only - no vt object is linked.
   "${SDK_BASE_DIR}/libs-massif/vt/src"
   "${SDK_BASE_DIR}/libs-external/cglib"
@@ -42,3 +49,6 @@ target_include_directories(style_tests PRIVATE
   "${SDK_BASE_DIR}/libs-external/tinyformat")
 
 add_test(NAME style COMMAND style_tests)
+# A parser that regresses to exponential backtracking does not fail the depth guard, it never
+# returns. The whole suite runs in about a second, so this only ever fires on that.
+set_tests_properties(style PROPERTIES TIMEOUT 60)

--- a/tests/style/CartoCSSParseTest.cpp
+++ b/tests/style/CartoCSSParseTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Parsing a CartoCSS expression has to stay linear in its nesting depth.
+ *
+ * `expressionlist` used to be two alternatives that both began with `expression`: parse the head,
+ * demand a comma, and on the missing comma backtrack and parse the very same head again. Every
+ * parenthesised sub-expression goes through that rule, and a nested ternary is parentheses all the
+ * way down, so the cost doubled per level. Measured on device: depth 12 loaded in ~5 s, depth 20 in
+ * 40 s, and MapTiler streets-v4's 28-deep road-shield country switch never finished at all.
+ */
+
+#include "TestCheck.h"
+
+#include <cartocss/CartoCSSParser.h>
+#include <cartocss/Expression.h>
+
+#include <chrono>
+#include <string>
+
+namespace css = massif::css;
+
+namespace {
+    std::string nestedTernary(int depth) {
+        std::string expr = "#ffffff";
+        for (int i = depth; i > 0; i--) {
+            expr = "(([iso_a2] = 'C" + std::to_string(i) + "') ? #000000 : " + expr + ")";
+        }
+        return "#road { line-color: " + expr + "; }";
+    }
+
+    double parseSeconds(const std::string& source) {
+        auto start = std::chrono::steady_clock::now();
+        css::StyleSheet styleSheet = css::CartoCSSParser::parse(source);
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        TEST_CHECK(!styleSheet.getElements().empty(), "nested ternary parses to a rule");
+        return std::chrono::duration<double>(elapsed).count();
+    }
+}
+
+void testCartoCSSParse() {
+    // The shape of the bug, not a wall-clock budget: doubling the depth may not more than quadruple
+    // the time. Exponential blows straight through that on any machine; linear stays near 2x.
+    double shallow = parseSeconds(nestedTernary(10));
+    double deep = parseSeconds(nestedTernary(20));
+    TEST_CHECK(deep < shallow * 4.0 + 0.05, "parse time does not explode with nesting depth");
+
+    // The depth that hung. A second is orders of magnitude above linear and far below exponential.
+    auto start = std::chrono::steady_clock::now();
+    css::StyleSheet styleSheet = css::CartoCSSParser::parse(nestedTernary(28));
+    double seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+    TEST_CHECK(!styleSheet.getElements().empty() && seconds < 1.0, "a 28-deep ternary parses at once");
+
+    // The comma list `expressionlist` exists for still has to parse - the head is read once now,
+    // and the tail is what makes it a list.
+    css::StyleSheet list = css::CartoCSSParser::parse("#a { line-dasharray: 1, 2, 3; }");
+    TEST_CHECK(!list.getElements().empty(), "a comma list still parses");
+}

--- a/tests/style/StyleTest.cpp
+++ b/tests/style/StyleTest.cpp
@@ -7,9 +7,11 @@
 int failures = 0;
 
 void testLayerConfig();
+void testCartoCSSParse();
 
 int main() {
     testLayerConfig();
+    testCartoCSSParse();
 
     std::printf("\n%d failure(s)\n", failures);
     return failures ? 1 : 0;


### PR DESCRIPTION
## Summary

A CartoCSS style whose expression nesting reached the high twenties never finished loading — no
error, no exception, just a thread burning CPU until the app was killed. The parser read every
nested expression once per enclosing parenthesis, so the cost doubled per level.

The fix is one grammar rule in `libs-massif` (see below). This PR carries the pointer bump and the
regression guard.

Measured on an emulator with the offending style layer isolated:

| ternary nesting depth | style load |
|---|---|
| 4 / 8 / 12 | ~5 s |
| 20 | 40 s |
| 28 | never finished |

It is not specific to converted styles — any hand-written CartoCSS that nests that deep pays the
same. It surfaced on a MapTiler streets-v4 style converted with `massif-style mapbox2css`, whose
road-shield country switch is 28 branches deep.

## Testing

- `cd tests && ./run.sh` — passes in 0.85 s. New `CartoCSSParseTest` asserts parse time does not
  more than quadruple when depth doubles, that a 28-deep ternary parses inside a second, and that a
  comma list still parses. Verified to **hang** without the submodule fix and pass with it, which is
  why the suite also gains a ctest `TIMEOUT` — the regression does not fail the guard, it never
  returns.
- The reduced link gains the CartoCSS parser and its own tree types only; the compiler and the
  mapnik translator are not reached from a parse.
- On device (emulator): streets-v4 converted from `api.maptiler.com/maps/streets-v4`, served from
  MapTiler's own `planet_v4` tiles with the cache cleared. Style compiles, tiles load, road shields
  render. Reproduce with:

  ```sh
  adb shell am start -n com.massifmaps.MassifDemo/.BenchActivity --es ui false \
    --es style dir --es styleDir streets \
    --es vectorUrl "https://api.maptiler.com/tiles/v4/{z}/{x}/{y}.pbf?key=<key>" \
    --es lon 6.39 --es lat 45.68 --es zoom 13
  ```

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/80 — merges first; the pointer bump here is
rebased onto the merged commit before this one merges.