### PR TITLE
feat(labels): rank shields and markers by the view, as text already could

### DIFF
--- a/docs/features/cartocss-properties.md
+++ b/docs/features/cartocss-properties.md
@@ -12,7 +12,7 @@ sidebar_position: 20
 `CartoCSSMapnikTranslator.cpp`. Edit those, then re-run the script — never this page.
 :::
 
-210 properties across 12 symbolizers.
+212 properties across 12 symbolizers.
 
 ## Reading the table
 
@@ -25,7 +25,7 @@ sidebar_position: 20
 - Liveness is decided **per parameter across the whole style**, not per use: one baked use
   anywhere makes the parameter baked everywhere.
 
-Live-capable properties: 41 of 210.
+Live-capable properties: 43 of 212.
 
 ## `building`
 
@@ -124,6 +124,7 @@ Live-capable properties: 41 of 210.
 | `marker-opacity` | `opacity` | float | `1.0` | yes |  |
 | `marker-placement` | `placement` | value | `point` |  |  |
 | `marker-placement-priority` | `placement-priority` | float | `0.0` |  |  |
+| `marker-rank` | `rank` | float | `0.0` | yes |  |
 | `marker-same-feature-id-dependent` | `same-feature-id-dependent` | bool | `false` |  |  |
 | `marker-sdf` | `sdf` | bool | `false` |  |  |
 | `marker-spacing` | `spacing` | float | `100.0` |  |  |
@@ -220,6 +221,7 @@ Live-capable properties: 41 of 210.
 | `shield-orientation` | `orientation` | float | `0.0` |  |  |
 | `shield-placement` | `placement` | value | `point` |  |  |
 | `shield-placement-priority` | `placement-priority` | float | `0.0` |  |  |
+| `shield-rank` | `rank` | float | `0.0` | yes |  |
 | `shield-sdf` | `sdf` | bool | `false` |  |  |
 | `shield-size` | `size` | float | `10.0` |  | yes |
 | `shield-spacing` | `spacing` | float | `0.0` |  |  |

--- a/docs/features/label-styling.md
+++ b/docs/features/label-styling.md
@@ -205,6 +205,19 @@ decoder.setStyleParameter("poi_rank", outdoorRanking);   // one call swaps the w
 The lookup is resolved while the tile is decoded, so it costs nothing per frame. Changing the table
 re-decodes the visible tiles, which suits a profile the user picks — not a slider.
 
+`text-rank` / `shield-rank` / `marker-rank` add to that priority **per placement pass**, which is
+the only place `view::distance` means anything, so the table decides the order and the view breaks
+the ties:
+
+```css
+#poi {
+  marker-placement-priority: get([param::poi_rank], [class], 100);
+  marker-rank: 0 - [view::distance]/50;      /* of two equals, the nearer one keeps its slot */
+}
+```
+
+Ranking never changes how a label looks — only which of two colliding labels survives.
+
 ## Distance limits
 
 Cut labels that are too far to be useful (metres; `0`, the default, means no limit):

--- a/docs/internals/rendering/06-labels.mdx
+++ b/docs/internals/rendering/06-labels.mdx
@@ -351,6 +351,10 @@ priority**:
 }
 ```
 
+All three label symbolizers carry it — `text-rank`, `shield-rank`, `marker-rank`. Shields inherit the
+property from `TextSymbolizer` and markers declare their own; both end up as `TileLabel::Style::rankFunc`,
+so the culler reads one field whatever built the label (`PointLabelStyle::rankFunc` for a marker).
+
 `view::distance` is metres from the camera to the label being ranked. It is defined **only** in this
 evaluation: `ViewState::labelDistance` is 0 everywhere else, because the renderer evaluates a style
 function once per batch (`GLTileRenderer::renderLabelPass` packs colour and size into a 16-slot

--- a/tools/style-cli/src/generated/properties.json
+++ b/tools/style-cli/src/generated/properties.json
@@ -695,6 +695,16 @@
       "baked": false
     },
     {
+      "cartocss": "marker-rank",
+      "mapnik": "rank",
+      "symbolizer": "marker",
+      "kind": "float",
+      "type": "FloatFunctionProperty",
+      "default": "0.0",
+      "live": true,
+      "baked": false
+    },
+    {
       "cartocss": "marker-same-feature-id-dependent",
       "mapnik": "same-feature-id-dependent",
       "symbolizer": "marker",
@@ -1402,6 +1412,16 @@
       "type": "FloatProperty",
       "default": "0.0",
       "live": false,
+      "baked": false
+    },
+    {
+      "cartocss": "shield-rank",
+      "mapnik": "rank",
+      "symbolizer": "shield",
+      "kind": "float",
+      "type": "FloatFunctionProperty",
+      "default": "0.0",
+      "live": true,
       "baked": false
     },
     {


### PR DESCRIPTION
## Summary

`text-rank` — the per-placement-pass term that lets a label be ranked by `view::distance` — existed
for text only. A shield inherited the property but never used it (dead even in Mapnik XML), and a
marker had none. The submodule PR gives all three the same field; this one carries the docs and the
pointer bump.

An app-owned POI ranking is now one recipe end to end:

```css
#poi {
  marker-placement-priority: get([param::poi_rank], [class], 100);   /* the app's table, folded at decode */
  marker-rank: 0 - [view::distance]/50;                              /* the nearer of two equals wins */
}
```

- `docs/features/cartocss-properties.md` and `tools/style-cli/src/generated/properties.json` —
  regenerated by `scripts/gen-cartocss-properties.py` (212 properties, 43 live).
- `docs/features/label-styling.md` — the three spellings beside the app-owned ranking recipe.
- `docs/internals/rendering/06-labels.mdx` — where a marker's rank ends up (`PointLabelStyle::rankFunc`
  → `TileLabel::Style::rankFunc`).

## Testing

`cd tests && ./run.sh` — `api` + `style`, 0 failures, but **no new host test**: the symbolizers and
`TileLayerBuilder` pull in vt, freetype and harfbuzz, which the reduced link excludes on purpose.
Syntax check clean on every touched translation unit.

**Still needs an on-device check** (not run): dense POI layer with the recipe above, `--es tilt 60`
so near and far markers collide, A/B with the `marker-rank` line removed.

## Depends on

https://github.com/massif-maps/massif-maps-libs/pull/83 — merge first, then rebase this pointer bump
onto the merged `libs-massif` commit.