### PR TITLE
perf(labels): rank POIs from an app-owned table at no per-frame cost

### DIFF
--- a/docs/features/label-styling.md
+++ b/docs/features/label-styling.md
@@ -179,6 +179,32 @@ back with a leader line; a name that loses its row steps to the next one instead
 - Unlike every other orientation, a callout is not dropped when the view meets the surface edge-on,
   which is what makes it work at a near-zero or negative tilt.
 
+## Ranking the app owns
+
+The `[rank]` a vector tile ships is one editor's idea of what matters, and an outdoor app wants a
+different one. Put the ranking in a [table style parameter](style-parameters.md) instead of in the
+style, and the app writes it:
+
+```json
+"styleparameters": {
+  "poi_rank": { "default": { "peak": 900, "alpine_hut": 800, "supermarket": 50, "zoo": 40 } }
+}
+```
+
+```css
+#poi {
+  marker-placement-priority: get([param::poi_rank], [class], 100);
+  text-placement-priority:   get([param::poi_rank], [class], 100);
+}
+```
+
+```java
+decoder.setStyleParameter("poi_rank", outdoorRanking);   // one call swaps the whole ranking
+```
+
+The lookup is resolved while the tile is decoded, so it costs nothing per frame. Changing the table
+re-decodes the visible tiles, which suits a profile the user picks — not a slider.
+
 ## Distance limits
 
 Cut labels that are too far to be useful (metres; `0`, the default, means no limit):

--- a/docs/features/style-parameters.md
+++ b/docs/features/style-parameters.md
@@ -103,6 +103,11 @@ per tile), decided per parameter when the style loads:
 So a colour an app exposes as a setting (`"water_color"`) is free to change, while a table read per
 feature class still costs a decode.
 
+A table read per feature costs nothing **per frame**, though: since changing it decodes the tiles
+again anyway, `get([param::poi_rank], [class], 100)` is resolved while the tile is built and the
+renderer sees a constant — the same as a plain field expression, so features answering alike still
+share one style slot.
+
 Which side a given property falls on is in the
 [CartoCSS property reference](cartocss-properties.md), one **live** / **baked** column per property.
 The decision is made **per parameter across the whole style**, not per use: one baked use anywhere

--- a/docs/internals/rendering/06-labels.mdx
+++ b/docs/internals/rendering/06-labels.mdx
@@ -361,7 +361,13 @@ Two notes for style authors:
 
 - Prefer an expression that reads **only** the view state. It has no feature dependency, so
   `FloatFunctionProperty::getFunction` hands every feature the same function object and the label
-  style is not rebuilt per feature.
+  style is not rebuilt per feature. An expression that reads no view state at all is as good: it
+  folds to a constant at decode, and two features answering alike share one function object — that
+  holds for a style parameter read together with a field
+  (`text-rank: get([param::poi_rank], [class], 100)`), which the property resolves at decode rather
+  than keeping behind the store, since such a parameter can never be live anyway
+  (`GenericFunctionProperty::foldsStyleParams`). Mixing the two — a field *and* `view::distance` —
+  is what costs a closure and a label style per feature.
 - `0 - x`, not `-x`: CartoCSS's `literal` rule accepts `-` as a first character, so a leading minus
   in front of a field is read as the literal string `"-"` and the declaration fails to parse.
 

--- a/tests/style/CMakeLists.txt
+++ b/tests/style/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(style_tests
   StyleTest.cpp
   LayerConfigTest.cpp
   CartoCSSParseTest.cpp
+  StyleParameterFoldTest.cpp
   ${STYLE_SOURCES})
 
 target_include_directories(style_tests PRIVATE

--- a/tests/style/StyleParameterFoldTest.cpp
+++ b/tests/style/StyleParameterFoldTest.cpp
@@ -1,0 +1,77 @@
+/*
+ * When a style parameter is resolved: while the tile is decoded, or per frame from the store. A
+ * parameter read together with a feature field cannot be live (isLiveCapable), so it has to fold
+ * at decode - otherwise every feature keeps its own closure over the store, which re-runs the
+ * expression interpreter per frame and splits the batches. See docs/features/style-parameters.md.
+ */
+
+#include "TestCheck.h"
+
+#include <mapnikvt/Feature.h>
+#include <mapnikvt/ExpressionContext.h>
+#include <mapnikvt/ParserUtils.h>
+#include <mapnikvt/Properties.h>
+#include <mapnikvt/StyleParameterStore.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace mvt = massif::mvt;
+namespace vt = massif::vt;
+
+namespace {
+    mvt::ExpressionContext contextWith(std::vector<std::pair<std::string, mvt::Value>> vars, const std::shared_ptr<const mvt::StyleParameterStore>& store) {
+        mvt::ExpressionContext context;
+        context.setFeatureData(std::make_shared<mvt::FeatureData>(
+            1, mvt::FeatureData::GeometryType::POINT_GEOMETRY, std::move(vars)));
+        context.setStyleParameterStore(store);
+        return context;
+    }
+
+    mvt::Value makeTable(std::map<std::string, mvt::Value> members) {
+        return mvt::Value(std::make_shared<const mvt::ValueObject>(std::move(members)));
+    }
+}
+
+void testStyleParameterFold() {
+    // 1. A table parameter indexed by a field - the app-owned POI ranking - folds to a constant,
+    // so the culler and the renderer see a plain value and features answering alike share it.
+    {
+        auto store = std::make_shared<mvt::StyleParameterStore>();
+        store->setValues({ { "ranks", makeTable({ { "peak", mvt::Value(900.0) } }) } });
+
+        mvt::FloatFunctionProperty rank(0.0f);
+        rank.setExpression(mvt::parseExpression("get([param::ranks], [class], 100)", false));
+        TEST_CHECK(!rank.isLiveCapable(), "a table read by a field is not a live parameter");
+
+        vt::FloatFunction peak = rank.getFunction(contextWith({ { "class", mvt::Value(std::string("peak")) } }, store));
+        vt::FloatFunction peak2 = rank.getFunction(contextWith({ { "class", mvt::Value(std::string("peak")) } }, store));
+        vt::FloatFunction zoo = rank.getFunction(contextWith({ { "class", mvt::Value(std::string("zoo")) } }, store));
+
+        TEST_CHECK(peak.function() == nullptr, "a table read by a field folds to a constant");
+        TEST_CHECK(peak(vt::ViewState()) == 900.0f, "and it is the table's value for that feature");
+        TEST_CHECK(zoo(vt::ViewState()) == 100.0f, "a key the table misses takes the fallback");
+        TEST_CHECK(peak == peak2, "two features answering alike share one function object");
+    }
+
+    // 2. A parameter-only property must NOT fold: it is live, and the tiles read it through the
+    // store, so setting the parameter repaints instead of decoding.
+    {
+        auto store = std::make_shared<mvt::StyleParameterStore>();
+        store->setValues({ { "boost", mvt::Value(10.0) } });
+
+        mvt::FloatFunctionProperty rank(0.0f);
+        rank.setExpression(mvt::parseExpression("[param::boost]", false));
+        TEST_CHECK(rank.isLiveCapable(), "a parameter-only property is live");
+
+        vt::FloatFunction func = rank.getFunction(contextWith({ }, store));
+        TEST_CHECK(func.function() != nullptr, "so it stays a function reading the store");
+        TEST_CHECK(func(vt::ViewState()) == 10.0f, "which gives the current value");
+
+        store->setValues({ { "boost", mvt::Value(20.0) } });
+        TEST_CHECK(func(vt::ViewState()) == 20.0f, "and follows a change with no new function");
+    }
+}

--- a/tests/style/StyleTest.cpp
+++ b/tests/style/StyleTest.cpp
@@ -8,10 +8,12 @@ int failures = 0;
 
 void testLayerConfig();
 void testCartoCSSParse();
+void testStyleParameterFold();
 
 int main() {
     testLayerConfig();
     testCartoCSSParse();
+    testStyleParameterFold();
 
     std::printf("\n%d failure(s)\n", failures);
     return failures ? 1 : 0;


### PR DESCRIPTION
## Summary

An app whose priorities differ from the tiles' `[rank]` — an outdoor app wanting summits and huts
over supermarkets and zoos — can already own the ranking with a **table style parameter**:

```json
"styleparameters": { "poi_rank": { "default": { "peak": 900, "alpine_hut": 800, "supermarket": 50 } } }
```
```css
#poi { text-placement-priority: get([param::poi_rank], [class], 100); }
```
```java
decoder.setStyleParameter("poi_rank", outdoorRanking);   // one call swaps the whole ranking
```

It was expensive for no reason. A parameter read together with a feature field is not live-capable,
so changing it re-decodes the tiles anyway — yet the property kept a closure over the parameter
store, which re-ran the expression interpreter per feature at render time (per label **per placement
pass** for `text-rank`) and handed every feature its own function object, splitting label styles and
geometry batches. The submodule PR folds it at decode instead; a parameter-only property still stays
live and repaints.

This PR carries the tests, the docs and the pointer bump:

- `tests/style/StyleParameterFoldTest.cpp` — the table-indexed-by-field case folds to a shared
  constant, the parameter-only case stays a live function that follows a store change.
- `docs/features/label-styling.md` — the ranking recipe, with what a change costs.
- `docs/features/style-parameters.md`, `docs/internals/rendering/06-labels.mdx` — the fold rule
  beside the existing cost table and the `text-rank` notes.

## Testing

`cd tests && ./run.sh` — `api` + `style`, 0 failures. The new checks fail against the pre-change
header (per-feature closure, no sharing) and pass after. No on-device check: the change moves *when*
a parameter is resolved, not what it evaluates to, so appearance is unchanged — the win is decode and
cull cost, **not** measured on a real style yet. A reviewer wanting to see it should bench a style
whose POI rule reads a table parameter, not the demo's inline style.

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/82 — merge that first, then rebase this
pointer bump onto the merged `libs-massif` commit before merging here.